### PR TITLE
ci: Python 3.13 in matrix, per-marker codecov uploads, drop stale deptry entry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                python-version: ["3.11", "3.12"]
+                python-version: ["3.11", "3.12", "3.13"]
             fail-fast: false
         defaults:
             run:
@@ -56,6 +56,8 @@ jobs:
             - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
               uses: codecov/codecov-action@v6
               if: ${{ matrix.python-version == '3.11' }}
+              with:
+                  flags: core
 
     tests-ase:
         runs-on: ubuntu-latest
@@ -79,7 +81,12 @@ jobs:
                   extras: ase
 
             - name: Run ASE tests
-              run: uv run pytest tests -m ase
+              run: uv run pytest tests -m ase --cov --cov-config=pyproject.toml --cov-report=xml
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v6
+              with:
+                  flags: ase
 
     tests-train:
         runs-on: ubuntu-latest
@@ -105,12 +112,18 @@ jobs:
             - name: Run train-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m train || rc=$?
+                  uv run pytest tests -m train --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No train-marked tests collected; treating as success."
                     exit 0
                   fi
                   exit "${rc:-0}"
+
+            - name: Upload coverage reports to Codecov
+              if: hashFiles('coverage.xml') != ''
+              uses: codecov/codecov-action@v6
+              with:
+                  flags: train
 
     tests-pysis:
         runs-on: ubuntu-latest
@@ -136,12 +149,18 @@ jobs:
             - name: Run pysis-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m pysis || rc=$?
+                  uv run pytest tests -m pysis --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No pysis-marked tests collected; treating as success."
                     exit 0
                   fi
                   exit "${rc:-0}"
+
+            - name: Upload coverage reports to Codecov
+              if: hashFiles('coverage.xml') != ''
+              uses: codecov/codecov-action@v6
+              with:
+                  flags: pysis
 
     tests-hf:
         runs-on: ubuntu-latest
@@ -167,12 +186,18 @@ jobs:
             - name: Run hf-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m hf || rc=$?
+                  uv run pytest tests -m hf --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No hf-marked tests collected; treating as success."
                     exit 0
                   fi
                   exit "${rc:-0}"
+
+            - name: Upload coverage reports to Codecov
+              if: hashFiles('coverage.xml') != ''
+              uses: codecov/codecov-action@v6
+              with:
+                  flags: hf
 
     check-docs:
         runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ exclude_lines = [
 package_module_name_map = { "pytorch-ignite" = "ignite" }
 
 [tool.deptry.per_rule_ignores]
-# Optional dependencies (ase, pysisyphus, ignite) are only available with extras
-DEP001 = ["ase", "pysisyphus", "ignite"]
+# Optional extras (ase, pysisyphus) — installed via [project.optional-dependencies]; deptry can't see them statically
+DEP001 = ["ase", "pysisyphus"]
 DEP003 = ["ase", "pysisyphus"]
 DEP004 = ["ase", "pysisyphus"]


### PR DESCRIPTION
## Summary

Wave 1 of post-audit follow-ups (config tidy, no behavior change).

| Item | Change |
|---|---|
| F3 | `tests-core` matrix gains `3.13`. Smoke-tested locally with `uv lock --python 3.13 --check`. |
| F2 | `tests-ase`, `tests-train`, `tests-pysis`, `tests-hf` now run with `--cov --cov-config=pyproject.toml --cov-report=xml` and upload to Codecov with a per-marker `flags:` discriminator (`core`, `ase`, `train`, `pysis`, `hf`). The empty-collection jobs gate the upload on `coverage.xml` actually existing. |
| F4 | Drop `ignite` from `[tool.deptry.per_rule_ignores] DEP001`. `pytorch-ignite` is a real runtime dep mapped via `package_module_name_map`; the ignore was redundant. Comment corrected. |

## Notes

- Branch protection currently requires `tests-core (3.11)` and `tests-core (3.12)` only. The new `tests-core (3.13)` job will run but is not blocking. We can add it to required after one or two clean cycles if you want.
- Codecov status is `project: off, patch: off` (intentional per `codecov.yaml`); flags only affect the dashboard view, not gating.

## Test plan

- [x] `make check` (ruff, prettier, deptry) — green
- [x] `uv run deptry .` — passes without `ignite` ignore
- [x] `uv lock --python 3.13 --check` — clean
- [ ] CI: full Main matrix on this branch including new `tests-core (3.13)`
- [ ] Codecov: confirm flags `core`/`ase`/`train`/`pysis`/`hf` show up after upload