### PR TITLE
refactor: rename has_d3ts local vars to has_embedded_d3ts

### DIFF
--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -656,8 +656,8 @@ def load_v1_model(
         else:
             # Check if D3TS is embedded
             outputs = model_config.get("kwargs", {}).get("outputs", {})
-            has_d3ts = any("D3TS" in outputs.get(k, {}).get("class", "") for k in ["dftd3", "d3bj", "d3ts"])
-            if has_d3ts:
+            has_embedded_d3ts = any("D3TS" in outputs.get(k, {}).get("class", "") for k in ["dftd3", "d3bj", "d3ts"])
+            if has_embedded_d3ts:
                 print("  D3TS dispersion kept embedded (uses NN-predicted C6/alpha)")
 
     # Detect if model has any embedded LR modules that need nbmat_lr
@@ -665,8 +665,8 @@ def load_v1_model(
     has_embedded_lr = False
 
     # Check for embedded D3TS
-    has_d3ts = any("D3TS" in outputs.get(k, {}).get("class", "") for k in ["dftd3", "d3bj", "d3ts"])
-    if has_d3ts:
+    has_embedded_d3ts = any("D3TS" in outputs.get(k, {}).get("class", "") for k in ["dftd3", "d3bj", "d3ts"])
+    if has_embedded_d3ts:
         has_embedded_lr = True
 
     # Check for embedded SRCoulomb (model had LRCoulomb before conversion)


### PR DESCRIPTION
## Summary

Wave 3 of post-audit follow-ups — F6 only (per your decision to leave the `aimnet/train/utils.py` vestigial-code items alone).

Two local variables inside `load_v1_model` (`aimnet/models/utils.py:659,668`) shadowed the module-level `has_d3ts(model: nn.Module)` function. The locals examine the YAML config dict (different semantic surface than the function, which inspects an `nn.Module`), so renaming to `has_embedded_d3ts` makes the intent clearer and removes the shadow. No behavior change.

## Test plan

- [x] `make check` (ruff, deptry) — green
- [x] `pytest -k 'convert or export or load_model'` — 3 passed, 1 skipped (no regression)
- [ ] CI: full Main matrix