### PR TITLE
enable torch compile with cudagraphs

### DIFF
--- a/aimnet/calculators/aimnet2ase.py
+++ b/aimnet/calculators/aimnet2ase.py
@@ -14,10 +14,10 @@ class AIMNet2ASE(Calculator):
 
     implemented_properties: ClassVar[list[str]] = ["energy", "forces", "free_energy", "charges", "stress", "dipole_moment"]
 
-    def __init__(self, base_calc: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1):
+    def __init__(self, base_calc: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1, compile_cuda_graphs: bool=False):
         super().__init__()
         if isinstance(base_calc, str):
-            base_calc = AIMNet2Calculator(base_calc)
+            base_calc = AIMNet2Calculator(base_calc, compile_cuda_graphs=compile_cuda_graphs)
         self.base_calc = base_calc
         self.reset()
         self.charge = charge

--- a/examples/ase_md.py
+++ b/examples/ase_md.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+from time import perf_counter
+
+import ase.io
+from ase import units
+from ase.md.langevin import Langevin
+from ase.md import MDLogger
+
+
+from aimnet.calculators import AIMNet2ASE
+
+
+def torch_show_device_into():
+    import torch
+
+    print(f"Torch version: {torch.__version__}")
+    if torch.cuda.is_available():
+        print(f"CUDA available, version {torch.version.cuda}, device: {torch.cuda.get_device_name()}")  # type: ignore
+    else:
+        print("CUDA not available")
+
+
+torch_show_device_into()
+# 59 conformations of taxol
+xyzfile = os.path.join(os.path.dirname(__file__), "taxol.xyz")
+
+# read the first one
+atoms = ase.io.read(xyzfile, index=0)
+
+# create the calculator with default model and enable/disable torch compile with cudagraphs
+COMPILE_CUDAGRAPHS=False
+if COMPILE_CUDAGRAPHS:
+    print('running with torch_compile+cudagraphs')
+else:
+    print('running without torch_compile+cudagraphs')
+
+calc = AIMNet2ASE(compile_cuda_graphs=COMPILE_CUDAGRAPHS)
+
+# attach the calculator to the atoms object
+atoms.calc = calc  # type: ignore
+
+# do a single point calculation to trigger compile and do a warmup step
+forces = atoms.get_forces()
+energy = atoms.get_potential_energy()
+print('energy:', energy)
+
+
+# setup MD
+temperature_K: float = 300
+timestep: float = 1.0 * units.fs
+friction: float = 0.01 / units.fs
+traj_interval: int = 1000
+log_interval: int   = 1000
+nsteps: int = 10000
+
+dyn = Langevin(atoms, timestep, temperature_K=temperature_K, friction=friction)
+dyn.attach(
+    lambda: ase.io.write("traj.xyz", atoms, append=True), interval=traj_interval
+)
+dyn.attach(MDLogger(dyn, atoms,  sys.stdout), interval=log_interval)
+
+
+# Run the dynamics
+t1 = perf_counter()
+dyn.run(steps=nsteps)
+t2 = perf_counter()
+
+print(f"Completed MD in {t2 - t1:.1f} s ({(t2 - t1)*1000 / nsteps:.3f} ms/step)")
+
+
+


### PR DESCRIPTION
As discussed by @giadefa This PR adds the necessary changes to AIMNet2 so that the model can be torch.compile'd with cudagraphs enabled.
 
This speeds up small molecule MD significantly. The new example `ase_md.py` script demonstrates the speedup.
The original runs 10000 steps in 76 seconds, the new version runs in 15 seconds.

Original:
```
Torch version: 2.8.0+cu128
CUDA available, version 12.8, device: NVIDIA GeForce RTX 4090
running without torch_compile+cudagraphs
energy: -79772.80223186754
Time[ps]      Etot[eV]     Epot[eV]     Ekin[eV]    T[K]
0.0000       -79772.802   -79772.802        0.000     0.0
1.0000       -79765.760   -79769.961        4.201   287.6
2.0000       -79766.232   -79770.634        4.402   301.4
3.0000       -79765.783   -79770.592        4.809   329.2
4.0000       -79766.131   -79770.321        4.191   286.9
5.0000       -79764.888   -79770.354        5.466   374.2
6.0000       -79765.719   -79770.835        5.116   350.3
7.0000       -79766.672   -79771.049        4.377   299.7
8.0000       -79766.566   -79770.707        4.141   283.5
9.0000       -79766.490   -79770.862        4.371   299.3
10.0000      -79767.403   -79771.511        4.109   281.3
Completed MD in 76.3 s (7.634 ms/step)
```

New with `torch.compile(self.model, fullgraph=True, options={'triton.cudagraphs':True})`:
```
Torch version: 2.8.0+cu128
CUDA available, version 12.8, device: NVIDIA GeForce RTX 4090
running with torch_compile+cudagraphs
energy: -79772.8125
Time[ps]      Etot[eV]     Epot[eV]     Ekin[eV]    T[K]
0.0000       -79772.812   -79772.812        0.000     0.0
1.0000       -79766.053   -79770.633        4.580   313.5
2.0000       -79766.829   -79770.547        3.718   254.5
3.0000       -79766.958   -79771.672        4.714   322.7
4.0000       -79766.121   -79770.664        4.543   311.0
5.0000       -79766.836   -79771.133        4.297   294.2
6.0000       -79765.915   -79770.078        4.164   285.1
7.0000       -79766.040   -79771.055        5.015   343.3
8.0000       -79766.454   -79770.727        4.273   292.5
9.0000       -79766.441   -79770.531        4.090   280.0
10.0000      -79766.390   -79771.016        4.625   316.7
Completed MD in 15.1 s (1.511 ms/step)
```

It is currently only implemented for nb_mode=0 and a single molecule.

The key required changes are to replace data dependent control flow with compile time constant control flow. Therefore, I have added a `setup_for_compile_cudagraphs` method to some modules to do this.

The feature is supported by the ASE calculator interface.