### PR TITLE
chore: repo audit (markdown, configs, source health, doc drift)

### DIFF
--- a/aimnet/calculators/aimnet2pysis.py
+++ b/aimnet/calculators/aimnet2pysis.py
@@ -24,7 +24,7 @@ class AIMNet2Pysis(Calculator):
             model = AIMNet2Calculator(model)
         self.model = model
 
-    def _prepere_input(self, atoms, coord):
+    def _prepare_input(self, atoms, coord):
         device = self.model.device
         numbers = torch.as_tensor([ATOMIC_NUMBERS[a.lower()] for a in atoms], device=device)
         coord = torch.as_tensor(coord, dtype=torch.float, device=device).view(-1, 3) * BOHR2ANG
@@ -50,20 +50,20 @@ class AIMNet2Pysis(Calculator):
         )
 
     def get_energy(self, atoms, coords):
-        _in = self._prepere_input(atoms, coords)
+        _in = self._prepare_input(atoms, coords)
         res = self.model(_in)
         energy = self._results_get_energy(res)
         return {"energy": energy}
 
     def get_forces(self, atoms, coords):
-        _in = self._prepere_input(atoms, coords)
+        _in = self._prepare_input(atoms, coords)
         res = self.model(_in, forces=True)
         energy = self._results_get_energy(res)
         forces = self._results_get_forces(res)
         return {"energy": energy, "forces": forces}
 
     def get_hessian(self, atoms, coords):
-        _in = self._prepere_input(atoms, coords)
+        _in = self._prepare_input(atoms, coords)
         res = self.model(_in, forces=True, hessian=True)
         energy = self._results_get_energy(res)
         forces = self._results_get_forces(res)

--- a/aimnet/train/export_model.py
+++ b/aimnet/train/export_model.py
@@ -93,7 +93,7 @@ def export_model(
     """Export trained model to distributable state dict format.
 
     weights: Path to the raw PyTorch weights file (.pt).
-    outoput: Path to the output .pt file.
+    output: Path to the output .pt file.
 
     Example:
         aimnet export weights.pt model.pt --model config.yaml --sae model.sae

--- a/aimnet/train/train.py
+++ b/aimnet/train/train.py
@@ -18,7 +18,7 @@ _default_config = os.path.join(os.path.dirname(__file__), "default_train.yaml")
     type=click.Path(exists=True),
     default=None,
     multiple=True,
-    help="Path to the extra configuration file (overrides values, could be preficied multiple times).",
+    help="Path to the extra configuration file (overrides values, can be specified multiple times).",
 )
 @click.option(
     "--model", type=click.Path(exists=True), default=_default_model, help="Path to the model definition file."

--- a/docs/advanced/open_shell.md
+++ b/docs/advanced/open_shell.md
@@ -19,7 +19,9 @@
 
 Standard AIMNet2 models (`aimnet2`, `aimnet2_b973c`, `aimnet2_2025`) use a single charge channel internally (`num_charge_channels=1`). This means the model predicts one set of atomic partial charges and implicitly assumes all electrons are paired. When applied to a radical -- a species with one or more unpaired electrons -- the model has no mechanism to represent the spin density distribution and produces unreliable energies and forces.
 
-!!! warning "Do not use closed-shell models for open-shell systems" Applying `aimnet2` to a doublet radical or triplet state will silently produce results that look reasonable but have large systematic errors. Always use `aimnet2nse` when unpaired electrons are present.
+!!! warning "Do not use closed-shell models for open-shell systems"
+
+    Applying `aimnet2` to a doublet radical or triplet state will silently produce results that look reasonable but have large systematic errors. Always use `aimnet2nse` when unpaired electrons are present.
 
 Common symptoms of using the wrong model:
 
@@ -83,7 +85,9 @@ calc = AIMNet2ASE("aimnet2nse", charge=0, mult=2)
 calc.set_mult(3)  # Switch to triplet
 ```
 
-!!! note "Default multiplicity" If `mult` is not provided, the calculator defaults to `mult=1` (singlet). For closed-shell molecules with `aimnet2nse`, this is correct and the model reduces to standard behavior. You do not need to switch models for closed-shell species.
+!!! note "Default multiplicity"
+
+    If `mult` is not provided, the calculator defaults to `mult=1` (singlet). For closed-shell molecules with `aimnet2nse`, this is correct and the model reduces to standard behavior. You do not need to switch models for closed-shell species.
 
 ## Worked Example: C-H Bond Dissociation Energy
 
@@ -160,7 +164,9 @@ print(f"Benzylic C-H BDE:     {BDE_kcal:.1f} kcal/mol")
 # Expected: ~90 kcal/mol (experimental: 89.8 kcal/mol)
 ```
 
-!!! warning "Zero-point energy corrections" The BDE values computed above are purely electronic (Delta E_e). For thermochemically accurate results, include zero-point energy (ZPE) corrections by computing the Hessian at each optimized geometry and extracting harmonic frequencies. The ZPE-corrected BDE is:
+!!! warning "Zero-point energy corrections"
+
+    The BDE values computed above are purely electronic (Delta E_e). For thermochemically accurate results, include zero-point energy (ZPE) corrections by computing the Hessian at each optimized geometry and extracting harmonic frequencies. The ZPE-corrected BDE is:
 
     BDE_0 = E(radical1) + E(radical2) - E(molecule) + ZPE(radical1) + ZPE(radical2) - ZPE(molecule)
 
@@ -252,7 +258,9 @@ print(f"aimnet2nse (open-shell): {E_nse:.4f} eV")
 print(f"Energy difference: {abs(E_closed - E_nse) * 23.0609:.1f} kcal/mol")
 ```
 
-!!! tip "When in doubt, use aimnet2nse" The NSE model handles closed-shell species correctly (mult=1 reduces to standard behavior). If your workflow involves a mix of closed-shell and open-shell species -- for example, computing BDEs -- use `aimnet2nse` throughout for consistent energetics.
+!!! tip "When in doubt, use aimnet2nse"
+
+    The NSE model handles closed-shell species correctly (mult=1 reduces to standard behavior). If your workflow involves a mix of closed-shell and open-shell species -- for example, computing BDEs -- use `aimnet2nse` throughout for consistent energetics.
 
 ## When to Fall Back to Multi-Reference Methods
 
@@ -272,7 +280,9 @@ AIMNet2-NSE handles most radical chemistry well, but certain electronic structur
 - Energy differences between spin states are unexpectedly small
 - The system has low-lying excited states (check literature)
 
-!!! info "Recommendation" For routine radical chemistry -- organic radical stability, BDEs, H-atom abstractions, radical additions -- AIMNet2-NSE is reliable and orders of magnitude faster than DFT. Reserve multi-reference methods (CASSCF, CASPT2, MRCI, NEVPT2) for the specific pathological cases listed above. Note that standard DFT is also a single-reference method and will fail for the same multi-reference cases.
+!!! info "Recommendation"
+
+    For routine radical chemistry -- organic radical stability, BDEs, H-atom abstractions, radical additions -- AIMNet2-NSE is reliable and orders of magnitude faster than DFT. Reserve multi-reference methods (CASSCF, CASPT2, MRCI, NEVPT2) for the specific pathological cases listed above. Note that standard DFT is also a single-reference method and will fail for the same multi-reference cases.
 
 ## What's Next
 

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -174,10 +174,10 @@ See [torch.compile documentation](https://pytorch.org/docs/stable/generated/torc
 
 Whether to put the model in training mode. Default: `False`.
 
-| Value             | Behavior                                                                  |
-| ----------------- | ------------------------------------------------------------------------- |
+| Value | Behavior |
+| --- | --- |
 | `False` (default) | Inference mode: model set to `.eval()`, all parameters set to `requires_grad_(False)` |
-| `True`            | Training mode: model set to `.train()`, parameters keep `requires_grad`   |
+| `True` | Training mode: model set to `.train()`, parameters keep `requires_grad` |
 
 For ordinary energy/force/charge inference (including external autograd through the calculator), leave this `False`. Set `True` only when using the calculator inside a training loop where model parameters need gradients.
 

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -73,6 +73,7 @@ AIMNet2Calculator(
     device: str | None = None,
     compile_model: bool = False,
     compile_kwargs: dict | None = None,
+    train: bool = False,
     ensemble_member: int = 0,
     revision: str | None = None,
     token: str | None = None,
@@ -168,6 +169,17 @@ calc = AIMNet2Calculator("aimnet2", compile_model=True, compile_kwargs={"mode": 
 ```
 
 See [torch.compile documentation](https://pytorch.org/docs/stable/generated/torch.compile.html) for available options.
+
+#### `train`
+
+Whether to put the model in training mode. Default: `False`.
+
+| Value             | Behavior                                                                  |
+| ----------------- | ------------------------------------------------------------------------- |
+| `False` (default) | Inference mode: model set to `.eval()`, all parameters set to `requires_grad_(False)` |
+| `True`            | Training mode: model set to `.train()`, parameters keep `requires_grad`   |
+
+For ordinary energy/force/charge inference (including external autograd through the calculator), leave this `False`. Set `True` only when using the calculator inside a training loop where model parameters need gradients.
 
 #### `ensemble_member`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,8 @@ aimnet train [OPTIONS] [ARGS]...
 | `--no-default-config` | Flag | Skip loading `aimnet/train/default_train.yaml` |
 | `ARGS` | Variadic | Dot-separated overrides applied last (e.g., `data.train=mydata.h5 run_name=firstrun`) |
 
+Trailing tokens after the named options (`ARGS`) are positional dot-form overrides into the merged training config — they are not flags.
+
 Device selection is controlled via `CUDA_VISIBLE_DEVICES`; training uses all visible GPUs in DDP mode.
 
 ### Example Configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,15 +32,19 @@ aimnet train --config config.yaml --model model.yaml
 ### Options
 
 ```bash
-aimnet train [OPTIONS]
+aimnet train [OPTIONS] [ARGS]...
 ```
 
-| Option            | Type     | Description                      |
-| ----------------- | -------- | -------------------------------- |
-| `--config PATH`   | Required | Training configuration YAML file |
-| `--model PATH`    | Required | Model architecture YAML file     |
-| `--resume PATH`   | Optional | Resume from checkpoint           |
-| `--device DEVICE` | Optional | Device to use (cuda/cpu)         |
+| Option                 | Type     | Description                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `--config PATH`        | Optional | Extra training configuration YAML (may be passed multiple times; merged over the default)    |
+| `--model PATH`         | Optional | Model architecture YAML (defaults to bundled `aimnet/models/aimnet2.yaml`)                   |
+| `--load PATH`          | Optional | Path to existing model weights to load before training                                       |
+| `--save PATH`          | Optional | Path to save model weights                                                                   |
+| `--no-default-config`  | Flag     | Skip loading `aimnet/train/default_train.yaml`                                               |
+| `ARGS`                 | Variadic | Dot-separated overrides applied last (e.g., `data.train=mydata.h5 run_name=firstrun`)        |
+
+Device selection is controlled via `CUDA_VISIBLE_DEVICES`; training uses all visible GPUs in DDP mode.
 
 ### Example Configuration
 
@@ -83,17 +87,17 @@ kwargs:
 ### Complete Example
 
 ```bash
-# Train with W&B logging
+# Train with W&B logging (GPU controlled via CUDA_VISIBLE_DEVICES)
 aimnet train \
   --config experiments/train_config.yaml \
-  --model models/aimnet2.yaml \
-  --device cuda
+  --model models/aimnet2.yaml
 
-# Resume training
+# Continue from existing weights
 aimnet train \
   --config experiments/train_config.yaml \
   --model models/aimnet2.yaml \
-  --resume checkpoints/last.pt
+  --load checkpoints/last.pt \
+  --save checkpoints/continued.pt
 ```
 
 See [train.md](train.md) for detailed training documentation.
@@ -230,7 +234,7 @@ See [model_format.md](model_format.md#migration-guide) for detailed migration gu
 
 ## aimnet calc_sae
 
-Calculate self-atomic energies (SAE) from a dataset.
+Calculate self-atomic energies (SAE) from a dataset by fitting a per-element energy shift to the training data.
 
 ### Basic Usage
 
@@ -241,21 +245,21 @@ aimnet calc_sae dataset.h5 output_sae.yaml
 ### Options
 
 ```bash
-aimnet calc_sae INPUT OUTPUT [OPTIONS]
+aimnet calc_sae [OPTIONS] DS OUTPUT
 ```
 
 **Positional Arguments:**
 
-| Argument | Description                            |
-| -------- | -------------------------------------- |
-| `INPUT`  | HDF5 dataset with single-atom energies |
-| `OUTPUT` | Output YAML file for SAE values        |
+| Argument | Description                                                            |
+| -------- | ---------------------------------------------------------------------- |
+| `DS`     | HDF5 dataset (`SizeGroupedDataset` layout) containing `numbers` and `energy` |
+| `OUTPUT` | Output YAML file for fitted SAE values                                       |
 
 **Options:**
 
-| Option            | Description                                      |
-| ----------------- | ------------------------------------------------ |
-| `--elements LIST` | Comma-separated atomic numbers (e.g., "1,6,7,8") |
+| Option       | Type | Default | Description                                          |
+| ------------ | ---- | ------- | ---------------------------------------------------- |
+| `--samples`  | int  | 100000  | Maximum number of dataset samples used for the fit   |
 
 ### SAE Format
 
@@ -272,41 +276,27 @@ Output YAML format:
 ### Example
 
 ```bash
-# Calculate SAE for H, C, N, O
+# Fit SAE from the training dataset (uses up to 100k samples by default)
 aimnet calc_sae \
-  data/single_atoms.h5 \
+  data/dataset.h5 \
+  configs/sae.yaml
+
+# Limit the number of samples used for the fit
+aimnet calc_sae \
+  data/dataset.h5 \
   configs/sae.yaml \
-  --elements "1,6,7,8"
+  --samples 50000
 
 # Use in training
 aimnet train \
   --config train_config.yaml \
-  --model model.yaml
-  # SAE loaded from train_config
+  --model model.yaml \
+  data.sae.energy.file=configs/sae.yaml
 ```
 
-### Creating Single-Atom Dataset
+### How SAE Is Computed
 
-SAE calculation requires single-atom reference calculations:
-
-```python
-import h5py
-import numpy as np
-
-# Single-atom energies from reference calculations (e.g., DFT)
-sae_data = {
-    1: -13.587,   # H atom energy
-    6: -1027.592, # C atom energy
-    # ... more elements
-}
-
-# Create HDF5 dataset
-with h5py.File("single_atoms.h5", "w") as f:
-    for z, energy in sae_data.items():
-        grp = f.create_group(f"atom_{z}")
-        grp["energy"] = energy
-        grp["numbers"] = [z]
-```
+`aimnet calc_sae` does not require a separate single-atom dataset. It operates on the same `SizeGroupedDataset` HDF5 file used for training, fits a per-element energy shift via a least-squares regression on `(numbers, energy)`, trims outliers (2nd/98th percentiles of the residual), and refits. The element list is inferred automatically from the dataset.
 
 ## Common Workflows
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,14 +35,14 @@ aimnet train --config config.yaml --model model.yaml
 aimnet train [OPTIONS] [ARGS]...
 ```
 
-| Option                 | Type     | Description                                                                                  |
-| ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `--config PATH`        | Optional | Extra training configuration YAML (may be passed multiple times; merged over the default)    |
-| `--model PATH`         | Optional | Model architecture YAML (defaults to bundled `aimnet/models/aimnet2.yaml`)                   |
-| `--load PATH`          | Optional | Path to existing model weights to load before training                                       |
-| `--save PATH`          | Optional | Path to save model weights                                                                   |
-| `--no-default-config`  | Flag     | Skip loading `aimnet/train/default_train.yaml`                                               |
-| `ARGS`                 | Variadic | Dot-separated overrides applied last (e.g., `data.train=mydata.h5 run_name=firstrun`)        |
+| Option | Type | Description |
+| --- | --- | --- |
+| `--config PATH` | Optional | Extra training configuration YAML (may be passed multiple times; merged over the default) |
+| `--model PATH` | Optional | Model architecture YAML (defaults to bundled `aimnet/models/aimnet2.yaml`) |
+| `--load PATH` | Optional | Path to existing model weights to load before training |
+| `--save PATH` | Optional | Path to save model weights |
+| `--no-default-config` | Flag | Skip loading `aimnet/train/default_train.yaml` |
+| `ARGS` | Variadic | Dot-separated overrides applied last (e.g., `data.train=mydata.h5 run_name=firstrun`) |
 
 Device selection is controlled via `CUDA_VISIBLE_DEVICES`; training uses all visible GPUs in DDP mode.
 
@@ -250,16 +250,16 @@ aimnet calc_sae [OPTIONS] DS OUTPUT
 
 **Positional Arguments:**
 
-| Argument | Description                                                            |
-| -------- | ---------------------------------------------------------------------- |
-| `DS`     | HDF5 dataset (`SizeGroupedDataset` layout) containing `numbers` and `energy` |
-| `OUTPUT` | Output YAML file for fitted SAE values                                       |
+| Argument | Description |
+| --- | --- |
+| `DS` | HDF5 dataset (`SizeGroupedDataset` layout) containing `numbers` and `energy` |
+| `OUTPUT` | Output YAML file for fitted SAE values |
 
 **Options:**
 
-| Option       | Type | Default | Description                                          |
-| ------------ | ---- | ------- | ---------------------------------------------------- |
-| `--samples`  | int  | 100000  | Maximum number of dataset samples used for the fit   |
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--samples` | int | 100000 | Maximum number of dataset samples used for the fit |
 
 ### SAE Format
 

--- a/docs/models/aimnet2.md
+++ b/docs/models/aimnet2.md
@@ -24,15 +24,25 @@ If you are unsure which model to use, start here. AIMNet2 provides the best bala
 
 ### Limitations
 
-!!! warning "No transition metals" AIMNet2 does not support any transition metal elements. For palladium chemistry, use [AIMNet2-Pd](aimnet2pd.md).
+!!! warning "No transition metals"
 
-!!! warning "Molecular systems only" The training data consists of molecular (gas-phase) structures. While periodic boundary conditions are supported computationally, the model has not been validated for bulk materials, surfaces, or extended solids.
+    AIMNet2 does not support any transition metal elements. For palladium chemistry, use [AIMNet2-Pd](aimnet2pd.md).
 
-!!! warning "System size" Validated for systems up to approximately 100 heavy atoms. Larger systems may work but accuracy has not been systematically benchmarked beyond this range.
+!!! warning "Molecular systems only"
 
-!!! warning "Closed-shell only" This model assumes closed-shell electronic structure. For radicals, triplet states, or any system with unpaired electrons, use [AIMNet2-NSE](aimnet2nse.md).
+    The training data consists of molecular (gas-phase) structures. While periodic boundary conditions are supported computationally, the model has not been validated for bulk materials, surfaces, or extended solids.
 
-!!! warning "Single-reference DFT" Trained on single-determinant DFT data. Systems with strong multi-reference character (e.g., biradicals, stretched bonds near dissociation, certain transition states) may not be reliable.
+!!! warning "System size"
+
+    Validated for systems up to approximately 100 heavy atoms. Larger systems may work but accuracy has not been systematically benchmarked beyond this range.
+
+!!! warning "Closed-shell only"
+
+    This model assumes closed-shell electronic structure. For radicals, triplet states, or any system with unpaired electrons, use [AIMNet2-NSE](aimnet2nse.md).
+
+!!! warning "Single-reference DFT"
+
+    Trained on single-determinant DFT data. Systems with strong multi-reference character (e.g., biradicals, stretched bonds near dissociation, certain transition states) may not be reliable.
 
 ## Typical Use Cases
 

--- a/docs/models/aimnet2_2025.md
+++ b/docs/models/aimnet2_2025.md
@@ -1,6 +1,8 @@
 # AIMNet2-2025
 
-!!! tip "Recommended B97-3c Model" AIMNet2-2025 is the **recommended B97-3c-level model** and supersedes the original [AIMNet2-B97-3c](aimnet2_b973c.md). It provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. Use this model for all new work requiring a B97-3c reference level.
+!!! tip "Recommended B97-3c Model"
+
+    AIMNet2-2025 is the **recommended B97-3c-level model** and supersedes the original [AIMNet2-B97-3c](aimnet2_b973c.md). It provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. Use this model for all new work requiring a B97-3c reference level.
 
 ## Overview
 
@@ -24,11 +26,17 @@ AIMNet2-2025 is the **current-generation B97-3c model**, combining the cost-effe
 
 ### Limitations
 
-!!! warning "B97-3c base level" The underlying reference data is at the B97-3c level. While intermolecular interactions are improved through enhanced training, the base functional limitations for intramolecular thermochemistry (e.g., barrier heights) remain. For general thermochemistry, prefer [AIMNet2 (wB97M-D3)](aimnet2.md).
+!!! warning "B97-3c base level"
 
-!!! warning "Non-covalent improvements may not transfer to all motifs" The improved intermolecular accuracy has been validated on common non-covalent interaction types. Unusual or exotic interaction motifs (e.g., halogen bonding with heavy halogens, aerogen bonding) may not benefit equally.
+    The underlying reference data is at the B97-3c level. While intermolecular interactions are improved through enhanced training, the base functional limitations for intramolecular thermochemistry (e.g., barrier heights) remain. For general thermochemistry, prefer [AIMNet2 (wB97M-D3)](aimnet2.md).
 
-!!! warning "Same scope restrictions" No transition metals, closed-shell only, molecular training data. See the [AIMNet2 page](aimnet2.md) for the full list of limitations.
+!!! warning "Non-covalent improvements may not transfer to all motifs"
+
+    The improved intermolecular accuracy has been validated on common non-covalent interaction types. Unusual or exotic interaction motifs (e.g., halogen bonding with heavy halogens, aerogen bonding) may not benefit equally.
+
+!!! warning "Same scope restrictions"
+
+    No transition metals, closed-shell only, molecular training data. See the [AIMNet2 page](aimnet2.md) for the full list of limitations.
 
 ## Typical Use Cases
 
@@ -91,7 +99,9 @@ print(f"Binding energy: {binding_energy * 1000:.1f} meV")
 print(f"Binding energy: {binding_energy * 23.0609:.2f} kcal/mol")
 ```
 
-!!! note "No BSSE correction needed" Unlike ab initio methods with finite basis sets, neural network potentials do not suffer from basis set superposition error (BSSE). The supramolecular approach (dimer minus monomers) directly gives the interaction energy without counterpoise correction.
+!!! note "No BSSE correction needed"
+
+    Unlike ab initio methods with finite basis sets, neural network potentials do not suffer from basis set superposition error (BSSE). The supramolecular approach (dimer minus monomers) directly gives the interaction energy without counterpoise correction.
 
 ### ASE Integration
 

--- a/docs/models/aimnet2_b973c.md
+++ b/docs/models/aimnet2_b973c.md
@@ -1,6 +1,8 @@
 # AIMNet2-B97-3c
 
-!!! warning "Superseded by AIMNet2-2025" This model has been superseded by [AIMNet2-2025](aimnet2_2025.md), which provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. **Use `aimnet2_2025` for all new work.** The original `aimnet2_b973c` is retained only for reproducing previously published results.
+!!! warning "Superseded by AIMNet2-2025"
+
+    This model has been superseded by [AIMNet2-2025](aimnet2_2025.md), which provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. **Use `aimnet2_2025` for all new work.** The original `aimnet2_b973c` is retained only for reproducing previously published results.
 
 ## Overview
 
@@ -23,18 +25,26 @@ AIMNet2-B97-3c is the **original B97-3c screening model** trained against B97-3c
 
 ### Limitations
 
-!!! warning "Lower reference accuracy" B97-3c is a GGA-level composite method. It is systematically less accurate than wB97M-D3 for barrier heights, reaction energies involving significant electron correlation changes, and non-covalent interaction energies. For higher accuracy, use [AIMNet2 (wB97M-D3)](aimnet2.md).
+!!! warning "Lower reference accuracy"
 
-!!! warning "Barrier heights" GGA functionals tend to underestimate reaction barriers. If accurate transition state energies are important, prefer the wB97M-D3 model or use [AIMNet2-NSE](aimnet2nse.md) for open-shell transition states.
+    B97-3c is a GGA-level composite method. It is systematically less accurate than wB97M-D3 for barrier heights, reaction energies involving significant electron correlation changes, and non-covalent interaction energies. For higher accuracy, use [AIMNet2 (wB97M-D3)](aimnet2.md).
 
-!!! warning "Same scope restrictions as AIMNet2" No transition metals, closed-shell only, molecular (gas-phase) training data. See the [AIMNet2 page](aimnet2.md) for the full list of limitations.
+!!! warning "Barrier heights"
+
+    GGA functionals tend to underestimate reaction barriers. If accurate transition state energies are important, prefer the wB97M-D3 model or use [AIMNet2-NSE](aimnet2nse.md) for open-shell transition states.
+
+!!! warning "Same scope restrictions as AIMNet2"
+
+    No transition metals, closed-shell only, molecular (gas-phase) training data. See the [AIMNet2 page](aimnet2.md) for the full list of limitations.
 
 ## Typical Use Cases
 
 - **Reproducing published results** -- use when replicating calculations from papers that used `aimnet2_b973c`
 - **Cross-validation** -- compare B97-3c and wB97M-D3 predictions to gauge sensitivity to the reference method
 
-!!! tip "For new projects, use AIMNet2-2025" For high-throughput screening, conformer ranking, and any new B97-3c-level work, switch to [`aimnet2_2025`](aimnet2_2025.md) which provides strictly better accuracy for the same computational cost.
+!!! tip "For new projects, use AIMNet2-2025"
+
+    For high-throughput screening, conformer ranking, and any new B97-3c-level work, switch to [`aimnet2_2025`](aimnet2_2025.md) which provides strictly better accuracy for the same computational cost.
 
 ## Quick Example
 

--- a/docs/models/aimnet2nse.md
+++ b/docs/models/aimnet2nse.md
@@ -24,7 +24,9 @@ AIMNet2-NSE (Neutral Spin Equilibrated) is the model for **open-shell molecular 
 
 ### Limitations
 
-!!! warning "Single-determinant DFT reference" AIMNet2-NSE is trained on unrestricted Kohn-Sham DFT data, which uses a single Slater determinant. It is **not reliable** for systems with genuine multi-reference character, including:
+!!! warning "Single-determinant DFT reference"
+
+    AIMNet2-NSE is trained on unrestricted Kohn-Sham DFT data, which uses a single Slater determinant. It is **not reliable** for systems with genuine multi-reference character, including:
 
     - Biradicals with significant open-shell singlet character
     - Near-degenerate spin states in transition-metal-free systems
@@ -32,9 +34,13 @@ AIMNet2-NSE (Neutral Spin Equilibrated) is the model for **open-shell molecular 
 
     If you suspect multi-reference character, validate against CASSCF or MRCI calculations.
 
-!!! warning "Spin contamination" The underlying DFT reference data may contain spin contamination from unrestricted KS calculations. The model learns from this data as-is, so predictions for heavily spin-contaminated states should be treated with caution.
+!!! warning "Spin contamination"
 
-!!! warning "Same element and system scope" No transition metals, molecular (gas-phase) training data only. For Pd-containing open-shell systems, neither this model nor [AIMNet2-Pd](aimnet2pd.md) is currently suitable -- use DFT directly.
+    The underlying DFT reference data may contain spin contamination from unrestricted KS calculations. The model learns from this data as-is, so predictions for heavily spin-contaminated states should be treated with caution.
+
+!!! warning "Same element and system scope"
+
+    No transition metals, molecular (gas-phase) training data only. For Pd-containing open-shell systems, neither this model nor [AIMNet2-Pd](aimnet2pd.md) is currently suitable -- use DFT directly.
 
 ## How Spin Multiplicity Works
 

--- a/docs/models/aimnet2pd.md
+++ b/docs/models/aimnet2pd.md
@@ -12,7 +12,9 @@ AIMNet2-Pd extends AIMNet2 to **palladium-catalyzed organometallic chemistry**. 
 
 **DFT reference:** B97-3c with CPCM implicit solvation (THF solvent)
 
-!!! warning "Element coverage difference" AIMNet2-Pd replaces **As** (arsenic) with **Pd** (palladium) compared to the standard AIMNet2 element set. Arsenic is **not supported** by this model.
+!!! warning "Element coverage difference"
+
+    AIMNet2-Pd replaces **As** (arsenic) with **Pd** (palladium) compared to the standard AIMNet2 element set. Arsenic is **not supported** by this model.
 
 ## Strengths and Limitations
 
@@ -27,15 +29,25 @@ AIMNet2-Pd extends AIMNet2 to **palladium-catalyzed organometallic chemistry**. 
 
 ### Limitations
 
-!!! warning "Palladium only" This model supports only palladium among transition metals. It cannot be used for other catalytic metals such as Ni, Cu, Fe, Ru, Rh, or Ir. For systems without transition metals, use the standard [AIMNet2](aimnet2.md) model instead.
+!!! warning "Palladium only"
 
-!!! warning "No arsenic" Arsenic (As) is excluded from the element set. If your Pd complex contains arsine ligands (AsR3), this model cannot be used.
+    This model supports only palladium among transition metals. It cannot be used for other catalytic metals such as Ni, Cu, Fe, Ru, Rh, or Ir. For systems without transition metals, use the standard [AIMNet2](aimnet2.md) model instead.
 
-!!! tip "Implicit solvation included" Unlike other AIMNet2 models, AIMNet2-Pd is trained on B97-3c/CPCM reference data with **THF as the implicit solvent**. This means solvent stabilization effects relevant to homogeneous catalysis in THF or similar non-polar aprotic solvents are captured directly. For reactions in very different solvent environments (e.g., water, DMSO), additional solvation corrections may still be needed.
+!!! warning "No arsenic"
 
-!!! warning "Closed-shell only" AIMNet2-Pd assumes closed-shell electronic structure. Open-shell Pd intermediates (e.g., Pd(I) species, radical mechanisms) require DFT treatment. For organic radical chemistry without Pd, use [AIMNet2-NSE](aimnet2nse.md).
+    Arsenic (As) is excluded from the element set. If your Pd complex contains arsine ligands (AsR3), this model cannot be used.
 
-!!! warning "Coordination environment" The model has been trained on common coordination environments. Unusual geometries (e.g., Pd clusters, Pd nanoparticles, bulk Pd metal) are outside the training domain and should not be trusted.
+!!! tip "Implicit solvation included"
+
+    Unlike other AIMNet2 models, AIMNet2-Pd is trained on B97-3c/CPCM reference data with **THF as the implicit solvent**. This means solvent stabilization effects relevant to homogeneous catalysis in THF or similar non-polar aprotic solvents are captured directly. For reactions in very different solvent environments (e.g., water, DMSO), additional solvation corrections may still be needed.
+
+!!! warning "Closed-shell only"
+
+    AIMNet2-Pd assumes closed-shell electronic structure. Open-shell Pd intermediates (e.g., Pd(I) species, radical mechanisms) require DFT treatment. For organic radical chemistry without Pd, use [AIMNet2-NSE](aimnet2nse.md).
+
+!!! warning "Coordination environment"
+
+    The model has been trained on common coordination environments. Unusual geometries (e.g., Pd clusters, Pd nanoparticles, bulk Pd metal) are outside the training domain and should not be trusted.
 
 ## Typical Use Cases
 
@@ -149,7 +161,9 @@ energies = torch.stack([r["energy"] for r in results])
 print(f"Energy: {energies.mean().item():.6f} +/- {energies.std().item():.6f} eV")
 ```
 
-!!! note "Ensemble member naming" The Pd model ensemble members use a hyphen: `aimnet2-pd_0` through `aimnet2-pd_3` (note the hyphen between "aimnet2" and "pd").
+!!! note "Ensemble member naming"
+
+    The Pd model ensemble members use a hyphen: `aimnet2-pd_0` through `aimnet2-pd_3` (note the hyphen between "aimnet2" and "pd").
 
 ### Performance
 

--- a/docs/train.md
+++ b/docs/train.md
@@ -6,7 +6,7 @@
 
 The training dataset must be formatted as an HDF5 file, with groups containing molecules of uniform size. For example, the dataset below contains 25,768 molecules with 28 atoms and 19,404 molecules with 29 atoms.
 
-```
+```bash
 $ h5ls -r dataset.h5
 /028                     Group
 /028/charge              Dataset {25768}
@@ -30,7 +30,7 @@ Units should be based on Angstrom, electron-volt, and electron charge.
 
 To access available options for the training script execute the following command:
 
-```
+```bash
 $ aimnet train --help
 ```
 
@@ -42,7 +42,7 @@ Key components for initiating training include:
 
 - **Self-Atomic Energies File:** This file can be generated using the following command:
 
-```
+```bash
 $ aimnet calc_sae dataset.h5 dataset_sae.yaml
 ```
 
@@ -54,13 +54,13 @@ The training script integrates with Weights & Biases (W&B), a platform for exper
 
 - **Online Account:**
 
-```
+```bash
 $ wandb login
 ```
 
 - **Project and Entity Configuration:** Create a configuration file (e.g., `extra_conf.yaml`) with your W&B project and entity details:
 
-```
+```yaml
 wandb:
   init:
     mode: online
@@ -74,19 +74,19 @@ Pass this configuration to the `aimnet train` command using the `--config` param
 
 For optimal data loader performance, it is recommended to disable numpy multithreading:
 
-```
+```bash
 $ export OMP_NUM_THREADS=1
 ```
 
 By default, training will utilize all available GPUs in a single-node, distributed data-parallel mode. To restrict training to a specific GPU (e.g., GPU 0):
 
-```
+```bash
 $ export CUDA_VISIBLE_DEVICES=0
 ```
 
 Finally, initiate the training script with default parameters and the specified `run_name`:
 
-```
+```bash
 $ aimnet train data.train=dataset.h5 data.sae.energy.file=dataset_sae.yaml run_name=firstrun
 ```
 
@@ -94,7 +94,7 @@ $ aimnet train data.train=dataset.h5 data.sae.energy.file=dataset_sae.yaml run_n
 
 To export a trained model for distribution and use with AIMNet calculators:
 
-```
+```bash
 $ aimnet export weights.pt model.pt --model config.yaml --sae model.sae
 ```
 
@@ -168,7 +168,7 @@ For legacy models, Coulomb and dispersion modules remain embedded in the model.
 
 To convert existing `.jpt` models to the new format:
 
-```
+```bash
 $ aimnet convert model.jpt config.yaml model_new.pt
 ```
 

--- a/docs/tutorials/geometry_optimization.md
+++ b/docs/tutorials/geometry_optimization.md
@@ -41,7 +41,9 @@ print(f"Initial energy: {energy:.6f} eV")
 print(f"Max force: {abs(forces).max():.6f} eV/A")
 ```
 
-!!! tip "Accessing the underlying calculator" The ASE wrapper stores the `AIMNet2Calculator` as `calc.base_calc`. You can use this to configure model settings that are not exposed through the ASE interface:
+!!! tip "Accessing the underlying calculator"
+
+    The ASE wrapper stores the `AIMNet2Calculator` as `calc.base_calc`. You can use this to configure model settings that are not exposed through the ASE interface:
 
     ```python
     # Switch long-range Coulomb method (for periodic systems)
@@ -96,7 +98,9 @@ write("aspirin_optimized.xyz", aspirin)
 
 The `fmax` parameter controls the convergence criterion: the optimization stops when the maximum atomic force magnitude (i.e., the largest per-atom force norm sqrt(fx^2+fy^2+fz^2)) drops below this threshold. A value of 0.01 eV/A is a reasonable default for most applications.
 
-!!! note "Why BFGS?" BFGS (Broyden--Fletcher--Goldfarb--Shanno) builds an approximate Hessian from force evaluations, giving superlinear convergence near the minimum. ASE also provides `LBFGS` (lower memory for large systems) and `FIRE` (robust for far-from-minimum starting geometries). For most molecules under ~200 atoms, `BFGS` is the best choice.
+!!! note "Why BFGS?"
+
+    BFGS (Broyden--Fletcher--Goldfarb--Shanno) builds an approximate Hessian from force evaluations, giving superlinear convergence near the minimum. ASE also provides `LBFGS` (lower memory for large systems) and `FIRE` (robust for far-from-minimum starting geometries). For most molecules under ~200 atoms, `BFGS` is the best choice.
 
 ## Step 3: Monitor Convergence
 
@@ -118,7 +122,9 @@ for i, frame in enumerate(traj):
 
 You should see the energy decrease monotonically (or nearly so) and the maximum force drop toward your `fmax` threshold.
 
-!!! warning "Convergence issues" If the optimization oscillates or takes more than ~100 steps for a molecule under 50 atoms, check:
+!!! warning "Convergence issues"
+
+    If the optimization oscillates or takes more than ~100 steps for a molecule under 50 atoms, check:
 
     1. **Starting geometry**: Very distorted structures may need `FIRE` instead
        of `BFGS` for the first phase.
@@ -192,7 +198,9 @@ else:
     print(f"\nWARNING: {n_imaginary} imaginary frequency(ies) found -> not a minimum")
 ```
 
-!!! warning "Hessian limitations" The Hessian calculation in AIMNet2 is limited to **single molecules** and scales as O(N^2) in memory. It is practical for molecules up to roughly 200 atoms. For larger systems, use finite-difference approaches or specialized phonon tools.
+!!! warning "Hessian limitations"
+
+    The Hessian calculation in AIMNet2 is limited to **single molecules** and scales as O(N^2) in memory. It is practical for molecules up to roughly 200 atoms. For larger systems, use finite-difference approaches or specialized phonon tools.
 
 ## Step 5: Thermochemistry from Frequencies
 
@@ -239,7 +247,9 @@ print(f"-T*S contribution:     {(G - H) * 23.0609:.2f} kcal/mol")
 
 This workflow -- optimize, compute Hessian, extract thermochemistry -- is the standard approach for obtaining reaction enthalpies and free energies with AIMNet2.
 
-!!! tip "Thermochemistry for reactions" To compute a reaction enthalpy Delta_H, run this workflow for each reactant and product separately, then take the difference:
+!!! tip "Thermochemistry for reactions"
+
+    To compute a reaction enthalpy Delta_H, run this workflow for each reactant and product separately, then take the difference:
 
     ```
     Delta_H = sum(H_products) - sum(H_reactants)
@@ -270,7 +280,9 @@ calc = AIMNet2ASE(
 # opt.run(fmax=0.01)
 ```
 
-!!! note "Practical size limits" - **Geometry optimization** works well up to thousands of atoms. - **Hessian computation** is practical up to ~200 atoms due to O(N^2) memory scaling (the full Hessian for 200 atoms requires 200 x 3 x 200 x 3 = 360,000 elements). - For larger systems needing frequencies, use finite-difference approaches with a displacement step.
+!!! note "Practical size limits"
+
+    - **Geometry optimization** works well up to thousands of atoms. - **Hessian computation** is practical up to ~200 atoms due to O(N^2) memory scaling (the full Hessian for 200 atoms requires 200 x 3 x 200 x 3 = 360,000 elements). - For larger systems needing frequencies, use finite-difference approaches with a displacement step.
 
 ## What's Next
 

--- a/docs/tutorials/geometry_optimization.md
+++ b/docs/tutorials/geometry_optimization.md
@@ -282,7 +282,9 @@ calc = AIMNet2ASE(
 
 !!! note "Practical size limits"
 
-    - **Geometry optimization** works well up to thousands of atoms. - **Hessian computation** is practical up to ~200 atoms due to O(N^2) memory scaling (the full Hessian for 200 atoms requires 200 x 3 x 200 x 3 = 360,000 elements). - For larger systems needing frequencies, use finite-difference approaches with a displacement step.
+    - **Geometry optimization** works well up to thousands of atoms.
+    - **Hessian computation** is practical up to ~200 atoms due to O(N^2) memory scaling (the full Hessian for 200 atoms requires 200 x 3 x 200 x 3 = 360,000 elements).
+    - For larger systems needing frequencies, use finite-difference approaches with a displacement step.
 
 ## What's Next
 

--- a/docs/tutorials/molecular_dynamics.md
+++ b/docs/tutorials/molecular_dynamics.md
@@ -51,7 +51,9 @@ opt.run(fmax=0.01)
 print(f"Optimized energy: {ethanol.get_potential_energy():.4f} eV")
 ```
 
-!!! note "What `compile_model=True` actually compiles" The `compile_model=True` flag wraps **only the neural network forward pass** with `torch.compile()`. The neighbor list construction, external Coulomb module, and external DFT-D3 module are **not** compiled. This means:
+!!! note "What `compile_model=True` actually compiles"
+
+    The `compile_model=True` flag wraps **only the neural network forward pass** with `torch.compile()`. The neighbor list construction, external Coulomb module, and external DFT-D3 module are **not** compiled. This means:
 
     - The NN evaluation (the most expensive part) gets compiled and optimized
     - Neighbor lists are rebuilt every step as normal
@@ -119,7 +121,9 @@ print(f"\nCompleted 1000 steps in {wall_time:.1f} s "
 traj.close()
 ```
 
-!!! warning "First-step warmup" The very first MD step is significantly slower than subsequent steps because of two one-time costs:
+!!! warning "First-step warmup"
+
+    The very first MD step is significantly slower than subsequent steps because of two one-time costs:
 
     1. **Warp kernel JIT compilation** (10--30 s): NVIDIA Warp compiles GPU
        kernels on first use. These are cached on disk for future sessions.
@@ -128,7 +132,9 @@ traj.close()
 
     After the first step, typical step times for a 9-atom molecule on a modern GPU are 1--5 ms. Do not include the first step in performance benchmarks.
 
-!!! tip "Timestep selection for ML potentials" ML potentials like AIMNet2 have smooth, continuous energy surfaces, so they tolerate slightly larger timesteps than ab initio MD. However, the safe range depends on the dynamics:
+!!! tip "Timestep selection for ML potentials"
+
+    ML potentials like AIMNet2 have smooth, continuous energy surfaces, so they tolerate slightly larger timesteps than ab initio MD. However, the safe range depends on the dynamics:
 
     - **0.5 fs**: Conservative. Good starting point for any system.
     - **1.0 fs**: Suitable for equilibrium sampling of organic molecules when
@@ -142,7 +148,9 @@ traj.close()
 
 NPT (constant pressure) is needed for condensed-phase simulations where the volume should fluctuate. ASE provides the `NPT` integrator for this purpose.
 
-!!! note "NPT requires periodic boundary conditions" The Berendsen barostat adjusts the unit cell dimensions, which only makes sense for periodic systems. For an isolated molecule in vacuum, use NVT instead.
+!!! note "NPT requires periodic boundary conditions"
+
+    The Berendsen barostat adjusts the unit cell dimensions, which only makes sense for periodic systems. For an isolated molecule in vacuum, use NVT instead.
 
 ```python
 from ase.md.npt import NPT as NPTIntegrator
@@ -181,7 +189,9 @@ from ase import units
 # traj.close()
 ```
 
-!!! tip "Equilibration strategy for condensed-phase systems" For reliable results, follow a two-phase protocol:
+!!! tip "Equilibration strategy for condensed-phase systems"
+
+    For reliable results, follow a two-phase protocol:
 
     1. **NVT equilibration** (1--5 ps): Let the temperature stabilize before
        coupling the barostat. This prevents large pressure spikes from an initial geometry that is far from the equilibrium density.
@@ -267,7 +277,9 @@ print(f"  Mean distance: {all_distances.mean():.2f} A")
 # rdf = ana.get_rdf(rmax=10.0, nbins=200, elements=("O", "H"))
 ```
 
-!!! tip "For periodic systems" The simplified distance histogram above works for isolated molecules. For proper RDF analysis of periodic (condensed-phase) systems, use the ASE `Analysis` class which correctly handles periodic images:
+!!! tip "For periodic systems"
+
+    The simplified distance histogram above works for isolated molecules. For proper RDF analysis of periodic (condensed-phase) systems, use the ASE `Analysis` class which correctly handles periodic images:
 
     ```python
     from ase.geometry.analysis import Analysis
@@ -321,7 +333,9 @@ calc = AIMNet2ASE(base_calc)
 | `True` (default) | 5--30 s | ~0.7x baseline | Most MD simulations |
 | `reduce-overhead` | 10--60 s | ~0.5x baseline | Long production runs |
 
-!!! warning "Compilation and system size changes" `torch.compile` traces the computation graph for a specific tensor shape. If the system size changes (e.g., atoms are added or removed), the model will be recompiled. For MD of a fixed system this is not an issue, but avoid using `compile_model=True` for workflows that process molecules of varying sizes.
+!!! warning "Compilation and system size changes"
+
+    `torch.compile` traces the computation graph for a specific tensor shape. If the system size changes (e.g., atoms are added or removed), the model will be recompiled. For MD of a fixed system this is not an issue, but avoid using `compile_model=True` for workflows that process molecules of varying sizes.
 
 ## Practical Recommendations
 

--- a/docs/tutorials/performance.md
+++ b/docs/tutorials/performance.md
@@ -52,7 +52,9 @@ result = calc({
 }, forces=True)
 ```
 
-!!! note Warp caches compiled kernels in `~/.cache/warp/` (or the directory set by `WARP_CACHE_PATH`). If you delete this cache, the next run will recompile.
+!!! note
+
+    Warp caches compiled kernels in `~/.cache/warp/` (or the directory set by `WARP_CACHE_PATH`). If you delete this cache, the next run will recompile.
 
 ## Step 2: Using torch.compile (compile_model)
 
@@ -107,7 +109,9 @@ calc = AIMNet2Calculator(
 )
 ```
 
-!!! warning "Do not use reduce-overhead with varying input sizes" The `reduce-overhead` mode uses CUDA graphs, which record a fixed execution pattern. If your input sizes vary between calls (different numbers of atoms or neighbors), this causes **graph breaks** and can actually slow things down or produce errors. Only use `reduce-overhead` when the system size is truly constant.
+!!! warning "Do not use reduce-overhead with varying input sizes"
+
+    The `reduce-overhead` mode uses CUDA graphs, which record a fixed execution pattern. If your input sizes vary between calls (different numbers of atoms or neighbors), this causes **graph breaks** and can actually slow things down or produce errors. Only use `reduce-overhead` when the system size is truly constant.
 
     ```python
     # AVOID for varying sizes
@@ -150,7 +154,9 @@ calc = AIMNet2Calculator("aimnet2", nb_threshold=80)
 calc = AIMNet2Calculator("aimnet2", nb_threshold=200)
 ```
 
-!!! warning "Avoid crossing the dense/sparse boundary with torch.compile" If you use `compile_model=True`, make sure all your inputs consistently land in the same mode (all dense or all sparse). Crossing the boundary (e.g., some calls with 100 atoms in dense mode, others with 150 atoms in sparse mode) causes recompilation each time, negating the benefits. Set `nb_threshold` so that your typical workload stays in one mode.
+!!! warning "Avoid crossing the dense/sparse boundary with torch.compile"
+
+    If you use `compile_model=True`, make sure all your inputs consistently land in the same mode (all dense or all sparse). Crossing the boundary (e.g., some calls with 100 atoms in dense mode, others with 150 atoms in sparse mode) causes recompilation each time, negating the benefits. Set `nb_threshold` so that your typical workload stays in one mode.
 
 ## Step 4: GPU Memory Considerations
 
@@ -166,7 +172,9 @@ The `AdaptiveNeighborList` starts with a buffer sized from an initial density es
 
 Hessian calculation requires O(N^2) memory because the full second-derivative matrix has shape `(N, 3, N, 3)`. For a 100-atom molecule, this is 100 x 3 x 100 x 3 = 90,000 float values (~360 KB in float32), and for 1000 atoms it becomes 1000 x 3 x 1000 x 3 = 9,000,000 values (~36 MB in float32).
 
-!!! warning Hessian computation is limited to **single molecules** and scales quadratically with atom count. For molecules larger than ~200 atoms, you may run out of GPU memory. Consider computing the Hessian on a CPU for large systems, or using finite-difference approaches for specific vibrational modes.
+!!! warning
+
+    Hessian computation is limited to **single molecules** and scales quadratically with atom count. For molecules larger than ~200 atoms, you may run out of GPU memory. Consider computing the Hessian on a CPU for large systems, or using finite-difference approaches for specific vibrational modes.
 
 ### Synchronization Points
 
@@ -260,7 +268,9 @@ calc = AIMNet2Calculator("aimnet2", train=True)
 calc = AIMNet2Calculator("aimnet2")  # train=False by default
 ```
 
-!!! note `train=False` (the default) disables `requires_grad` on all model parameters. This reduces memory usage and improves `torch.compile` compatibility. The calculator still computes forces and Hessians correctly via autograd on the input coordinates.
+!!! note
+
+    `train=False` (the default) disables `requires_grad` on all model parameters. This reduces memory usage and improves `torch.compile` compatibility. The calculator still computes forces and Hessians correctly via autograd on the input coordinates.
 
 ### Do Not Use Multiple GPUs
 

--- a/docs/tutorials/single_point.md
+++ b/docs/tutorials/single_point.md
@@ -47,7 +47,9 @@ print(f"Forces (eV/A):\n{result['forces']}")
 print(f"Partial charges (e): {result['charges']}")
 ```
 
-!!! note "First-run warmup" The very first calculation triggers two one-time costs:
+!!! note "First-run warmup"
+
+    The very first calculation triggers two one-time costs:
 
     1. **Warp kernel JIT compilation** (10--30 seconds): AIMNet2 uses NVIDIA Warp
        for GPU-accelerated neighbor list and kernel operations. These kernels are compiled on first use and cached for subsequent runs.
@@ -154,7 +156,9 @@ hessian = result["hessian"]
 print(f"Hessian shape: {hessian.shape}")  # (21, 3, 21, 3) for aspirin
 ```
 
-!!! tip "When to request each property" Only request what you need. Computing forces adds one backward pass. Computing the hessian adds `3N` backward passes (one per force component), so it becomes expensive for large molecules. The hessian is also limited to single-molecule calculations.
+!!! tip "When to request each property"
+
+    Only request what you need. Computing forces adds one backward pass. Computing the hessian adds `3N` backward passes (one per force component), so it becomes expensive for large molecules. The hessian is also limited to single-molecule calculations.
 
     If you need to differentiate through the calculator from **outside** (e.g., wrapping it in an optimizer or computing a Hessian via `torch.autograd.functional.hessian`), pass `coord` as a tensor with `requires_grad=True` and use `forces=False`:
 
@@ -190,7 +194,9 @@ for name in model_names:
     print(f"{name:<20} {e:>14.6f} {f_max:>18.6f}")
 ```
 
-!!! warning "Absolute energies differ between models" Different models use different DFT functionals as training targets, so their absolute energy scales are not comparable. **Relative** energies (e.g., conformer energy differences, reaction energies) are meaningful within the same model but should not be mixed across models.
+!!! warning "Absolute energies differ between models"
+
+    Different models use different DFT functionals as training targets, so their absolute energy scales are not comparable. **Relative** energies (e.g., conformer energy differences, reaction energies) are meaningful within the same model but should not be mixed across models.
 
 The available model aliases are:
 
@@ -237,7 +243,9 @@ t1 = time.perf_counter()
 print(f"Average over 100 calls: {(t1 - t0) / 100 * 1000:.2f} ms")
 ```
 
-!!! note "What `compile_model=True` does" This wraps the neural network forward pass with `torch.compile()`. It does **not** compile the neighbor list construction or the external Coulomb/DFTD3 modules. The benefit is greatest for repeated evaluations on the same system size, such as MD trajectories or geometry optimizations.
+!!! note "What `compile_model=True` does"
+
+    This wraps the neural network forward pass with `torch.compile()`. It does **not** compile the neighbor list construction or the external Coulomb/DFTD3 modules. The benefit is greatest for repeated evaluations on the same system size, such as MD trajectories or geometry optimizations.
 
 ## What's Next
 


### PR DESCRIPTION
## Summary

Multi-agent audit pass: parallel agents reviewed Markdown docs, YAML/TOML configs, Python source health, and doc/code drift. Conservative writes only — concrete bugs, not stylistic refactors.

### Agent A — Markdown audit (`751b124`)

Fixed inline-admonition syntax across 10 docs. Lines like `!!! warning "Title" body text` were rendering as literal paragraphs instead of admonition blocks. Title and body now split across lines as mkdocs-material requires.

Touched: `docs/{advanced,models,tutorials}/*.md`, `docs/train.md`. Also added `bash`/`yaml` language tags to fences in `docs/train.md`.

Cap reached at 10 files; ~21 more admonition instances flagged for a follow-up sweep.

### Agent B — YAML/config audit

No changes — configs verified clean after recent remediation work. Flagged for follow-up (out of scope here): coverage upload only on `tests-core (3.11)` (other marker jobs run extras but don't `--cov`); Python 3.13 classifier in `pyproject.toml` while CI matrix is 3.11/3.12; one stale `ignite` entry in `[tool.deptry.per_rule_ignores]`.

### Agent C — Python source health (`161e527`)

Fixed `_prepere_input` → `_prepare_input` typo (private method, 1 def + 3 callers in `aimnet/calculators/aimnet2pysis.py`). No public API changes, no kernel/autograd/PBC changes per audit constraints.

### Agent E — Doc/code drift (`00faf92`)

- `docs/calculator.md`: `AIMNet2Calculator` signature was missing `train: bool = False` (added in code, not in docs). Added to signature listing and behavior docs.
- `docs/cli.md`: `aimnet train` doc claimed `--resume`/`--device` (neither exists). Replaced with the real options from `aimnet/train/train.py`.
- `docs/cli.md`: `aimnet calc_sae` doc described positional `INPUT OUTPUT` with `--elements`. Real signature is `DS OUTPUT` with `--samples`. Surrounding prose corrected.

### Misc (`fed8af0`)

Two CLI/docstring typos surfaced by Agent E (`outoput` → `output`, `preficied` → `specified`).

## Test plan

- [x] `make check` (ruff, prettier, deptry, etc.) — green
- [x] Full pytest with `-n 4`: **328 passed, 1 skipped** in 21:40
- [ ] CI: full `Main` matrix on this branch