### PR TITLE
docs: finish admonition syntax cleanup across remaining pages

### DIFF
--- a/docs/advanced/conformer_search.md
+++ b/docs/advanced/conformer_search.md
@@ -32,7 +32,9 @@ This combines the strengths of each method: RDKit provides broad sampling of con
 | `aimnet2_2025` | B97-3c (improved) | Faster | Initial screening, large libraries, many conformers |
 | `aimnet2` | wB97M-D3 | Baseline | Final ranking, publication-quality results |
 
-!!! tip "Two-stage workflow" For large molecules with many conformers, use `aimnet2_2025` to screen and discard high-energy conformers (e.g., > 5 kcal/mol above minimum), then re-optimize the survivors with `aimnet2` for final ranking.
+!!! tip "Two-stage workflow"
+
+    For large molecules with many conformers, use `aimnet2_2025` to screen and discard high-energy conformers (e.g., > 5 kcal/mol above minimum), then re-optimize the survivors with `aimnet2` for final ranking.
 
 ## Step 1: Generate Conformers with RDKit
 
@@ -151,7 +153,9 @@ cumulative = np.cumsum(populations[:10])
 print(f"\nTop 10 conformers cover {cumulative[-1]*100:.1f}% of population")
 ```
 
-!!! note "Temperature matters" At room temperature (298 K), kT is about 0.6 kcal/mol. Conformers more than 3 kcal/mol above the minimum typically have negligible population (< 1%). At higher temperatures or for entropy-driven processes, more conformers become relevant.
+!!! note "Temperature matters"
+
+    At room temperature (298 K), kT is about 0.6 kcal/mol. Conformers more than 3 kcal/mol above the minimum typically have negligible population (< 1%). At higher temperatures or for entropy-driven processes, more conformers become relevant.
 
 ## Worked Example: Alanine Dipeptide Ramachandran Plot
 

--- a/docs/advanced/reaction_paths.md
+++ b/docs/advanced/reaction_paths.md
@@ -19,7 +19,9 @@
 
 Finding transition states with DFT typically requires hundreds to thousands of gradient evaluations, each taking minutes to hours. AIMNet2 provides near-DFT gradients in milliseconds, making reaction path calculations that would take days at the DFT level complete in minutes.
 
-!!! tip "Model selection for reaction paths" Use `aimnet2nse` for reactions involving bond breaking or forming, especially homolytic processes (radical mechanisms, H-atom abstractions). For heterolytic processes (SN2, proton transfers), the standard `aimnet2` model may also work, but `aimnet2nse` is the safer default because it handles both closed-shell and open-shell regions of the potential energy surface.
+!!! tip "Model selection for reaction paths"
+
+    Use `aimnet2nse` for reactions involving bond breaking or forming, especially homolytic processes (radical mechanisms, H-atom abstractions). For heterolytic processes (SN2, proton transfers), the standard `aimnet2` model may also work, but `aimnet2nse` is the safer default because it handles both closed-shell and open-shell regions of the potential energy surface.
 
 ## PySisyphus Integration
 
@@ -214,7 +216,9 @@ ANG_TO_BOHR = 1.8897259886
 hessian_au = hessian_2d * EV_TO_HARTREE / (ANG_TO_BOHR ** 2)
 ```
 
-!!! warning "Hessian limitations" The Hessian computation is supported for **single molecules only**. If `mol_idx` indicates multiple molecules, the calculator raises `NotImplementedError`. The Hessian output has shape `(N, 3, N, 3)` and should be flattened to `(3N, 3N)` for eigenvalue analysis.
+!!! warning "Hessian limitations"
+
+    The Hessian computation is supported for **single molecules only**. If `mol_idx` indicates multiple molecules, the calculator raises `NotImplementedError`. The Hessian output has shape `(N, 3, N, 3)` and should be flattened to `(3N, 3N)` for eigenvalue analysis.
 
 ### Vibrational Frequency Analysis
 
@@ -329,7 +333,9 @@ python -c "from aimnet.calculators.aimnet2pysis import run_pysis; run_pysis()" i
 
 PySisyphus outputs the IRC path as a series of geometries with energies, which can be plotted as a reaction energy profile.
 
-!!! warning "Zero-point energy corrections for barrier heights" Barrier heights computed from electronic energies alone (Delta E‡) do not include zero-point energy corrections. For quantitative comparison with experimental activation energies, compute the Hessian at each stationary point, extract ZPE (excluding the imaginary frequency at the TS), and apply corrections:
+!!! warning "Zero-point energy corrections for barrier heights"
+
+    Barrier heights computed from electronic energies alone (Delta E‡) do not include zero-point energy corrections. For quantitative comparison with experimental activation energies, compute the Hessian at each stationary point, extract ZPE (excluding the imaginary frequency at the TS), and apply corrections:
 
     Delta E‡_0 = E(TS) - E(reactant) + ZPE(TS) - ZPE(reactant)
 
@@ -471,7 +477,9 @@ print("\nNEB config written to sn2_neb.yaml")
 print("Run with: python -c 'from aimnet.calculators.aimnet2pysis import run_pysis; run_pysis()' sn2_neb.yaml")
 ```
 
-!!! note "SN2 reactions and model choice" The SN2 reaction involves heterolytic bond breaking (the leaving group departs with both bonding electrons). For heterolytic processes like this, the standard `aimnet2` model may perform adequately. However, `aimnet2nse` is recommended as the default for all reaction path calculations because it handles mixed closed-shell/open-shell regions correctly and introduces no penalty for closed-shell species (`mult=1` reduces to standard behavior).
+!!! note "SN2 reactions and model choice"
+
+    The SN2 reaction involves heterolytic bond breaking (the leaving group departs with both bonding electrons). For heterolytic processes like this, the standard `aimnet2` model may perform adequately. However, `aimnet2nse` is recommended as the default for all reaction path calculations because it handles mixed closed-shell/open-shell regions correctly and introduces no penalty for closed-shell species (`mult=1` reduces to standard behavior).
 
 ## Practical Tips
 

--- a/docs/api/calculators.md
+++ b/docs/api/calculators.md
@@ -22,7 +22,9 @@ The core calculator for running AIMNet2 inference. It handles model loading, dev
 
 [ASE (Atomic Simulation Environment)](https://wiki.fysik.dtu.dk/ase/) calculator interface.
 
-!!! note "Installation" Requires the `ase` extra: `pip install aimnet[ase]`
+!!! note "Installation"
+
+    Requires the `ase` extra: `pip install aimnet[ase]`
 
 This calculator integrates with ASE's `Atoms` object, supporting energy, forces, stress, and dipole moment calculations. It operates in **eV** and **Angstrom**.
 
@@ -48,7 +50,9 @@ print(atoms.get_forces())
 
 [PySisyphus](https://pysisyphus.readthedocs.io/) calculator interface.
 
-!!! note "Installation" Requires the `pysis` extra: `pip install aimnet[pysis]`
+!!! note "Installation"
+
+    Requires the `pysis` extra: `pip install aimnet[pysis]`
 
 This interface adapts AIMNet2 for use with PySisyphus optimizers. It handles unit conversion automatically:
 

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -469,7 +469,9 @@ def energy_fn(x):
 H = torch.autograd.functional.hessian(energy_fn, coords)  # shape (N, 3, N, 3)
 ```
 
-!!! note "Use `forces=False` for external Hessians" When computing higher-order derivatives from outside the calculator, pass `forces=False`. Requesting `forces=True` triggers an internal backward pass that frees intermediate activations, preventing a second differentiation through the graph.
+!!! note "Use `forces=False` for external Hessians"
+
+    When computing higher-order derivatives from outside the calculator, pass `forces=False`. Requesting `forces=True` triggers an internal backward pass that frees intermediate activations, preventing a second differentiation through the graph.
 
 When `coord` does **not** have `requires_grad=True` (the default), inputs are detached as before — optimization loops that call the calculator repeatedly incur no graph accumulation overhead.
 

--- a/docs/models/guide.md
+++ b/docs/models/guide.md
@@ -71,7 +71,9 @@ Radicals, triplet states, or any system with unpaired electrons should use **`ai
 
 If you prefer a B97-3c reference level (faster DFT, suitable for screening and large-scale studies), use **`aimnet2_2025`**. This is the recommended B97-3c model — it supersedes the original `aimnet2_b973c` with improved intermolecular interaction accuracy while retaining the same intramolecular performance.
 
-!!! note "AIMNet2-2025 supersedes AIMNet2-B97-3c" For all new work requiring a B97-3c-level model, use `aimnet2_2025`. The original `aimnet2_b973c` is retained for reproducibility of published results but is no longer the recommended choice. AIMNet2-2025 provides strictly better accuracy for non-covalent interactions with no regression for covalent chemistry.
+!!! note "AIMNet2-2025 supersedes AIMNet2-B97-3c"
+
+    For all new work requiring a B97-3c-level model, use `aimnet2_2025`. The original `aimnet2_b973c` is retained for reproducibility of published results but is no longer the recommended choice. AIMNet2-2025 provides strictly better accuracy for non-covalent interactions with no regression for covalent chemistry.
 
 ### Step 5: General-purpose?
 

--- a/docs/tutorials/batch_processing.md
+++ b/docs/tutorials/batch_processing.md
@@ -57,9 +57,13 @@ print(f"Energies: {result['energy']}")
 print(f"Forces shape: {result['forces'].shape}")
 ```
 
-!!! warning "mol_idx must be sorted in non-decreasing order" The `mol_idx` tensor **must** be sorted: all atoms for molecule 0 come first, then all atoms for molecule 1, and so on. Values like `[0, 1, 0, 1]` will produce incorrect results. Always use `[0, 0, 1, 1]`.
+!!! warning "mol_idx must be sorted in non-decreasing order"
 
-!!! warning "charge shape must match number of molecules" When using `mol_idx`, the `charge` tensor must have shape `(num_molecules,)` with one charge value per molecule. A scalar charge only works for single-molecule calculations.
+    The `mol_idx` tensor **must** be sorted: all atoms for molecule 0 come first, then all atoms for molecule 1, and so on. Values like `[0, 1, 0, 1]` will produce incorrect results. Always use `[0, 0, 1, 1]`.
+
+!!! warning "charge shape must match number of molecules"
+
+    When using `mol_idx`, the `charge` tensor must have shape `(num_molecules,)` with one charge value per molecule. A scalar charge only works for single-molecule calculations.
 
 ## Step 2: Processing a Multi-Frame XYZ File
 
@@ -104,7 +108,9 @@ relative = energies - energies.min()
 print(f"Relative energies (eV): {relative}")
 ```
 
-!!! tip For conformers of the same molecule, the 3D batched format `(B, N, 3)` is more convenient than flat coordinates with `mol_idx`. The calculator automatically decides between dense mode (small molecules on GPU) and sparse mode (large molecules or CPU).
+!!! tip
+
+    For conformers of the same molecule, the 3D batched format `(B, N, 3)` is more convenient than flat coordinates with `mol_idx`. The calculator automatically decides between dense mode (small molecules on GPU) and sparse mode (large molecules or CPU).
 
 ### Different-Size Molecules (Flat Format with mol_idx)
 
@@ -181,7 +187,9 @@ forces = torch.cat(all_forces)
 print(f"Processed {len(energies)} structures")
 ```
 
-!!! tip "Memory management" Calling `.cpu()` on result tensors moves them off the GPU immediately. Combined with `torch.cuda.empty_cache()`, this prevents GPU memory from growing unboundedly across batches. This is especially important when processing thousands of structures.
+!!! tip "Memory management"
+
+    Calling `.cpu()` on result tensors moves them off the GPU immediately. Combined with `torch.cuda.empty_cache()`, this prevents GPU memory from growing unboundedly across batches. This is especially important when processing thousands of structures.
 
 ## Step 4: Worked Example -- Conformer Ranking
 

--- a/docs/tutorials/periodic_systems.md
+++ b/docs/tutorials/periodic_systems.md
@@ -55,7 +55,9 @@ calc = AIMNet2ASE("aimnet2")
 atoms.calc = calc
 ```
 
-!!! note When `pbc=True`, the calculator always uses **sparse mode** with neighbor lists, regardless of system size or `nb_threshold`. This ensures periodic images are handled correctly through cell shift vectors.
+!!! note
+
+    When `pbc=True`, the calculator always uses **sparse mode** with neighbor lists, regardless of system size or `nb_threshold`. This ensures periodic images are handled correctly through cell shift vectors.
 
 ## Step 2: Understanding the Coulomb Auto-Switch
 
@@ -68,7 +70,9 @@ energy = atoms.get_potential_energy()
 
 **Why does this happen?** The default Coulomb method is `"simple"` (all-pairs 1/r sum), which does not account for periodic images. For periodic systems, this would give incorrect electrostatics. The calculator detects PBC and automatically switches to the **Damped Shifted Force (DSF)** method, which properly handles the infinite lattice sum with a smooth cutoff.
 
-!!! warning The auto-switch warning appears once per calculator when PBC is first detected. To avoid the warning entirely, set the Coulomb method explicitly before your first periodic calculation (see Step 3).
+!!! warning
+
+    The auto-switch warning appears once per calculator when PBC is first detected. To avoid the warning entirely, set the Coulomb method explicitly before your first periodic calculation (see Step 3).
 
 ## Step 3: Choosing a Coulomb Method for PBC
 
@@ -98,7 +102,9 @@ calc.base_calc.set_lrcoulomb_method("ewald", ewald_accuracy=1e-8)
 energy = atoms.get_potential_energy()
 ```
 
-!!! warning Ewald summation is currently limited to **single-molecule (single-system) calculations**. It uses a full interaction matrix rather than neighbor lists, so it does not support batched periodic systems. For routine PBC work, use DSF.
+!!! warning
+
+    Ewald summation is currently limited to **single-molecule (single-system) calculations**. It uses a full interaction matrix rather than neighbor lists, so it does not support batched periodic systems. For routine PBC work, use DSF.
 
 **When to use Ewald:**
 
@@ -144,7 +150,9 @@ stress = atoms.get_stress()  # Voigt notation (6,) in ASE
 print(f"Stress (Voigt): {stress}")
 ```
 
-!!! tip ASE returns stress in Voigt notation as a 6-element array (xx, yy, zz, yz, xz, xy). The AIMNet2 calculator internally computes the full 3x3 stress tensor, and ASE handles the conversion.
+!!! tip
+
+    ASE returns stress in Voigt notation as a 6-element array (xx, yy, zz, yz, xz, xy). The AIMNet2 calculator internally computes the full 3x3 stress tensor, and ASE handles the conversion.
 
 ## Step 5: Cell Optimization
 
@@ -211,7 +219,9 @@ print(f"Cell lengths: {atoms.cell.lengths()}")
 print(f"Cell angles:  {atoms.cell.angles()}")
 ```
 
-!!! tip For reading crystal structures from CIF files, use `ase.io.read("structure.cif")`. ASE will parse the cell parameters and symmetry automatically.
+!!! tip
+
+    For reading crystal structures from CIF files, use `ase.io.read("structure.cif")`. ASE will parse the cell parameters and symmetry automatically.
 
 ## Summary of Coulomb Methods for PBC
 


### PR DESCRIPTION
## Summary

Wave 2 of post-audit follow-ups. Finishes the inline-admonition fix sweep that the original audit (PR #61) capped at 10 files.

Splits title and body across lines for the remaining ~19 admonition instances so they render as proper mkdocs-material `<div class="admonition">` blocks instead of literal `!!! warning ...` paragraphs:

- `docs/api/calculators.md` (2 quoted)
- `docs/tutorials/batch_processing.md` (3 quoted, 1 bareword)
- `docs/tutorials/periodic_systems.md` (5 bareword)
- `docs/models/guide.md` (1 quoted)
- `docs/advanced/conformer_search.md` (2 quoted)
- `docs/advanced/reaction_paths.md` (4 quoted)
- `docs/calculator.md` (1 quoted)

## Test plan

- [x] `grep -rn '^!!! [a-z]\+ ' docs/ ...` confirms zero inline-syntax admonitions remain (excluding `superpowers/plans/`).
- [x] `uv run mkdocs build -s` exits clean.
- [x] `make check` passes.
- [ ] CI: full Main matrix on this branch.