### PR TITLE
Fix embedded D3TS dispersion detection

### DIFF
--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -441,30 +441,44 @@ class AIMNet2Calculator:
         """
         return self._dftd3_cutoff
 
+#    def _has_embedded_dispersion(self) -> bool:
+#        """Check if model has embedded dispersion (not externalized).
+#
+#        Uses model metadata when available, otherwise returns False (unknown).
+#
+#        Returns
+#        -------
+#        bool
+#            True if model has embedded dispersion module (D3TS or legacy DFTD3).
+#        """
+#        meta = getattr(self.model, "_metadata", None)
+#        if meta is None:
+#            return False  # Unknown, assume no embedded dispersion
+#
+#        # New format: Check for embedded D3TS via has_embedded_lr
+#        # If has_embedded_lr=True and coulomb_mode != "sr_embedded", it's D3TS
+#        if meta.get("has_embedded_lr", False):
+#            coulomb_mode = meta.get("coulomb_mode", "none")
+#            if coulomb_mode != "sr_embedded":
+#                return True  # Must be D3TS (embedded dispersion)
+#
+#        # Legacy format: If needs_dispersion=False and d3_params exist, dispersion is embedded
+#        # (legacy JIT models have dispersion embedded)
+#        return not meta.get("needs_dispersion", False) and meta.get("d3_params") is not None
+
     def _has_embedded_dispersion(self) -> bool:
-        """Check if model has embedded dispersion (not externalized).
+        """Check if model has embedded dispersion."""
 
-        Uses model metadata when available, otherwise returns False (unknown).
+        # Best way to check: inspect actual model modules
+        if any(m.__class__.__name__ == "D3TS" for m in self.model.modules()):
+            return True
 
-        Returns
-        -------
-        bool
-            True if model has embedded dispersion module (D3TS or legacy DFTD3).
-        """
+        # Fallback for older exported / legacy models
         meta = getattr(self.model, "_metadata", None)
         if meta is None:
-            return False  # Unknown, assume no embedded dispersion
+            return False
 
-        # New format: Check for embedded D3TS via has_embedded_lr
-        # If has_embedded_lr=True and coulomb_mode != "sr_embedded", it's D3TS
-        if meta.get("has_embedded_lr", False):
-            coulomb_mode = meta.get("coulomb_mode", "none")
-            if coulomb_mode != "sr_embedded":
-                return True  # Must be D3TS (embedded dispersion)
-
-        # Legacy format: If needs_dispersion=False and d3_params exist, dispersion is embedded
-        # (legacy JIT models have dispersion embedded)
-        return not meta.get("needs_dispersion", False) and meta.get("d3_params") is not None
+        return (not meta.get("needs_dispersion", False)) and (meta.get("d3_params") is not None)
 
     def _has_embedded_coulomb(self) -> bool:
         """Check if model has embedded Coulomb (not externalized).


### PR DESCRIPTION
During crystal structure optimization in `AIMNet2Calculator._has_embedded_dispersion()`: for exported models with `has_embedded_lr=True` and `coulomb_mode="sr_embedded"`, it incorrectly returned False, even though the exported model contained an embedded D3TS dispersion module. And so, the calculator could not build the long-range neighbor list (`nbmat_lr` / `shifts_lr`), and `D3TS.forward()` failed with `KeyError: No neighbor matrix found for any suffix in ['_dftd3', '_lr']`.