### PR TITLE
feat: aimnet2-rxn integration (registry + chemistry safeguards)

### DIFF
--- a/aimnet/calculators/aimnet2ase.py
+++ b/aimnet/calculators/aimnet2ase.py
@@ -21,11 +21,18 @@ class AIMNet2ASE(Calculator):
         "dipole_moment",
     ]
 
-    def __init__(self, base_calc: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1):
+    def __init__(
+        self,
+        base_calc: AIMNet2Calculator | str = "aimnet2",
+        charge=0,
+        mult=1,
+        validate_species: bool = True,
+    ):
         super().__init__()
         if isinstance(base_calc, str):
             base_calc = AIMNet2Calculator(base_calc)
         self.base_calc = base_calc
+        self.validate_species = validate_species
         if self.base_calc.is_nse:
             self.implemented_properties = [*self.__class__.implemented_properties, "spin_charges"]
         self.reset()
@@ -142,7 +149,12 @@ class AIMNet2ASE(Calculator):
                 _in[k] = v.unsqueeze(0)
             _unsqueezed = True
 
-        results = self.base_calc(_in, forces="forces" in properties, stress="stress" in properties)
+        results = self.base_calc(
+            _in,
+            forces="forces" in properties,
+            stress="stress" in properties,
+            validate_species=self.validate_species,
+        )
 
         for k, v in results.items():
             if _unsqueezed:

--- a/aimnet/calculators/aimnet2pysis.py
+++ b/aimnet/calculators/aimnet2pysis.py
@@ -18,8 +18,9 @@ EV2AU = 1 / AU2EV
 class AIMNet2Pysis(Calculator):
     implemented_properties: ClassVar = ["energy", "forces", "free_energy", "charges", "stress"]
 
-    def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1,
-                 validate_species: bool = True, **kwargs):
+    def __init__(
+        self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1, validate_species: bool = True, **kwargs
+    ):
         super().__init__(charge=charge, mult=mult, **kwargs)
         if isinstance(model, str):
             model = AIMNet2Calculator(model)

--- a/aimnet/calculators/aimnet2pysis.py
+++ b/aimnet/calculators/aimnet2pysis.py
@@ -18,11 +18,13 @@ EV2AU = 1 / AU2EV
 class AIMNet2Pysis(Calculator):
     implemented_properties: ClassVar = ["energy", "forces", "free_energy", "charges", "stress"]
 
-    def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1, **kwargs):
+    def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1,
+                 validate_species: bool = True, **kwargs):
         super().__init__(charge=charge, mult=mult, **kwargs)
         if isinstance(model, str):
             model = AIMNet2Calculator(model)
         self.model = model
+        self.validate_species = validate_species
 
     def _prepare_input(self, atoms, coord):
         device = self.model.device
@@ -51,20 +53,20 @@ class AIMNet2Pysis(Calculator):
 
     def get_energy(self, atoms, coords):
         _in = self._prepare_input(atoms, coords)
-        res = self.model(_in)
+        res = self.model(_in, validate_species=self.validate_species)
         energy = self._results_get_energy(res)
         return {"energy": energy}
 
     def get_forces(self, atoms, coords):
         _in = self._prepare_input(atoms, coords)
-        res = self.model(_in, forces=True)
+        res = self.model(_in, forces=True, validate_species=self.validate_species)
         energy = self._results_get_energy(res)
         forces = self._results_get_forces(res)
         return {"energy": energy, "forces": forces}
 
     def get_hessian(self, atoms, coords):
         _in = self._prepare_input(atoms, coords)
-        res = self.model(_in, forces=True, hessian=True)
+        res = self.model(_in, forces=True, hessian=True, validate_species=self.validate_species)
         energy = self._results_get_energy(res)
         forces = self._results_get_forces(res)
         hessian = self._results_get_hessian(res)

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -763,6 +763,15 @@ class AIMNet2Calculator:
                         f"For ions use `isayevlab/aimnet2-wb97m-d3`. "
                         f"Pass validate_species=False to bypass."
                     )
+        # Hessian + torch.compile is known to hang on the double-backward
+        # path through GELU activations. Fail fast instead.
+        if hessian and getattr(self, "_was_compiled", False):
+            raise RuntimeError(
+                "Hessian computation is incompatible with compile_model=True "
+                "(Dynamo + double-backward through GELU hangs). Reconstruct calculator "
+                "with compile_model=False."
+            )
+
         data = self.prepare_input(data)
 
         if hessian and "mol_idx" in data and data["mol_idx"][-1] > 0:

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -433,6 +433,10 @@ class AIMNet2Calculator:
         """If multiple distinct families have been constructed in this process,
         emit a one-time UserWarning about energy-scale incompatibility.
 
+        ``family=None`` is the no-op contract — calculators built from raw
+        ``nn.Module`` inputs or from .pt files that don't declare ``family``
+        in metadata pass ``None`` here and skip both tracking and warning.
+
         Bypass: set the AIMNET_QUIET_FAMILY_MIX environment variable to '1'.
         """
         if family is None:
@@ -800,11 +804,15 @@ class AIMNet2Calculator:
                     )
             meta = self.metadata or {}
             if meta.get("supports_charged_systems") is False:
-                charge_val = float(data.get("charge", 0.0))
-                if abs(charge_val) > 1e-6:
+                # torch.as_tensor handles scalars, lists, ndarrays, 0-d and N-d tensors
+                # uniformly so per-system charges in batched inputs (e.g. batched-NEB)
+                # don't raise the misleading "only one element tensors..." from float().
+                charge_t = torch.as_tensor(data.get("charge", 0.0))
+                if charge_t.numel() > 0 and float(charge_t.abs().max().item()) > 1e-6:
+                    bad = charge_t[charge_t.abs() > 1e-6].flatten().tolist()
                     raise ValueError(
                         f"This model does not support net-charged systems "
-                        f"(got charge={charge_val}). Net-neutral zwitterions are supported. "
+                        f"(got non-zero charge(s) {bad}). Net-neutral zwitterions are supported. "
                         f"For ions use `isayevlab/aimnet2-wb97m-d3`. "
                         f"Pass validate_species=False to bypass."
                     )

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -781,7 +781,9 @@ class AIMNet2Calculator:
         # Species validation — opt-out via validate_species=False.
         # Silent no-op for models that did not declare implemented_species (older .pt,
         # raw nn.Module).
-        if validate_species:
+        if validate_species and "numbers" in data:
+            # Guarded by "numbers" in data so prepare_input still owns the missing-key
+            # error path with its descriptive "Missing key numbers" message.
             impl = (self.metadata or {}).get("implemented_species") or []
             if impl:
                 # data["numbers"] may be a raw list, ndarray, or tensor — normalize first.

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -733,7 +733,25 @@ class AIMNet2Calculator:
             self.external_dftd3.set_smoothing(cutoff, smoothing_fraction)
         self._update_lr_nblists()
 
-    def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False) -> dict[str, Tensor]:
+    def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
+             *, validate_species: bool = True) -> dict[str, Tensor]:
+        # Species validation — opt-out via validate_species=False.
+        # Silent no-op for models that did not declare implemented_species (older .pt,
+        # raw nn.Module).
+        if validate_species:
+            impl = (self.metadata or {}).get("implemented_species") or []
+            if impl:
+                seen = {int(z) for z in data["numbers"].flatten().tolist() if int(z) > 0}
+                unsupported = sorted(seen - set(impl))
+                if unsupported:
+                    raise ValueError(
+                        f"Atomic numbers {unsupported} are not in this model's "
+                        f"implemented_species {sorted(impl)}. This model was trained on "
+                        f"a restricted element set; passing other elements yields undefined "
+                        f"output. For broader element coverage on equilibrium structures use "
+                        f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
+                        f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
+                    )
         data = self.prepare_input(data)
 
         if hessian and "mol_idx" in data and data["mol_idx"][-1] > 0:

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -752,6 +752,16 @@ class AIMNet2Calculator:
                         f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
                         f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
                     )
+            meta = self.metadata or {}
+            if meta.get("supports_charged_systems") is False:
+                charge_val = float(data.get("charge", 0.0))
+                if abs(charge_val) > 1e-6:
+                    raise ValueError(
+                        f"This model does not support net-charged systems "
+                        f"(got charge={charge_val}). Net-neutral zwitterions are supported. "
+                        f"For ions use `isayevlab/aimnet2-wb97m-d3`. "
+                        f"Pass validate_species=False to bypass."
+                    )
         data = self.prepare_input(data)
 
         if hessian and "mol_idx" in data and data["mol_idx"][-1] > 0:

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -780,8 +780,9 @@ class AIMNet2Calculator:
             self.external_dftd3.set_smoothing(cutoff, smoothing_fraction)
         self._update_lr_nblists()
 
-    def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
-             *, validate_species: bool = True) -> dict[str, Tensor]:
+    def eval(
+        self, data: dict[str, Any], forces=False, stress=False, hessian=False, *, validate_species: bool = True
+    ) -> dict[str, Tensor]:
         # Species validation — opt-out via validate_species=False.
         # Silent no-op for models that did not declare implemented_species (older .pt,
         # raw nn.Module).

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -286,6 +286,7 @@ class AIMNet2Calculator:
             raise TypeError("Invalid model type/name.")
 
         # Compile model if requested
+        self._was_compiled = bool(compile_model)
         if compile_model:
             kwargs = compile_kwargs or {}
             self.model = torch.compile(self.model, **kwargs)
@@ -415,6 +416,17 @@ class AIMNet2Calculator:
         return self.eval(*args, **kwargs)
 
     @property
+    def metadata(self) -> dict | None:
+        """Read-only view of the model's metadata dict.
+
+        Returns the same object as ``model._metadata`` for v2 .pt models,
+        or ``None`` for raw ``nn.Module`` inputs that don't carry metadata.
+        Downstream consumers should prefer this accessor over reaching into
+        the private ``model._metadata`` attribute.
+        """
+        return getattr(self.model, "_metadata", None)
+
+    @property
     def has_external_coulomb(self) -> bool:
         """Check if calculator has external Coulomb module attached.
 
@@ -487,7 +499,7 @@ class AIMNet2Calculator:
         bool
             True if model has embedded dispersion module (D3TS or legacy DFTD3).
         """
-        meta = getattr(self.model, "_metadata", None)
+        meta = self.metadata
         if meta is None:
             return False  # Unknown, assume no embedded dispersion
 
@@ -512,7 +524,7 @@ class AIMNet2Calculator:
         bool
             True if model has embedded Coulomb module.
         """
-        meta = getattr(self.model, "_metadata", None)
+        meta = self.metadata
         if meta is None:
             return False  # Unknown, assume no embedded Coulomb
         # If needs_coulomb=False and coulomb_mode is not "none", Coulomb is embedded

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -741,7 +741,8 @@ class AIMNet2Calculator:
         if validate_species:
             impl = (self.metadata or {}).get("implemented_species") or []
             if impl:
-                seen = {int(z) for z in data["numbers"].flatten().tolist() if int(z) > 0}
+                # data["numbers"] may be a raw list, ndarray, or tensor — normalize first.
+                seen = {int(z) for z in torch.as_tensor(data["numbers"]).flatten().tolist() if int(z) > 0}
                 unsupported = sorted(seen - set(impl))
                 if unsupported:
                     raise ValueError(

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -647,6 +647,21 @@ class AIMNet2Calculator:
         if method not in ("simple", "dsf", "ewald"):
             raise ValueError(f"Invalid method: {method}")
 
+        # rxn-family guard: the 4.6 A SR/LR cancellation point is physically
+        # frozen for this family. Changing the cutoff silently breaks matching.
+        meta = self.metadata or {}
+        if meta.get("family") == "rxn":
+            sr_rc = meta.get("coulomb_sr_rc")
+            if sr_rc is not None and method in ("dsf", "ewald") and abs(cutoff - float(sr_rc)) > 1e-6:
+                warnings.warn(
+                    f"Setting Coulomb {method} cutoff to {cutoff} A on aimnet2-rxn breaks "
+                    f"the SR/LR cancellation matching (this family was trained with a "
+                    f"physically frozen crossover at coulomb_sr_rc={sr_rc} A). Use the "
+                    f"matching cutoff or revert to the default external Coulomb.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         # Warn if model has embedded Coulomb (legacy models)
         if self._has_embedded_coulomb() and self.external_coulomb is None:
             warnings.warn(

--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -214,6 +214,7 @@ class AIMNet2Calculator:
     }
     keys_out: ClassVar[list[str]] = ["energy", "charges", "spin_charges", "forces", "hessian", "stress"]
     atom_feature_keys: ClassVar[list[str]] = ["coord", "numbers", "charges", "spin_charges", "forces"]
+    _constructed_families: ClassVar[set[str]] = set()
 
     def __init__(
         self,
@@ -412,6 +413,8 @@ class AIMNet2Calculator:
                 for param in self.external_dftd3.parameters():
                     param.requires_grad_(False)
 
+        self._maybe_warn_family_mix((metadata or {}).get("family") if metadata else None)
+
     def __call__(self, *args, **kwargs):
         return self.eval(*args, **kwargs)
 
@@ -425,6 +428,31 @@ class AIMNet2Calculator:
         the private ``model._metadata`` attribute.
         """
         return getattr(self.model, "_metadata", None)
+
+    def _maybe_warn_family_mix(self, family: str | None) -> None:
+        """If multiple distinct families have been constructed in this process,
+        emit a one-time UserWarning about energy-scale incompatibility.
+
+        Bypass: set the AIMNET_QUIET_FAMILY_MIX environment variable to '1'.
+        """
+        if family is None:
+            return
+        if os.environ.get("AIMNET_QUIET_FAMILY_MIX") == "1":
+            self._constructed_families.add(family)
+            return
+        already_warned = family in self._constructed_families
+        self._constructed_families.add(family)
+        if not already_warned and len(self._constructed_families) > 1:
+            warnings.warn(
+                f"AIMNet2Calculator instances from different families have been "
+                f"constructed in this process: {sorted(self._constructed_families)}. "
+                f"Energy scales differ across families (e.g. rxn uses a learned "
+                f"shifted-electronic scale; aimnet2-wb97m-d3 uses absolute "
+                f"electronic energies on the ~-1100 eV scale). Do not mix or compare "
+                f"energies across families. Set AIMNET_QUIET_FAMILY_MIX=1 to silence.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     @property
     def has_external_coulomb(self) -> bool:

--- a/aimnet/calculators/hf_hub.py
+++ b/aimnet/calculators/hf_hub.py
@@ -279,6 +279,8 @@ def load_from_hf_repo(
         "d3_params": _cfg("d3_params"),
         "has_embedded_lr": _cfg("has_embedded_lr", False),
         "implemented_species": _cfg("implemented_species", []),
+        "family": _cfg("family"),
+        "supports_charged_systems": _cfg("supports_charged_systems"),
     }
 
     model._metadata = metadata

--- a/aimnet/calculators/model_registry.yaml
+++ b/aimnet/calculators/model_registry.yaml
@@ -60,6 +60,18 @@ models:
     aimnet2-pd_3:
         file: aimnet2-pd_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2Pd/aimnet2-pd_3.pt
+    aimnet2_rxn_0:
+        file: aimnet2_rxn_0.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
+    aimnet2_rxn_1:
+        file: aimnet2_rxn_1.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt
+    aimnet2_rxn_2:
+        file: aimnet2_rxn_2.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt
+    aimnet2_rxn_3:
+        file: aimnet2_rxn_3.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt
 
 # map model alias to file name
 aliases:
@@ -69,3 +81,4 @@ aliases:
     aimnet2nse: aimnet2nse_0
     aimnet2pd: aimnet2-pd_0
     aimnet2_2025: aimnet2_b973c_2025_d3_0
+    aimnet2rxn: aimnet2_rxn_0

--- a/aimnet/models/aimnet2_rxn.yaml
+++ b/aimnet/models/aimnet2_rxn.yaml
@@ -1,0 +1,52 @@
+class: aimnet.models.AIMNet2
+kwargs:
+    nfeature: 16
+    d2features: true
+    ncomb_v: 12
+    hidden:
+        - [512, 380]
+        - [512, 380]
+        - [512, 380, 380]
+    aim_size: 256
+    num_charge_channels: 1
+    aev:
+        rc_s: 5.0
+        nshifts_s: 16
+    outputs:
+        energy_mlp:
+            class: aimnet.modules.Output
+            kwargs:
+                n_in: 256
+                n_out: 1
+                key_in: aim
+                key_out: energy
+                mlp:
+                    activation_fn: torch.nn.GELU
+                    last_linear: true
+                    hidden: [128, 128]
+        atomic_shift:
+            class: aimnet.modules.AtomicShift
+            kwargs:
+                key_in: energy
+                key_out: energy
+        atomic_sum:
+            class: aimnet.modules.AtomicSum
+            kwargs:
+                key_in: energy
+                key_out: energy
+        dipole:
+            class: aimnet.modules.Dipole
+            kwargs:
+                key_in: charges
+                key_out: dipole
+        quadrupole:
+            class: aimnet.modules.Quadrupole
+            kwargs:
+                key_in: charges
+                key_out: quadrupole
+        lrcoulomb:
+            class: aimnet.modules.LRCoulomb
+            kwargs:
+                rc: 4.6
+                key_in: charges
+                key_out: energy

--- a/aimnet/models/base.py
+++ b/aimnet/models/base.py
@@ -44,7 +44,7 @@ class ModelMetadata(TypedDict):
 
     implemented_species: list[int]  # Supported atomic numbers
 
-    family: NotRequired[str | None]                    # e.g. "rxn"; None for legacy/families that don't declare
+    family: NotRequired[str | None]  # e.g. "rxn"; None for legacy/families that don't declare
     supports_charged_systems: NotRequired[bool | None]  # False for rxn; None for legacy
 
 

--- a/aimnet/models/base.py
+++ b/aimnet/models/base.py
@@ -122,6 +122,8 @@ def load_model(path: str, device: str = "cpu") -> tuple[nn.Module, ModelMetadata
             "d3_params": data.get("d3_params"),
             "has_embedded_lr": data.get("has_embedded_lr", False),
             "implemented_species": data.get("implemented_species", []),
+            "family": data.get("family"),
+            "supports_charged_systems": data.get("supports_charged_systems"),
         }
 
         # Attach metadata to model for easy access

--- a/aimnet/models/base.py
+++ b/aimnet/models/base.py
@@ -44,6 +44,9 @@ class ModelMetadata(TypedDict):
 
     implemented_species: list[int]  # Supported atomic numbers
 
+    family: NotRequired[str | None]                    # e.g. "rxn"; None for legacy/families that don't declare
+    supports_charged_systems: NotRequired[bool | None]  # False for rxn; None for legacy
+
 
 def load_model(path: str, device: str = "cpu") -> tuple[nn.Module, ModelMetadata]:
     """Load model from file, supporting both new and legacy formats.

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -587,6 +587,24 @@ def load_v1_model(
         Path to the model YAML configuration file.
     output_path : str, optional
         If provided, save the converted model to this path.
+    implemented_species : list[int] | None, optional
+        If given, overrides the species list derived from `afv.weight` and ALSO
+        NaN-pads `afv.weight` rows for atomic numbers outside this set. Use this
+        for models (like aimnet2-rxn) where `afv.weight` is fully populated but
+        only a restricted element subset was actually trained. NaN padding makes
+        `validate_species=False` at inference time produce immediate
+        NaN-propagation rather than plausible-looking nonsense from
+        populated-but-untrained rows.
+    family : str | None, optional
+        Family tag (e.g. `"rxn"`) written into the metadata. Used by the
+        calculator to route family-specific safeguards (charge guard, Coulomb
+        cutoff lock, cross-family mixing detection). Omit for legacy families
+        that don't declare a family.
+    supports_charged_systems : bool | None, optional
+        If `False`, the calculator's `validate_species=True` path will raise
+        `ValueError` on non-zero charge inputs. Use for families trained only
+        on net-neutral systems (zwitterions remain in scope). Omit for
+        families with no charge restriction.
     verbose : bool
         Whether to print progress messages.
 
@@ -605,12 +623,29 @@ def load_v1_model(
         - coulomb_sr_envelope: str | None
         - d3_params: dict | None
         - implemented_species: list[int]
+        - family: str | None (only present if `family` kwarg was given)
+        - supports_charged_systems: bool | None (only present if kwarg was given)
 
-    Example
-    -------
+    Examples
+    --------
+    Convert a single legacy JIT model to the v2 .pt format:
+
     >>> from aimnet.models.utils import load_v1_model
     >>> model, metadata = load_v1_model("model.jpt", "config.yaml")
-    >>> print(metadata["format_version"])  # 2
+
+    Convert the four aimnet2-rxn ensemble members with explicit species,
+    family, and charge-support declarations (writes AFV-sanitized .pt files
+    with rows for elements outside [1, 6, 7, 8] NaN-padded):
+
+    >>> for i in range(4):
+    ...     load_v1_model(
+    ...         f"_tmp/model_{i+1}.jpt",
+    ...         "aimnet/models/aimnet2_rxn.yaml",
+    ...         output_path=f"aimnet2_rxn_{i}.pt",
+    ...         implemented_species=[1, 6, 7, 8],
+    ...         family="rxn",
+    ...         supports_charged_systems=False,
+    ...     )
 
     Warnings
     --------

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -569,6 +569,10 @@ def load_v1_model(
     jpt_path: str,
     yaml_config_path: str,
     output_path: str | None = None,
+    *,
+    implemented_species: list[int] | None = None,
+    family: str | None = None,
+    supports_charged_systems: bool | None = None,
     verbose: bool = True,
 ) -> tuple[nn.Module, dict]:
     """Load legacy JIT model (v1) and convert to v2 format.
@@ -631,7 +635,11 @@ def load_v1_model(
 
     # Extract metadata from JIT
     cutoff = float(jit_model.cutoff)
-    implemented_species = extract_species(jit_model)
+    _species_kwarg = implemented_species  # rename to avoid shadowing the metadata field below
+    if _species_kwarg is not None:
+        implemented_species_list = sorted(set(_species_kwarg))
+    else:
+        implemented_species_list = extract_species(jit_model)
 
     # Strip LR modules from YAML and add SRCoulomb
     # Note: disp_ptfile is unused here because JIT model already has disp_param0 in its state dict
@@ -718,8 +726,23 @@ def load_v1_model(
         "coulomb_sr_envelope": coulomb_sr_envelope if needs_coulomb else None,
         "d3_params": d3_params if needs_dispersion else None,
         "has_embedded_lr": has_embedded_lr,
-        "implemented_species": implemented_species,
+        "implemented_species": implemented_species_list,
     }
+    if family is not None:
+        metadata["family"] = family
+    if supports_charged_systems is not None:
+        metadata["supports_charged_systems"] = bool(supports_charged_systems)
+
+    # AFV row sanitization: when the caller declares the supported species
+    # explicitly, NaN-pad rows for elements outside that set so
+    # validate_species=False at inference time produces NaN-propagation
+    # instead of plausible-looking garbage from populated-but-untrained rows.
+    if _species_kwarg is not None:
+        species_set = set(implemented_species_list)
+        afv = core_model.afv.weight.data
+        for z in range(1, afv.shape[0]):
+            if z not in species_set:
+                afv[z] = float("nan")
 
     # Save if output path provided
     if output_path is not None:

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -773,11 +773,15 @@ def load_v1_model(
     # validate_species=False at inference time produces NaN-propagation
     # instead of plausible-looking garbage from populated-but-untrained rows.
     if _species_kwarg is not None:
-        species_set = set(implemented_species_list)
         afv = core_model.afv.weight.data
-        for z in range(1, afv.shape[0]):
-            if z not in species_set:
-                afv[z] = float("nan")
+        # Build a row-mask: True for rows to NaN (everything except row 0 placeholder
+        # and the supported species rows).
+        mask = torch.ones(afv.shape[0], dtype=torch.bool, device=afv.device)
+        mask[0] = False
+        for z in implemented_species_list:
+            if 0 <= z < afv.shape[0]:
+                mask[z] = False
+        afv[mask] = float("nan")
 
     # Save if output path provided
     if output_path is not None:

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -689,6 +689,15 @@ def load_v1_model(
         print("Building model from YAML config...")
     core_model = build_module(copy.deepcopy(core_config))
 
+    # Cast atomic_shift to float64 BEFORE load_state_dict so the destination
+    # buffer can hold full precision when load_state_dict's internal copy_ runs.
+    # Order matters: doing this after load_state_dict + a redundant copy_ from
+    # the still-float32 source is the bug this fixes.
+    if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
+        core_model.outputs.atomic_shift.double()
+        if verbose:
+            print("  Atomic shift cast to float64 before load_state_dict")
+
     # Load weights from JIT model
     jit_sd = jit_model.state_dict()
     load_result = core_model.load_state_dict(jit_sd, strict=False)
@@ -701,15 +710,6 @@ def load_v1_model(
         print(f"WARNING: Unexpected extra keys: {real_unexpected}")
     if not real_missing and not real_unexpected and verbose:
         print("Loaded weights successfully")
-
-    # Convert atomic_shift to float64 to preserve SAE precision
-    if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
-        core_model.outputs.atomic_shift.double()
-        atomic_shift_key = "outputs.atomic_shift.shifts.weight"
-        if atomic_shift_key in jit_sd:
-            core_model.outputs.atomic_shift.shifts.weight.data.copy_(jit_sd[atomic_shift_key])
-            if verbose:
-                print("  Atomic shift converted to float64")
 
     core_model.eval()
 

--- a/docs/models/aimnet2_rxn.md
+++ b/docs/models/aimnet2_rxn.md
@@ -1,0 +1,40 @@
+# AIMNet2-rxn
+
+A neural network interatomic potential specialized for **closed-shell organic reactions** (H, C, N, O), trained on ~4.7M reaction-relevant geometries at ωB97M-V/def2-TZVPP. Use for transition-state searches, NEB / batched-NEB, IRC profiles, and reaction-coordinate energy work.
+
+## Loading
+
+```python
+from aimnet.calculators import AIMNet2Calculator
+
+# From the GCS-backed registry (alias):
+calc = AIMNet2Calculator("aimnet2rxn", ensemble_member=0)
+
+# From Hugging Face Hub:
+calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0)
+```
+
+Both paths produce equivalent calculators. The HF path requires `pip install "aimnet[hf]"`.
+
+## Calculator-enforced safeguards (this family)
+
+The calculator applies the following checks automatically when `validate_species=True` (the default). Each can be bypassed with `validate_species=False`:
+
+- **Element scope**: input atomic numbers must be a subset of `[1, 6, 7, 8]`. Other elements raise `ValueError` with pointers to alternative families.
+- **Net charge**: only net-neutral systems (zwitterions OK). Non-zero `charge` raises `ValueError` pointing at `aimnet2-wb97m-d3` for ions.
+- **AFV row sanitization**: at conversion time, atomic-feature-vector rows for elements outside `[1, 6, 7, 8]` are NaN-padded so `validate_species=False` produces NaN-propagation rather than plausible-looking nonsense.
+
+Two further safeguards fire regardless of `validate_species`:
+
+- **Hessian + `torch.compile`**: setting both raises `RuntimeError` (Dynamo + double-backward through GELU is known to hang). Reconstruct with `compile_model=False` for TS / IRC / vibrational work.
+- **Coulomb cutoff lock**: calling `set_lrcoulomb_method(method, cutoff=…)` with a cutoff different from the model's `coulomb_sr_rc` (4.6 Å) emits a `UserWarning` because the SR/LR cancellation point was physically frozen during training.
+
+A separate one-time `UserWarning` fires if the same Python process constructs calculators from two different AIMNet2 families (rxn vs. wb97m-d3 etc.), because the energy scales are not comparable.
+
+## Canonical model card
+
+Full content (energy convention, training data details, full limitations list, citation) lives at the Hugging Face model card:
+
+[https://huggingface.co/isayevlab/aimnet2-rxn](https://huggingface.co/isayevlab/aimnet2-rxn)
+
+The HF README is the canonical source — this page summarizes only the integration mechanics.

--- a/docs/superpowers/plans/2026-04-25-aimnet2-rxn-integration.md
+++ b/docs/superpowers/plans/2026-04-25-aimnet2-rxn-integration.md
@@ -38,27 +38,28 @@
 
 - [ ] **Step 1: Confirm clean working tree on `main`**
 
-Run: `git -C /home/olexandr/aimnetcentral status`
-Expected: `nothing to commit, working tree clean` (the spec commits should already be on main).
+Run: `git -C /home/olexandr/aimnetcentral status` Expected: `nothing to commit, working tree clean` (the spec commits should already be on main).
 
 - [ ] **Step 2: Create and switch to a feature branch**
 
 Run:
+
 ```bash
 git -C /home/olexandr/aimnetcentral switch -c feat/aimnet2-rxn-integration
 ```
+
 Expected: `Switched to a new branch 'feat/aimnet2-rxn-integration'`.
 
 - [ ] **Step 3: Verify the branch**
 
-Run: `git -C /home/olexandr/aimnetcentral branch --show-current`
-Expected: `feat/aimnet2-rxn-integration`.
+Run: `git -C /home/olexandr/aimnetcentral branch --show-current` Expected: `feat/aimnet2-rxn-integration`.
 
 ---
 
 ## Task 1: Extend `ModelMetadata` TypedDict
 
 **Files:**
+
 - Modify: `aimnet/models/base.py:20-45` (TypedDict)
 - Test: `tests/test_model.py` (append a new test function)
 
@@ -81,8 +82,7 @@ def test_model_metadata_typeddict_includes_family_and_charge_fields():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v`
-Expected: FAIL with `AssertionError: ModelMetadata missing 'family' field`.
+Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v` Expected: FAIL with `AssertionError: ModelMetadata missing 'family' field`.
 
 - [ ] **Step 3: Add the new fields to `ModelMetadata`**
 
@@ -97,8 +97,7 @@ Verify `NotRequired` is already imported at the top of `base.py` (it is — used
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v`
-Expected: PASS.
+Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -112,6 +111,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(models): add family and supp
 ## Task 2: Propagate new metadata fields in `load_model`
 
 **Files:**
+
 - Modify: `aimnet/models/base.py:111-122` (the v2-format metadata construction inside `load_model`)
 - Test: `tests/test_model.py` (append)
 
@@ -142,8 +142,7 @@ def test_load_model_propagates_family_and_charge_fields(tmp_path):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v`
-Expected: FAIL — `metadata.get("family")` returns `None` because `load_model` does not yet propagate the field.
+Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v` Expected: FAIL — `metadata.get("family")` returns `None` because `load_model` does not yet propagate the field.
 
 - [ ] **Step 3: Update the `load_model` v2 branch**
 
@@ -175,8 +174,7 @@ The full block now looks like:
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v`
-Expected: PASS.
+Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -190,6 +188,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(models): propagate family/su
 ## Task 3: Propagate new metadata fields in `load_from_hf_repo`
 
 **Files:**
+
 - Modify: `aimnet/calculators/hf_hub.py:270-282` (metadata construction in `load_from_hf_repo`)
 - Test: `tests/test_hf_hub.py` (append)
 
@@ -242,8 +241,7 @@ def test_load_from_hf_repo_propagates_family_and_charge_fields(fake_hf_repo_with
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v`
-Expected: FAIL — `metadata.get("family")` returns `None`.
+Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v` Expected: FAIL — `metadata.get("family")` returns `None`.
 
 - [ ] **Step 3: Update the metadata construction in `hf_hub.py`**
 
@@ -275,8 +273,7 @@ The full block now reads:
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v`
-Expected: PASS.
+Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -290,6 +287,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(hf_hub): propagate family/su
 ## Task 4: Extend `load_v1_model` with override kwargs + AFV sanitization
 
 **Files:**
+
 - Modify: `aimnet/models/utils.py:568-735` (`load_v1_model` function)
 - Test: `tests/test_model.py` (append)
 
@@ -366,14 +364,14 @@ def test_load_v1_model_without_overrides_is_backward_compatible():
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v`
-Expected: FAIL on the override test (`unexpected keyword argument 'implemented_species'`); the backward-compat test should pass already.
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v` Expected: FAIL on the override test (`unexpected keyword argument 'implemented_species'`); the backward-compat test should pass already.
 
 - [ ] **Step 3: Add the new kwargs and AFV sanitization**
 
 Edit `aimnet/models/utils.py`. Locate the `load_v1_model` signature at line ~568:
 
 Replace:
+
 ```python
 def load_v1_model(
     jpt_path: str,
@@ -384,6 +382,7 @@ def load_v1_model(
 ```
 
 With:
+
 ```python
 def load_v1_model(
     jpt_path: str,
@@ -400,12 +399,14 @@ def load_v1_model(
 Then locate the species extraction (around line 634):
 
 Replace:
+
 ```python
     cutoff = float(jit_model.cutoff)
     implemented_species = extract_species(jit_model)
 ```
 
 With:
+
 ```python
     cutoff = float(jit_model.cutoff)
     _species_kwarg = implemented_species  # rename to avoid shadowing the metadata field below
@@ -418,6 +419,7 @@ With:
 Then locate the metadata construction near the end of the function (around line 710):
 
 Replace:
+
 ```python
     metadata = {
         "format_version": 2,
@@ -435,6 +437,7 @@ Replace:
 ```
 
 With:
+
 ```python
     metadata = {
         "format_version": 2,
@@ -468,8 +471,7 @@ With:
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v`
-Expected: PASS for both (or `SKIPPED` if `_tmp/` is not present — that's acceptable).
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v` Expected: PASS for both (or `SKIPPED` if `_tmp/` is not present — that's acceptable).
 
 - [ ] **Step 5: Commit**
 
@@ -483,19 +485,20 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(models): add implemented_spe
 ## Task 5: Reorder `.double()` in `load_v1_model`
 
 **Files:**
+
 - Modify: `aimnet/models/utils.py:697-704` (the atomic_shift block inside `load_v1_model`)
 - Test: covered by `test_load_v1_model_species_override_nan_pads_other_rows` (Task 4)
 
 - [ ] **Step 1: Verify the test from Task 4 still asserts float64**
 
-Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v`
-Expected: PASS (the existing pre-fix code happens to leave atomic_shift as float64 because it calls `.double()` after `load_state_dict`).
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v` Expected: PASS (the existing pre-fix code happens to leave atomic_shift as float64 because it calls `.double()` after `load_state_dict`).
 
 - [ ] **Step 2: Reorder `.double()` to run BEFORE `load_state_dict`**
 
 Edit `aimnet/models/utils.py`. Locate the section around line 686-704 inside `load_v1_model`:
 
 Replace:
+
 ```python
     # Load weights from JIT model
     jit_sd = jit_model.state_dict()
@@ -521,6 +524,7 @@ Replace:
 ```
 
 With:
+
 ```python
     # Cast atomic_shift to float64 BEFORE load_state_dict so the destination
     # buffer can hold full precision when load_state_dict's internal copy_ runs.
@@ -547,13 +551,11 @@ With:
 
 - [ ] **Step 3: Run the regression test**
 
-Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v`
-Expected: PASS — atomic_shift dtype is still float64; numerical behavior is byte-identical for current JIT models (atomic_shift in source is float32).
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v` Expected: PASS — atomic_shift dtype is still float64; numerical behavior is byte-identical for current JIT models (atomic_shift in source is float32).
 
 - [ ] **Step 4: Run the full test_model.py to catch any unrelated regressions**
 
-Run: `pytest tests/test_model.py -v`
-Expected: All tests PASS or `SKIPPED` (no FAIL).
+Run: `pytest tests/test_model.py -v` Expected: All tests PASS or `SKIPPED` (no FAIL).
 
 - [ ] **Step 5: Commit**
 
@@ -567,6 +569,7 @@ git -C /home/olexandr/aimnetcentral commit -m "fix(models): cast atomic_shift to
 ## Task 6: Add docstring example to `load_v1_model`
 
 **Files:**
+
 - Modify: `aimnet/models/utils.py` (the docstring of `load_v1_model`)
 
 - [ ] **Step 1: Locate the docstring**
@@ -603,8 +606,7 @@ Just before the existing `Warnings` section in the docstring, insert:
 
 - [ ] **Step 3: Verify the docstring renders without raising**
 
-Run: `python -c "from aimnet.models.utils import load_v1_model; help(load_v1_model)"`
-Expected: docstring prints with no exception; `Examples` section visible.
+Run: `python -c "from aimnet.models.utils import load_v1_model; help(load_v1_model)"` Expected: docstring prints with no exception; `Examples` section visible.
 
 - [ ] **Step 4: Commit**
 
@@ -618,6 +620,7 @@ git -C /home/olexandr/aimnetcentral commit -m "docs(models): add aimnet2-rxn con
 ## Task 7: Add architecture YAML for aimnet2-rxn
 
 **Files:**
+
 - Create: `aimnet/models/aimnet2_rxn.yaml`
 - Test: `tests/test_model.py` (append)
 
@@ -649,8 +652,7 @@ def test_aimnet2_rxn_yaml_builds():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v`
-Expected: FAIL — `aimnet2_rxn.yaml` does not exist yet.
+Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v` Expected: FAIL — `aimnet2_rxn.yaml` does not exist yet.
 
 - [ ] **Step 3: Create the YAML**
 
@@ -659,62 +661,61 @@ Create `aimnet/models/aimnet2_rxn.yaml` with this exact content (this is the sam
 ```yaml
 class: aimnet.models.AIMNet2
 kwargs:
-    nfeature: 16
-    d2features: true
-    ncomb_v: 12
-    hidden:
-        - [512, 380]
-        - [512, 380]
-        - [512, 380, 380]
-    aim_size: 256
-    num_charge_channels: 1
-    aev:
-        rc_s: 5.0
-        nshifts_s: 16
-    outputs:
-        energy_mlp:
-            class: aimnet.modules.Output
-            kwargs:
-                n_in: 256
-                n_out: 1
-                key_in: aim
-                key_out: energy
-                mlp:
-                    activation_fn: torch.nn.GELU
-                    last_linear: true
-                    hidden: [128, 128]
-        atomic_shift:
-            class: aimnet.modules.AtomicShift
-            kwargs:
-                key_in: energy
-                key_out: energy
-        atomic_sum:
-            class: aimnet.modules.AtomicSum
-            kwargs:
-                key_in: energy
-                key_out: energy
-        dipole:
-            class: aimnet.modules.Dipole
-            kwargs:
-                key_in: charges
-                key_out: dipole
-        quadrupole:
-            class: aimnet.modules.Quadrupole
-            kwargs:
-                key_in: charges
-                key_out: quadrupole
-        lrcoulomb:
-            class: aimnet.modules.LRCoulomb
-            kwargs:
-                rc: 4.6
-                key_in: charges
-                key_out: energy
+  nfeature: 16
+  d2features: true
+  ncomb_v: 12
+  hidden:
+    - [512, 380]
+    - [512, 380]
+    - [512, 380, 380]
+  aim_size: 256
+  num_charge_channels: 1
+  aev:
+    rc_s: 5.0
+    nshifts_s: 16
+  outputs:
+    energy_mlp:
+      class: aimnet.modules.Output
+      kwargs:
+        n_in: 256
+        n_out: 1
+        key_in: aim
+        key_out: energy
+        mlp:
+          activation_fn: torch.nn.GELU
+          last_linear: true
+          hidden: [128, 128]
+    atomic_shift:
+      class: aimnet.modules.AtomicShift
+      kwargs:
+        key_in: energy
+        key_out: energy
+    atomic_sum:
+      class: aimnet.modules.AtomicSum
+      kwargs:
+        key_in: energy
+        key_out: energy
+    dipole:
+      class: aimnet.modules.Dipole
+      kwargs:
+        key_in: charges
+        key_out: dipole
+    quadrupole:
+      class: aimnet.modules.Quadrupole
+      kwargs:
+        key_in: charges
+        key_out: quadrupole
+    lrcoulomb:
+      class: aimnet.modules.LRCoulomb
+      kwargs:
+        rc: 4.6
+        key_in: charges
+        key_out: energy
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v`
-Expected: PASS.
+Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -728,6 +729,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(models): add aimnet2_rxn.yam
 ## Task 8: Add registry entries for aimnet2-rxn
 
 **Files:**
+
 - Modify: `aimnet/calculators/model_registry.yaml` (append entries + alias)
 - Test: `tests/test_model_registry.py` (append)
 
@@ -758,38 +760,36 @@ def test_aimnet2rxn_registry_entries_and_alias():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v`
-Expected: FAIL — `KeyError` or `assertion` because the entries don't exist.
+Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v` Expected: FAIL — `KeyError` or `assertion` because the entries don't exist.
 
 - [ ] **Step 3: Add the entries to `model_registry.yaml`**
 
 Edit `aimnet/calculators/model_registry.yaml`. Locate the last `aimnet2-pd_3:` entry (around line 60-62). Add immediately after it (before the `# map model alias` comment):
 
 ```yaml
-    aimnet2_rxn_0:
-        file: aimnet2_rxn_0.pt
-        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
-    aimnet2_rxn_1:
-        file: aimnet2_rxn_1.pt
-        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt
-    aimnet2_rxn_2:
-        file: aimnet2_rxn_2.pt
-        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt
-    aimnet2_rxn_3:
-        file: aimnet2_rxn_3.pt
-        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt
+aimnet2_rxn_0:
+  file: aimnet2_rxn_0.pt
+  url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
+aimnet2_rxn_1:
+  file: aimnet2_rxn_1.pt
+  url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt
+aimnet2_rxn_2:
+  file: aimnet2_rxn_2.pt
+  url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt
+aimnet2_rxn_3:
+  file: aimnet2_rxn_3.pt
+  url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt
 ```
 
 In the `aliases:` section at the end, add the alias right after `aimnet2_2025: aimnet2_b973c_2025_d3_0`:
 
 ```yaml
-    aimnet2rxn: aimnet2_rxn_0
+aimnet2rxn: aimnet2_rxn_0
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v`
-Expected: PASS.
+Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -803,6 +803,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(registry): register aimnet2-
 ## Task 9: Add `metadata` property and `_was_compiled` flag to `AIMNet2Calculator`
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py` (`__init__` + new property)
 - Test: `tests/test_calculator.py` (append)
 
@@ -831,14 +832,14 @@ def test_calculator_was_compiled_flag_default_false():
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v`
-Expected: FAIL — `metadata` does not exist as a property; `_was_compiled` not set.
+Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v` Expected: FAIL — `metadata` does not exist as a property; `_was_compiled` not set.
 
 - [ ] **Step 3: Add the `_was_compiled` flag in `__init__`**
 
 Edit `aimnet/calculators/calculator.py`. Locate the constructor block around line 286-291 where `compile_model` is handled:
 
 Replace:
+
 ```python
         # Compile model if requested
         if compile_model:
@@ -847,6 +848,7 @@ Replace:
 ```
 
 With:
+
 ```python
         # Compile model if requested
         self._was_compiled = bool(compile_model)
@@ -884,13 +886,11 @@ At around line 515, replace `meta = getattr(self.model, "_metadata", None)` with
 
 - [ ] **Step 6: Run tests to verify they pass**
 
-Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v` Expected: PASS.
 
 - [ ] **Step 7: Run the full calculator test suite to catch regressions**
 
-Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"`
-Expected: All non-skipped tests PASS.
+Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"` Expected: All non-skipped tests PASS.
 
 - [ ] **Step 8: Commit**
 
@@ -904,6 +904,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add metadata pr
 ## Task 10: Add species-validation guard in `eval`
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py:724` (`eval` method signature + new validation block at top)
 - Test: `tests/test_calculator.py` (append)
 
@@ -950,14 +951,14 @@ def test_calculator_validate_species_false_bypasses():
 
 - [ ] **Step 2: Run tests to verify the first fails**
 
-Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v`
-Expected: FIRST test FAILs (calculator silently produces output for U); the bypass test may FAIL with "got unexpected keyword argument 'validate_species'".
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v` Expected: FIRST test FAILs (calculator silently produces output for U); the bypass test may FAIL with "got unexpected keyword argument 'validate_species'".
 
 - [ ] **Step 3: Add `validate_species` to the `eval` signature**
 
 Edit `aimnet/calculators/calculator.py`. Locate `def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False)` at line 724.
 
 Replace with:
+
 ```python
     def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
              *, validate_species: bool = True) -> dict[str, Tensor]:
@@ -989,8 +990,7 @@ Immediately after the new signature line and BEFORE the existing `data = self.pr
 
 - [ ] **Step 5: Run tests to verify they pass**
 
-Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v` Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -1004,6 +1004,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add validate_sp
 ## Task 11: Add charge-guard for `supports_charged_systems: false` models
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py` (`eval` — append a second guard inside the `if validate_species` block)
 - Test: `tests/test_calculator.py` (append)
 
@@ -1038,8 +1039,7 @@ def test_calculator_rejects_charged_input_when_unsupported(monkeypatch):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v`
-Expected: FAIL — no charge guard yet.
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v` Expected: FAIL — no charge guard yet.
 
 - [ ] **Step 3: Add the charge guard inside `eval`**
 
@@ -1062,8 +1062,7 @@ Edit `aimnet/calculators/calculator.py`. Locate the species-validation block add
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -1077,6 +1076,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add charge guar
 ## Task 12: Add `hessian + compile_model` guard
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py` (`eval` — guard added after the validate_species block)
 - Test: `tests/test_calculator.py` (append)
 
@@ -1107,8 +1107,7 @@ def test_hessian_with_compile_raises():
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v`
-Expected: FAIL — no guard yet (test hangs OR proceeds to the hessian path).
+Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v` Expected: FAIL — no guard yet (test hangs OR proceeds to the hessian path).
 
 - [ ] **Step 3: Add the guard in `eval`**
 
@@ -1127,8 +1126,7 @@ Edit `aimnet/calculators/calculator.py`. The Task-11 charge-guard block ends ins
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -1142,6 +1140,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): raise RuntimeEr
 ## Task 13: Add `set_lrcoulomb_method` rxn-family cutoff guard
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py:601-670` (`set_lrcoulomb_method`)
 - Test: `tests/test_calculator.py` (append)
 
@@ -1184,8 +1183,7 @@ def test_set_lrcoulomb_method_no_warn_on_matching_cutoff():
 
 - [ ] **Step 2: Run tests to verify the first fails**
 
-Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v`
-Expected: First test FAILs (no warning raised); second test PASSes already (no warning is the current behavior).
+Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v` Expected: First test FAILs (no warning raised); second test PASSes already (no warning is the current behavior).
 
 - [ ] **Step 3: Add the rxn guard at the top of `set_lrcoulomb_method`**
 
@@ -1210,8 +1208,7 @@ Edit `aimnet/calculators/calculator.py`. Locate `def set_lrcoulomb_method(...)` 
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -1225,6 +1222,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): warn on set_lrc
 ## Task 14: Add cross-family mixing detection
 
 **Files:**
+
 - Modify: `aimnet/calculators/calculator.py` (add ClassVar + record-and-warn at end of `__init__`)
 - Test: `tests/test_calculator.py` (append)
 
@@ -1266,8 +1264,7 @@ def test_constructing_two_families_warns_once(monkeypatch):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v`
-Expected: FAIL — `_constructed_families` and `_maybe_warn_family_mix` do not exist.
+Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v` Expected: FAIL — `_constructed_families` and `_maybe_warn_family_mix` do not exist.
 
 - [ ] **Step 3: Add the ClassVar and helper, and call from `__init__`**
 
@@ -1317,13 +1314,11 @@ The right place is at the very end of `__init__` — find the last line of the c
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v`
-Expected: PASS.
+Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v` Expected: PASS.
 
 - [ ] **Step 5: Run the full test_calculator.py to catch regressions**
 
-Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"`
-Expected: All non-skipped tests PASS.
+Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"` Expected: All non-skipped tests PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -1337,6 +1332,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): warn once on cr
 ## Task 15: Propagate `validate_species` through `AIMNet2ASE`
 
 **Files:**
+
 - Modify: `aimnet/calculators/aimnet2ase.py:24-45` (`__init__`) and `aimnet2ase.py:121-145` (`calculate`)
 - Test: `tests/test_ase.py` (append)
 
@@ -1368,14 +1364,14 @@ def test_aimnet2ase_propagates_validate_species(monkeypatch):
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v`
-Expected: FAIL — `AIMNet2ASE.__init__` does not accept `validate_species`.
+Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v` Expected: FAIL — `AIMNet2ASE.__init__` does not accept `validate_species`.
 
 - [ ] **Step 3: Add `validate_species` to `AIMNet2ASE.__init__`**
 
 Edit `aimnet/calculators/aimnet2ase.py`. Locate `def __init__(self, base_calc: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1):` at line 24.
 
 Replace with:
+
 ```python
     def __init__(
         self,
@@ -1387,6 +1383,7 @@ Replace with:
 ```
 
 After the existing assignment of `base_calc` to `self.base_calc` (around line 27-28), add:
+
 ```python
         self.validate_species = validate_species
 ```
@@ -1396,6 +1393,7 @@ After the existing assignment of `base_calc` to `self.base_calc` (around line 27
 Locate the `results = self.base_calc(_in, forces="forces" in properties, stress="stress" in properties)` line (around line 145).
 
 Replace with:
+
 ```python
         results = self.base_calc(
             _in,
@@ -1407,8 +1405,7 @@ Replace with:
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v`
-Expected: PASS.
+Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v` Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -1422,6 +1419,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(ase): propagate validate_spe
 ## Task 16: Propagate `validate_species` through `AIMNet2Pysis`
 
 **Files:**
+
 - Modify: `aimnet/calculators/aimnet2pysis.py:21-65` (`__init__` + the call site that invokes `self.base_calc`)
 - Test: NOT added — pysisyphus is heavy and behind a marker; manual smoke is sufficient. Skip a test for this wrapper.
 
@@ -1436,12 +1434,14 @@ Read the printed lines to identify the single point where the wrapper invokes th
 Edit `aimnet/calculators/aimnet2pysis.py`. Locate `def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1, **kwargs):` at line 21.
 
 Replace with:
+
 ```python
     def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1,
                  validate_species: bool = True, **kwargs):
 ```
 
 Right after the existing model assignment block (look for `self.base_calc = model` or equivalent — around line 24-25), add:
+
 ```python
         self.validate_species = validate_species
 ```
@@ -1454,8 +1454,7 @@ For example, if the call looks like `results = self.base_calc(in_data, forces=Tr
 
 - [ ] **Step 4: Smoke-import the module to catch syntax errors**
 
-Run: `python -c "from aimnet.calculators.aimnet2pysis import AIMNet2Pysis; print('OK')"`
-Expected: `OK` (no exception).
+Run: `python -c "from aimnet.calculators.aimnet2pysis import AIMNet2Pysis; print('OK')"` Expected: `OK` (no exception).
 
 - [ ] **Step 5: Commit**
 
@@ -1469,6 +1468,7 @@ git -C /home/olexandr/aimnetcentral commit -m "feat(pysis): propagate validate_s
 ## Task 17: Alias end-to-end test for `aimnet2rxn`
 
 **Files:**
+
 - Test: `tests/test_calculator.py` (append)
 
 This test exercises Tasks 7 + 8 + 9 together: the alias resolves, the .pt downloads (or hits cache), the calculator constructs cleanly, and the metadata carries the rxn-specific fields. Network-gated because it needs the GCS object — only meaningful AFTER the maintainer has uploaded the re-converted .pt files.
@@ -1501,8 +1501,7 @@ def test_aimnet2rxn_alias_calculator_e2e():
 
 - [ ] **Step 2: Add `network` marker to `pyproject.toml` if not present**
 
-Check: `grep -n "network" /home/olexandr/aimnetcentral/pyproject.toml`
-If `"network: ..."` is not in the markers list, add to the `markers = [...]` block in `[tool.pytest.ini_options]`:
+Check: `grep -n "network" /home/olexandr/aimnetcentral/pyproject.toml` If `"network: ..."` is not in the markers list, add to the `markers = [...]` block in `[tool.pytest.ini_options]`:
 
 ```toml
     "network: marks tests that hit external services (deselect with: -m 'not network')",
@@ -1510,8 +1509,7 @@ If `"network: ..."` is not in the markers list, add to the `markers = [...]` blo
 
 - [ ] **Step 3: Run the test (will skip if GCS not yet populated)**
 
-Run: `pytest tests/test_calculator.py::test_aimnet2rxn_alias_calculator_e2e -v`
-Expected: SKIPPED with "GCS .pt for aimnet2rxn not yet uploaded" (acceptable for CI before maintainer uploads), or PASS if GCS objects already exist.
+Run: `pytest tests/test_calculator.py::test_aimnet2rxn_alias_calculator_e2e -v` Expected: SKIPPED with "GCS .pt for aimnet2rxn not yet uploaded" (acceptable for CI before maintainer uploads), or PASS if GCS objects already exist.
 
 - [ ] **Step 4: Commit**
 
@@ -1525,6 +1523,7 @@ git -C /home/olexandr/aimnetcentral commit -m "test(calculator): add aimnet2rxn 
 ## Task 18: HF end-to-end test for aimnet2-rxn
 
 **Files:**
+
 - Test: `tests/test_hf_hub.py` (append)
 
 - [ ] **Step 1: Write the test**
@@ -1562,8 +1561,7 @@ def test_aimnet2_rxn_hf_load_matches_gcs_metadata():
 
 - [ ] **Step 2: Run the test (network-gated, requires HF deps)**
 
-Run: `pytest tests/test_hf_hub.py::test_aimnet2_rxn_hf_load_matches_gcs_metadata -v -m hf`
-Expected: PASS if HF repo's `config.json` has been updated; otherwise FAIL with the explicit "maintainer must update HF repo" message — that failure is informative, not a real bug.
+Run: `pytest tests/test_hf_hub.py::test_aimnet2_rxn_hf_load_matches_gcs_metadata -v -m hf` Expected: PASS if HF repo's `config.json` has been updated; otherwise FAIL with the explicit "maintainer must update HF repo" message — that failure is informative, not a real bug.
 
 - [ ] **Step 3: Commit**
 
@@ -1577,6 +1575,7 @@ git -C /home/olexandr/aimnetcentral commit -m "test(hf_hub): add aimnet2-rxn HF 
 ## Task 19: Add docs page for aimnet2-rxn
 
 **Files:**
+
 - Create: `docs/models/aimnet2_rxn.md`
 - Modify: `mkdocs.yml` (add nav entry)
 
@@ -1584,7 +1583,7 @@ git -C /home/olexandr/aimnetcentral commit -m "test(hf_hub): add aimnet2-rxn HF 
 
 Create `docs/models/aimnet2_rxn.md` with this content:
 
-```markdown
+````markdown
 # AIMNet2-rxn
 
 A neural network interatomic potential specialized for **closed-shell organic reactions** (H, C, N, O), trained on ~4.7M reaction-relevant geometries at ωB97M-V/def2-TZVPP. Use for transition-state searches, NEB / batched-NEB, IRC profiles, and reaction-coordinate energy work.
@@ -1600,6 +1599,7 @@ calc = AIMNet2Calculator("aimnet2rxn", ensemble_member=0)
 # From Hugging Face Hub:
 calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0)
 ```
+````
 
 Both paths produce equivalent calculators. The HF path requires `pip install "aimnet[hf]"`.
 
@@ -1625,7 +1625,8 @@ Full content (energy convention, training data details, full limitations list, c
 [https://huggingface.co/isayevlab/aimnet2-rxn](https://huggingface.co/isayevlab/aimnet2-rxn)
 
 The HF README is the canonical source — this page summarizes only the integration mechanics.
-```
+
+````
 
 - [ ] **Step 2: Add the nav entry to `mkdocs.yml`**
 
@@ -1637,18 +1638,17 @@ Open `mkdocs.yml`. Locate the existing model entries (around lines 15-19):
           - AIMNet2-2025: models/aimnet2_2025.md
           - AIMNet2-NSE: models/aimnet2nse.md
           - AIMNet2-Pd: models/aimnet2pd.md
-```
+````
 
 Append immediately after the `AIMNet2-Pd` line, with the same indentation:
 
 ```yaml
-          - AIMNet2-rxn: models/aimnet2_rxn.md
+- AIMNet2-rxn: models/aimnet2_rxn.md
 ```
 
 - [ ] **Step 3: Verify mkdocs builds**
 
-Run: `mkdocs build --strict --site-dir /tmp/aimnet-mkdocs-test`
-Expected: build succeeds, no warnings, no broken links. The test directory `/tmp/aimnet-mkdocs-test` will contain the generated site; you can `rm -rf /tmp/aimnet-mkdocs-test` afterward.
+Run: `mkdocs build --strict --site-dir /tmp/aimnet-mkdocs-test` Expected: build succeeds, no warnings, no broken links. The test directory `/tmp/aimnet-mkdocs-test` will contain the generated site; you can `rm -rf /tmp/aimnet-mkdocs-test` afterward.
 
 - [ ] **Step 4: Commit**
 
@@ -1666,24 +1666,25 @@ git -C /home/olexandr/aimnetcentral commit -m "docs(models): add aimnet2-rxn pag
 - [ ] **Step 1: Run the entire affected test surface**
 
 Run:
+
 ```bash
 pytest tests/test_model.py tests/test_calculator.py tests/test_model_registry.py tests/test_hf_hub.py tests/test_ase.py -v -m "not gpu"
 ```
+
 Expected: All non-skipped tests PASS. Skipped tests are acceptable (`hf`, `network`, `pysis`, missing `_tmp/` data, missing GCS upload).
 
 - [ ] **Step 2: Run the full suite once to catch unrelated regressions**
 
-Run: `pytest -v -m "not gpu and not hf and not network and not pysis"`
-Expected: green or pre-existing-yellow only.
+Run: `pytest -v -m "not gpu and not hf and not network and not pysis"` Expected: green or pre-existing-yellow only.
 
 - [ ] **Step 3: Show the branch's commit graph**
 
-Run: `git -C /home/olexandr/aimnetcentral log main..HEAD --oneline`
-Expected: ~17-18 commits, each labeled with `feat(...)`, `fix(...)`, `test(...)`, or `docs(...)`. Verify no commit message contains "Claude", "Anthropic", or "Co-Authored-By".
+Run: `git -C /home/olexandr/aimnetcentral log main..HEAD --oneline` Expected: ~17-18 commits, each labeled with `feat(...)`, `fix(...)`, `test(...)`, or `docs(...)`. Verify no commit message contains "Claude", "Anthropic", or "Co-Authored-By".
 
 - [ ] **Step 4: Stop and surface the out-of-band tasks before any push/PR**
 
 The following must be done by the maintainer before the PR can be considered ready:
+
 1. Upload `_tmp/aimnet2_rxn_v2_gcs.zip`'s four `.pt` files to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/` (sha256s: see `_tmp/aimnet2_rxn_v2_gcs.zip`).
 2. Update the HF repo `isayevlab/aimnet2-rxn`'s `config.json` to add `"family": "rxn"` and `"supports_charged_systems": false`.
 

--- a/docs/superpowers/plans/2026-04-25-aimnet2-rxn-integration.md
+++ b/docs/superpowers/plans/2026-04-25-aimnet2-rxn-integration.md
@@ -1,0 +1,1714 @@
+# aimnet2-rxn Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the `aimnet2-rxn` model family in `aimnetcentral` (registry + architecture YAML + load path), wired up with the chemistry safeguards rxn requires (charge validation, AFV row sanitization, Coulomb-cutoff lock, cross-family mixing detection, Hessian + `torch.compile` guard) and three orthogonal cleanups surfaced during the integration (`load_v1_model` `.double()` ordering, calculator `metadata` property, ASE/Pysis `validate_species` propagation).
+
+**Architecture:** Two-layer change. **Bottom layer**: `aimnet/models/base.py::ModelMetadata` and the two metadata-construction sites (`base.py::load_model` and `hf_hub.py::load_from_hf_repo`) gain optional `family` and `supports_charged_systems` fields. `aimnet/models/utils.py::load_v1_model` gains keyword-only `implemented_species`, `family`, `supports_charged_systems` overrides plus AFV-row NaN-padding when species are declared. **Top layer**: `AIMNet2Calculator` reads the new metadata fields via a new `metadata` property and enforces the safeguards inside `eval` and `set_lrcoulomb_method`. Wrappers (`AIMNet2ASE`, `AIMNet2Pysis`) propagate `validate_species`. Registry and architecture YAML are pure additions.
+
+**Tech Stack:** Python 3.11+, PyTorch, pytest with `@pytest.mark.hf` marker (existing), YAML configs read via `yaml.safe_load`.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md`.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+| --- | --- | --- |
+| `aimnet/models/base.py` | Modify | Extend `ModelMetadata` TypedDict; propagate `family` + `supports_charged_systems` in `load_model`. |
+| `aimnet/calculators/hf_hub.py` | Modify | Propagate `family` + `supports_charged_systems` in `load_from_hf_repo`. |
+| `aimnet/models/utils.py` | Modify | Add `implemented_species`/`family`/`supports_charged_systems` kwargs to `load_v1_model`; AFV-row NaN-padding when species declared; reorder `.double()` before `load_state_dict`. Add docstring example. |
+| `aimnet/models/aimnet2_rxn.yaml` | Create | Architecture YAML for the rxn model family. |
+| `aimnet/calculators/model_registry.yaml` | Modify | 4 entries + 1 alias for aimnet2-rxn. |
+| `aimnet/calculators/calculator.py` | Modify | Add `metadata` property; `_was_compiled` flag; `_constructed_families` ClassVar; safeguards in `eval`; rxn-family warning in `set_lrcoulomb_method`. |
+| `aimnet/calculators/aimnet2ase.py` | Modify | Propagate `validate_species` kwarg through to base calculator. |
+| `aimnet/calculators/aimnet2pysis.py` | Modify | Propagate `validate_species` kwarg through to base calculator. |
+| `tests/test_model.py` | Modify | Add `test_load_v1_model_species_override_nan_pads_other_rows` (also covers `.double()` ordering). |
+| `tests/test_calculator.py` | Modify | Add 7 tests for safeguards + alias E2E + metadata property coverage. |
+| `tests/test_hf_hub.py` | Modify | Add `test_aimnet2_rxn_hf_load_matches_gcs_metadata` (network-gated). |
+| `docs/models/aimnet2_rxn.md` | Create | ≤30-line stub model card with canonical link to HF README. |
+| `mkdocs.yml` | Modify | One nav entry pointing at the new docs page. |
+
+---
+
+## Task 0: Preparation — feature branch
+
+**Files:** none (git only).
+
+- [ ] **Step 1: Confirm clean working tree on `main`**
+
+Run: `git -C /home/olexandr/aimnetcentral status`
+Expected: `nothing to commit, working tree clean` (the spec commits should already be on main).
+
+- [ ] **Step 2: Create and switch to a feature branch**
+
+Run:
+```bash
+git -C /home/olexandr/aimnetcentral switch -c feat/aimnet2-rxn-integration
+```
+Expected: `Switched to a new branch 'feat/aimnet2-rxn-integration'`.
+
+- [ ] **Step 3: Verify the branch**
+
+Run: `git -C /home/olexandr/aimnetcentral branch --show-current`
+Expected: `feat/aimnet2-rxn-integration`.
+
+---
+
+## Task 1: Extend `ModelMetadata` TypedDict
+
+**Files:**
+- Modify: `aimnet/models/base.py:20-45` (TypedDict)
+- Test: `tests/test_model.py` (append a new test function)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_model.py`:
+
+```python
+def test_model_metadata_typeddict_includes_family_and_charge_fields():
+    """ModelMetadata must declare family and supports_charged_systems as optional fields."""
+    from typing import get_type_hints
+    from aimnet.models.base import ModelMetadata
+
+    hints = get_type_hints(ModelMetadata, include_extras=False)
+    assert "family" in hints, "ModelMetadata missing 'family' field"
+    assert "supports_charged_systems" in hints, (
+        "ModelMetadata missing 'supports_charged_systems' field"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v`
+Expected: FAIL with `AssertionError: ModelMetadata missing 'family' field`.
+
+- [ ] **Step 3: Add the new fields to `ModelMetadata`**
+
+Edit `aimnet/models/base.py`. Locate the `class ModelMetadata(TypedDict):` block (around line 20). After the existing `implemented_species: list[int]  # Supported atomic numbers` line, add:
+
+```python
+    family: NotRequired[str | None]                       # e.g. "rxn"; None for legacy/families that don't declare
+    supports_charged_systems: NotRequired[bool | None]    # False for rxn; None for legacy
+```
+
+Verify `NotRequired` is already imported at the top of `base.py` (it is — used by other fields like `coulomb_sr_rc`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_model.py::test_model_metadata_typeddict_includes_family_and_charge_fields -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/base.py tests/test_model.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(models): add family and supports_charged_systems to ModelMetadata"
+```
+
+---
+
+## Task 2: Propagate new metadata fields in `load_model`
+
+**Files:**
+- Modify: `aimnet/models/base.py:111-122` (the v2-format metadata construction inside `load_model`)
+- Test: `tests/test_model.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_model.py`:
+
+```python
+def test_load_model_propagates_family_and_charge_fields(tmp_path):
+    """load_model must include family/supports_charged_systems in metadata when present in .pt."""
+    import torch
+    from aimnet.calculators.model_registry import get_model_path
+    from aimnet.models.base import load_model
+
+    # Take the existing aimnet2 .pt as a template; add the new fields; save; reload.
+    src = get_model_path("aimnet2")
+    raw = torch.load(src, map_location="cpu", weights_only=False)
+    raw["family"] = "test-family"
+    raw["supports_charged_systems"] = False
+
+    out = tmp_path / "with_family.pt"
+    torch.save(raw, str(out))
+
+    _, metadata = load_model(str(out), device="cpu")
+    assert metadata.get("family") == "test-family"
+    assert metadata.get("supports_charged_systems") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v`
+Expected: FAIL — `metadata.get("family")` returns `None` because `load_model` does not yet propagate the field.
+
+- [ ] **Step 3: Update the `load_model` v2 branch**
+
+Edit `aimnet/models/base.py`. Locate the v2-format `metadata: ModelMetadata = { ... }` block (around line 111). Add two lines just before the closing brace, immediately after `"implemented_species": data.get("implemented_species", []),`:
+
+```python
+            "family": data.get("family"),
+            "supports_charged_systems": data.get("supports_charged_systems"),
+```
+
+The full block now looks like:
+
+```python
+        metadata: ModelMetadata = {
+            "format_version": data.get("format_version", 2),
+            "cutoff": data["cutoff"],
+            "needs_coulomb": data.get("needs_coulomb", False),
+            "needs_dispersion": data.get("needs_dispersion", False),
+            "coulomb_mode": data.get("coulomb_mode", "none"),
+            "coulomb_sr_rc": data.get("coulomb_sr_rc"),
+            "coulomb_sr_envelope": data.get("coulomb_sr_envelope"),
+            "d3_params": data.get("d3_params"),
+            "has_embedded_lr": data.get("has_embedded_lr", False),
+            "implemented_species": data.get("implemented_species", []),
+            "family": data.get("family"),
+            "supports_charged_systems": data.get("supports_charged_systems"),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_model.py::test_load_model_propagates_family_and_charge_fields -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/base.py tests/test_model.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(models): propagate family/supports_charged_systems in load_model"
+```
+
+---
+
+## Task 3: Propagate new metadata fields in `load_from_hf_repo`
+
+**Files:**
+- Modify: `aimnet/calculators/hf_hub.py:270-282` (metadata construction in `load_from_hf_repo`)
+- Test: `tests/test_hf_hub.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_hf_hub.py` (keep the existing `fake_hf_repo` fixture pattern; create a separate fixture that injects the new fields):
+
+```python
+@pytest.fixture
+def fake_hf_repo_with_family(tmp_path):
+    """A fake HF repo whose config.json declares family + supports_charged_systems."""
+    from aimnet.calculators.model_registry import get_model_path
+
+    pt_path = get_model_path("aimnet2")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", ".*weights_only.*")
+        raw = torch.load(pt_path, map_location="cpu", weights_only=False)
+
+    state_dict = raw["state_dict"]
+    save_file(state_dict, str(tmp_path / "ensemble_0.safetensors"))
+
+    config = {
+        "config_schema_version": 1,
+        "family_name": "fake-family",
+        "ensemble_size": 1,
+        "member_names": ["fake_0"],
+        "cutoff": float(raw["cutoff"]),
+        "needs_coulomb": raw.get("needs_coulomb", False),
+        "needs_dispersion": raw.get("needs_dispersion", False),
+        "coulomb_mode": raw.get("coulomb_mode", "none"),
+        "implemented_species": raw.get("implemented_species", []),
+        "model_yaml": raw["model_yaml"],
+        "format_version": 2,
+        "coulomb_sr_rc": raw.get("coulomb_sr_rc"),
+        "coulomb_sr_envelope": raw.get("coulomb_sr_envelope"),
+        "has_embedded_lr": raw.get("has_embedded_lr", False),
+        # NEW fields under test:
+        "family": "test-family",
+        "supports_charged_systems": False,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    return tmp_path
+
+
+def test_load_from_hf_repo_propagates_family_and_charge_fields(fake_hf_repo_with_family):
+    _, metadata = load_from_hf_repo(str(fake_hf_repo_with_family), ensemble_member=0, device="cpu")
+    assert metadata.get("family") == "test-family"
+    assert metadata.get("supports_charged_systems") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v`
+Expected: FAIL — `metadata.get("family")` returns `None`.
+
+- [ ] **Step 3: Update the metadata construction in `hf_hub.py`**
+
+Edit `aimnet/calculators/hf_hub.py`. Locate `metadata: ModelMetadata = { ... }` (around line 271). Add two lines after `"implemented_species": _cfg("implemented_species", []),`:
+
+```python
+        "family": _cfg("family"),
+        "supports_charged_systems": _cfg("supports_charged_systems"),
+```
+
+The full block now reads:
+
+```python
+    metadata: ModelMetadata = {
+        "format_version": _cfg("format_version", 2),
+        "cutoff": config["cutoff"],
+        "needs_coulomb": _cfg("needs_coulomb", False),
+        "needs_dispersion": _cfg("needs_dispersion", False),
+        "coulomb_mode": _cfg("coulomb_mode", "none"),
+        "coulomb_sr_rc": coulomb_sr_rc,
+        "coulomb_sr_envelope": coulomb_sr_envelope,
+        "d3_params": _cfg("d3_params"),
+        "has_embedded_lr": _cfg("has_embedded_lr", False),
+        "implemented_species": _cfg("implemented_species", []),
+        "family": _cfg("family"),
+        "supports_charged_systems": _cfg("supports_charged_systems"),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_hf_hub.py::test_load_from_hf_repo_propagates_family_and_charge_fields -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/hf_hub.py tests/test_hf_hub.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(hf_hub): propagate family/supports_charged_systems in load_from_hf_repo"
+```
+
+---
+
+## Task 4: Extend `load_v1_model` with override kwargs + AFV sanitization
+
+**Files:**
+- Modify: `aimnet/models/utils.py:568-735` (`load_v1_model` function)
+- Test: `tests/test_model.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_model.py`:
+
+```python
+def test_load_v1_model_species_override_nan_pads_other_rows():
+    """load_v1_model with implemented_species override must NaN-pad AFV rows
+    for elements outside the supported set, write family/supports_charged_systems
+    to metadata, AND keep atomic_shift in float64 (regression on .double() ordering)."""
+    import math
+    from pathlib import Path
+
+    import pytest
+    import torch
+
+    src_jpt = Path("_tmp/model_1.jpt")
+    src_yaml = Path("_tmp/config.yaml")
+    if not src_jpt.exists() or not src_yaml.exists():
+        pytest.skip("aimnet2-rxn JIT source not available in _tmp/; skipping override test")
+
+    from aimnet.models.utils import load_v1_model
+
+    species = [1, 6, 7, 8]
+    model, metadata = load_v1_model(
+        str(src_jpt),
+        str(src_yaml),
+        output_path=None,
+        implemented_species=species,
+        family="rxn",
+        supports_charged_systems=False,
+        verbose=False,
+    )
+
+    assert metadata["implemented_species"] == species
+    assert metadata.get("family") == "rxn"
+    assert metadata.get("supports_charged_systems") is False
+
+    afv = model.afv.weight.data
+    species_set = set(species)
+    for z in range(1, afv.shape[0]):
+        row = afv[z]
+        if z in species_set:
+            assert not torch.isnan(row).any(), f"row {z} (in species) must not be NaN"
+        else:
+            assert torch.isnan(row).all(), f"row {z} (out of species) must be all-NaN"
+
+    # .double() ordering regression: atomic_shift dtype is float64.
+    assert hasattr(model, "outputs") and hasattr(model.outputs, "atomic_shift")
+    assert model.outputs.atomic_shift.shifts.weight.dtype == torch.float64
+
+
+def test_load_v1_model_without_overrides_is_backward_compatible():
+    """Existing four families' conversions must still work when the new kwargs are omitted."""
+    from pathlib import Path
+
+    import pytest
+
+    src_jpt = Path("_tmp/model_1.jpt")
+    src_yaml = Path("_tmp/config.yaml")
+    if not src_jpt.exists() or not src_yaml.exists():
+        pytest.skip("JIT source not available")
+
+    from aimnet.models.utils import load_v1_model
+
+    _, metadata = load_v1_model(str(src_jpt), str(src_yaml), output_path=None, verbose=False)
+    # No overrides → species derived from afv.weight (which for rxn means [1..63]).
+    assert isinstance(metadata["implemented_species"], list)
+    assert metadata.get("family") is None
+    assert metadata.get("supports_charged_systems") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v`
+Expected: FAIL on the override test (`unexpected keyword argument 'implemented_species'`); the backward-compat test should pass already.
+
+- [ ] **Step 3: Add the new kwargs and AFV sanitization**
+
+Edit `aimnet/models/utils.py`. Locate the `load_v1_model` signature at line ~568:
+
+Replace:
+```python
+def load_v1_model(
+    jpt_path: str,
+    yaml_config_path: str,
+    output_path: str | None = None,
+    verbose: bool = True,
+) -> tuple[nn.Module, dict]:
+```
+
+With:
+```python
+def load_v1_model(
+    jpt_path: str,
+    yaml_config_path: str,
+    output_path: str | None = None,
+    *,
+    implemented_species: list[int] | None = None,
+    family: str | None = None,
+    supports_charged_systems: bool | None = None,
+    verbose: bool = True,
+) -> tuple[nn.Module, dict]:
+```
+
+Then locate the species extraction (around line 634):
+
+Replace:
+```python
+    cutoff = float(jit_model.cutoff)
+    implemented_species = extract_species(jit_model)
+```
+
+With:
+```python
+    cutoff = float(jit_model.cutoff)
+    _species_kwarg = implemented_species  # rename to avoid shadowing the metadata field below
+    if _species_kwarg is not None:
+        implemented_species_list = sorted(set(_species_kwarg))
+    else:
+        implemented_species_list = extract_species(jit_model)
+```
+
+Then locate the metadata construction near the end of the function (around line 710):
+
+Replace:
+```python
+    metadata = {
+        "format_version": 2,
+        "model_yaml": core_yaml_str,
+        "cutoff": cutoff,
+        "needs_coulomb": needs_coulomb,
+        "needs_dispersion": needs_dispersion,
+        "coulomb_mode": coulomb_mode,
+        "coulomb_sr_rc": coulomb_sr_rc if needs_coulomb else None,
+        "coulomb_sr_envelope": coulomb_sr_envelope if needs_coulomb else None,
+        "d3_params": d3_params if needs_dispersion else None,
+        "has_embedded_lr": has_embedded_lr,
+        "implemented_species": implemented_species,
+    }
+```
+
+With:
+```python
+    metadata = {
+        "format_version": 2,
+        "model_yaml": core_yaml_str,
+        "cutoff": cutoff,
+        "needs_coulomb": needs_coulomb,
+        "needs_dispersion": needs_dispersion,
+        "coulomb_mode": coulomb_mode,
+        "coulomb_sr_rc": coulomb_sr_rc if needs_coulomb else None,
+        "coulomb_sr_envelope": coulomb_sr_envelope if needs_coulomb else None,
+        "d3_params": d3_params if needs_dispersion else None,
+        "has_embedded_lr": has_embedded_lr,
+        "implemented_species": implemented_species_list,
+    }
+    if family is not None:
+        metadata["family"] = family
+    if supports_charged_systems is not None:
+        metadata["supports_charged_systems"] = bool(supports_charged_systems)
+
+    # AFV row sanitization: when the caller declares the supported species
+    # explicitly, NaN-pad rows for elements outside that set so
+    # validate_species=False at inference time produces NaN-propagation
+    # instead of plausible-looking garbage from populated-but-untrained rows.
+    if _species_kwarg is not None:
+        species_set = set(implemented_species_list)
+        afv = core_model.afv.weight.data
+        for z in range(1, afv.shape[0]):
+            if z not in species_set:
+                afv[z] = float("nan")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows tests/test_model.py::test_load_v1_model_without_overrides_is_backward_compatible -v`
+Expected: PASS for both (or `SKIPPED` if `_tmp/` is not present — that's acceptable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/utils.py tests/test_model.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(models): add implemented_species/family/supports_charged_systems overrides to load_v1_model with AFV sanitization"
+```
+
+---
+
+## Task 5: Reorder `.double()` in `load_v1_model`
+
+**Files:**
+- Modify: `aimnet/models/utils.py:697-704` (the atomic_shift block inside `load_v1_model`)
+- Test: covered by `test_load_v1_model_species_override_nan_pads_other_rows` (Task 4)
+
+- [ ] **Step 1: Verify the test from Task 4 still asserts float64**
+
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v`
+Expected: PASS (the existing pre-fix code happens to leave atomic_shift as float64 because it calls `.double()` after `load_state_dict`).
+
+- [ ] **Step 2: Reorder `.double()` to run BEFORE `load_state_dict`**
+
+Edit `aimnet/models/utils.py`. Locate the section around line 686-704 inside `load_v1_model`:
+
+Replace:
+```python
+    # Load weights from JIT model
+    jit_sd = jit_model.state_dict()
+    load_result = core_model.load_state_dict(jit_sd, strict=False)
+
+    # Validate keys
+    real_missing, real_unexpected = validate_state_dict_keys(load_result.missing_keys, load_result.unexpected_keys)
+    if real_missing:
+        print(f"WARNING: Unexpected missing keys: {real_missing}")
+    if real_unexpected:
+        print(f"WARNING: Unexpected extra keys: {real_unexpected}")
+    if not real_missing and not real_unexpected and verbose:
+        print("Loaded weights successfully")
+
+    # Convert atomic_shift to float64 to preserve SAE precision
+    if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
+        core_model.outputs.atomic_shift.double()
+        atomic_shift_key = "outputs.atomic_shift.shifts.weight"
+        if atomic_shift_key in jit_sd:
+            core_model.outputs.atomic_shift.shifts.weight.data.copy_(jit_sd[atomic_shift_key])
+            if verbose:
+                print("  Atomic shift converted to float64")
+```
+
+With:
+```python
+    # Cast atomic_shift to float64 BEFORE load_state_dict so the destination
+    # buffer can hold full precision when load_state_dict's internal copy_ runs.
+    # Order matters: doing this after load_state_dict + a redundant copy_ from
+    # the still-float32 source is the bug this fixes.
+    if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
+        core_model.outputs.atomic_shift.double()
+        if verbose:
+            print("  Atomic shift cast to float64 before load_state_dict")
+
+    # Load weights from JIT model
+    jit_sd = jit_model.state_dict()
+    load_result = core_model.load_state_dict(jit_sd, strict=False)
+
+    # Validate keys
+    real_missing, real_unexpected = validate_state_dict_keys(load_result.missing_keys, load_result.unexpected_keys)
+    if real_missing:
+        print(f"WARNING: Unexpected missing keys: {real_missing}")
+    if real_unexpected:
+        print(f"WARNING: Unexpected extra keys: {real_unexpected}")
+    if not real_missing and not real_unexpected and verbose:
+        print("Loaded weights successfully")
+```
+
+- [ ] **Step 3: Run the regression test**
+
+Run: `pytest tests/test_model.py::test_load_v1_model_species_override_nan_pads_other_rows -v`
+Expected: PASS — atomic_shift dtype is still float64; numerical behavior is byte-identical for current JIT models (atomic_shift in source is float32).
+
+- [ ] **Step 4: Run the full test_model.py to catch any unrelated regressions**
+
+Run: `pytest tests/test_model.py -v`
+Expected: All tests PASS or `SKIPPED` (no FAIL).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/utils.py
+git -C /home/olexandr/aimnetcentral commit -m "fix(models): cast atomic_shift to float64 before load_state_dict in load_v1_model"
+```
+
+---
+
+## Task 6: Add docstring example to `load_v1_model`
+
+**Files:**
+- Modify: `aimnet/models/utils.py` (the docstring of `load_v1_model`)
+
+- [ ] **Step 1: Locate the docstring**
+
+Open `aimnet/models/utils.py` and find the `load_v1_model` docstring (starts around line 574, ends around line 615 with the `Warnings` section).
+
+- [ ] **Step 2: Add an Examples section**
+
+Just before the existing `Warnings` section in the docstring, insert:
+
+```python
+    Examples
+    --------
+    Convert a single legacy JIT model to the v2 .pt format:
+
+    >>> from aimnet.models.utils import load_v1_model
+    >>> model, metadata = load_v1_model("model.jpt", "config.yaml")
+
+    Convert the four aimnet2-rxn ensemble members with explicit species,
+    family, and charge-support declarations (writes AFV-sanitized .pt files
+    with rows for elements outside [1, 6, 7, 8] NaN-padded):
+
+    >>> for i in range(4):
+    ...     load_v1_model(
+    ...         f"_tmp/model_{i+1}.jpt",
+    ...         "aimnet/models/aimnet2_rxn.yaml",
+    ...         output_path=f"aimnet2_rxn_{i}.pt",
+    ...         implemented_species=[1, 6, 7, 8],
+    ...         family="rxn",
+    ...         supports_charged_systems=False,
+    ...     )
+
+```
+
+- [ ] **Step 3: Verify the docstring renders without raising**
+
+Run: `python -c "from aimnet.models.utils import load_v1_model; help(load_v1_model)"`
+Expected: docstring prints with no exception; `Examples` section visible.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/utils.py
+git -C /home/olexandr/aimnetcentral commit -m "docs(models): add aimnet2-rxn conversion example to load_v1_model docstring"
+```
+
+---
+
+## Task 7: Add architecture YAML for aimnet2-rxn
+
+**Files:**
+- Create: `aimnet/models/aimnet2_rxn.yaml`
+- Test: `tests/test_model.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_model.py`:
+
+```python
+def test_aimnet2_rxn_yaml_builds():
+    """The architecture YAML for aimnet2-rxn must be loadable and produce a real AIMNet2 module."""
+    import importlib.resources
+    import yaml
+
+    from aimnet.config import build_module
+
+    yaml_text = importlib.resources.files("aimnet.models").joinpath("aimnet2_rxn.yaml").read_text()
+    cfg = yaml.safe_load(yaml_text)
+    model = build_module(cfg)
+
+    # The reconstructed module must have the rxn output heads.
+    assert hasattr(model, "outputs")
+    assert hasattr(model.outputs, "energy_mlp")
+    assert hasattr(model.outputs, "atomic_shift")
+    assert hasattr(model.outputs, "atomic_sum")
+    assert hasattr(model.outputs, "dipole")
+    assert hasattr(model.outputs, "quadrupole")
+    assert hasattr(model.outputs, "lrcoulomb")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v`
+Expected: FAIL — `aimnet2_rxn.yaml` does not exist yet.
+
+- [ ] **Step 3: Create the YAML**
+
+Create `aimnet/models/aimnet2_rxn.yaml` with this exact content (this is the same architecture already embedded in the per-member `.pt` `model_yaml` field and in the HF `config.json`):
+
+```yaml
+class: aimnet.models.AIMNet2
+kwargs:
+    nfeature: 16
+    d2features: true
+    ncomb_v: 12
+    hidden:
+        - [512, 380]
+        - [512, 380]
+        - [512, 380, 380]
+    aim_size: 256
+    num_charge_channels: 1
+    aev:
+        rc_s: 5.0
+        nshifts_s: 16
+    outputs:
+        energy_mlp:
+            class: aimnet.modules.Output
+            kwargs:
+                n_in: 256
+                n_out: 1
+                key_in: aim
+                key_out: energy
+                mlp:
+                    activation_fn: torch.nn.GELU
+                    last_linear: true
+                    hidden: [128, 128]
+        atomic_shift:
+            class: aimnet.modules.AtomicShift
+            kwargs:
+                key_in: energy
+                key_out: energy
+        atomic_sum:
+            class: aimnet.modules.AtomicSum
+            kwargs:
+                key_in: energy
+                key_out: energy
+        dipole:
+            class: aimnet.modules.Dipole
+            kwargs:
+                key_in: charges
+                key_out: dipole
+        quadrupole:
+            class: aimnet.modules.Quadrupole
+            kwargs:
+                key_in: charges
+                key_out: quadrupole
+        lrcoulomb:
+            class: aimnet.modules.LRCoulomb
+            kwargs:
+                rc: 4.6
+                key_in: charges
+                key_out: energy
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_model.py::test_aimnet2_rxn_yaml_builds -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/models/aimnet2_rxn.yaml tests/test_model.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(models): add aimnet2_rxn.yaml architecture descriptor"
+```
+
+---
+
+## Task 8: Add registry entries for aimnet2-rxn
+
+**Files:**
+- Modify: `aimnet/calculators/model_registry.yaml` (append entries + alias)
+- Test: `tests/test_model_registry.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_model_registry.py`:
+
+```python
+def test_aimnet2rxn_registry_entries_and_alias():
+    """All four aimnet2-rxn members must be registered with the canonical GCS URL,
+    and the `aimnet2rxn` alias must resolve to member 0."""
+    from aimnet.calculators.model_registry import load_model_registry
+
+    registry = load_model_registry()
+    models = registry["models"]
+
+    base_url = "https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn"
+    for i in range(4):
+        name = f"aimnet2_rxn_{i}"
+        assert name in models, f"missing registry entry: {name}"
+        entry = models[name]
+        assert entry["file"] == f"{name}.pt"
+        assert entry["url"] == f"{base_url}/{name}.pt"
+
+    aliases = registry["aliases"]
+    assert aliases.get("aimnet2rxn") == "aimnet2_rxn_0"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v`
+Expected: FAIL — `KeyError` or `assertion` because the entries don't exist.
+
+- [ ] **Step 3: Add the entries to `model_registry.yaml`**
+
+Edit `aimnet/calculators/model_registry.yaml`. Locate the last `aimnet2-pd_3:` entry (around line 60-62). Add immediately after it (before the `# map model alias` comment):
+
+```yaml
+    aimnet2_rxn_0:
+        file: aimnet2_rxn_0.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
+    aimnet2_rxn_1:
+        file: aimnet2_rxn_1.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt
+    aimnet2_rxn_2:
+        file: aimnet2_rxn_2.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt
+    aimnet2_rxn_3:
+        file: aimnet2_rxn_3.pt
+        url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt
+```
+
+In the `aliases:` section at the end, add the alias right after `aimnet2_2025: aimnet2_b973c_2025_d3_0`:
+
+```yaml
+    aimnet2rxn: aimnet2_rxn_0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_model_registry.py::test_aimnet2rxn_registry_entries_and_alias -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/model_registry.yaml tests/test_model_registry.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(registry): register aimnet2-rxn family (4 GCS entries + aimnet2rxn alias)"
+```
+
+---
+
+## Task 9: Add `metadata` property and `_was_compiled` flag to `AIMNet2Calculator`
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py` (`__init__` + new property)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_calculator_metadata_property_returns_model_metadata():
+    """AIMNet2Calculator.metadata must return the same dict as model._metadata."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    assert calc.metadata is calc.model._metadata
+    # Existing aimnet2 family declares neither family nor supports_charged_systems.
+    assert calc.metadata.get("family") is None
+    assert calc.metadata.get("supports_charged_systems") is None
+
+
+def test_calculator_was_compiled_flag_default_false():
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    assert calc._was_compiled is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v`
+Expected: FAIL — `metadata` does not exist as a property; `_was_compiled` not set.
+
+- [ ] **Step 3: Add the `_was_compiled` flag in `__init__`**
+
+Edit `aimnet/calculators/calculator.py`. Locate the constructor block around line 286-291 where `compile_model` is handled:
+
+Replace:
+```python
+        # Compile model if requested
+        if compile_model:
+            kwargs = compile_kwargs or {}
+            self.model = torch.compile(self.model, **kwargs)
+```
+
+With:
+```python
+        # Compile model if requested
+        self._was_compiled = bool(compile_model)
+        if compile_model:
+            kwargs = compile_kwargs or {}
+            self.model = torch.compile(self.model, **kwargs)
+```
+
+- [ ] **Step 4: Add the `metadata` property**
+
+In the same file, locate the existing `@property` for `has_external_coulomb` (around line 417). Just before it, add:
+
+```python
+    @property
+    def metadata(self) -> dict | None:
+        """Read-only view of the model's metadata dict.
+
+        Returns the same object as ``model._metadata`` for v2 .pt models,
+        or ``None`` for raw ``nn.Module`` inputs that don't carry metadata.
+        Downstream consumers should prefer this accessor over reaching into
+        the private ``model._metadata`` attribute.
+        """
+        return getattr(self.model, "_metadata", None)
+```
+
+- [ ] **Step 5: Migrate existing reads to use the property (lines 490 and 515)**
+
+Locate the two existing `getattr(self.model, "_metadata", None)` calls outside `__init__`:
+
+At around line 490, replace `meta = getattr(self.model, "_metadata", None)` with `meta = self.metadata`.
+
+At around line 515, replace `meta = getattr(self.model, "_metadata", None)` with `meta = self.metadata`.
+
+**Do NOT change** the `getattr(self.model, "_metadata", None)` at around line 284 — that one is inside `__init__` and runs before `self.model` is fully usable as a property surface; leaving it as `getattr` keeps the constructor independent of the property.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_calculator.py::test_calculator_metadata_property_returns_model_metadata tests/test_calculator.py::test_calculator_was_compiled_flag_default_false -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full calculator test suite to catch regressions**
+
+Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"`
+Expected: All non-skipped tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add metadata property and _was_compiled flag"
+```
+
+---
+
+## Task 10: Add species-validation guard in `eval`
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py:724` (`eval` method signature + new validation block at top)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_calculator_rejects_unsupported_species():
+    """Calling the calculator with an unsupported atomic number must raise ValueError
+    with chemistry context and pointers to alternative models."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # aimnet2's implemented_species does NOT include Z=92 (uranium).
+    coords = torch.tensor([[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]])
+    numbers = torch.tensor([1, 92])  # H + U; U is unsupported
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    with pytest.raises(ValueError, match=r"implemented_species"):
+        calc(data)
+
+
+def test_calculator_validate_species_false_bypasses():
+    """Passing validate_species=False must skip the species check (no ValueError)."""
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # H is supported by aimnet2, so this should not raise even without bypass;
+    # the test asserts the kwarg flows through and does not itself raise.
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    # Both calls should succeed; validate_species=False is the explicit bypass path.
+    calc(data, validate_species=True)
+    calc(data, validate_species=False)
+```
+
+- [ ] **Step 2: Run tests to verify the first fails**
+
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v`
+Expected: FIRST test FAILs (calculator silently produces output for U); the bypass test may FAIL with "got unexpected keyword argument 'validate_species'".
+
+- [ ] **Step 3: Add `validate_species` to the `eval` signature**
+
+Edit `aimnet/calculators/calculator.py`. Locate `def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False)` at line 724.
+
+Replace with:
+```python
+    def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
+             *, validate_species: bool = True) -> dict[str, Tensor]:
+```
+
+- [ ] **Step 4: Add the species-validation block at the top of `eval`**
+
+Immediately after the new signature line and BEFORE the existing `data = self.prepare_input(data)` line at line 725, insert:
+
+```python
+        # Species validation — opt-out via validate_species=False.
+        # Silent no-op for models that did not declare implemented_species (older .pt,
+        # raw nn.Module).
+        if validate_species:
+            impl = (self.metadata or {}).get("implemented_species") or []
+            if impl:
+                seen = {int(z) for z in data["numbers"].flatten().tolist() if int(z) > 0}
+                unsupported = sorted(seen - set(impl))
+                if unsupported:
+                    raise ValueError(
+                        f"Atomic numbers {unsupported} are not in this model's "
+                        f"implemented_species {sorted(impl)}. This model was trained on "
+                        f"a restricted element set; passing other elements yields undefined "
+                        f"output. For broader element coverage on equilibrium structures use "
+                        f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
+                        f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
+                    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_unsupported_species tests/test_calculator.py::test_calculator_validate_species_false_bypasses -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add validate_species ValueError on unsupported atomic numbers"
+```
+
+---
+
+## Task 11: Add charge-guard for `supports_charged_systems: false` models
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py` (`eval` — append a second guard inside the `if validate_species` block)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_calculator_rejects_charged_input_when_unsupported(monkeypatch):
+    """When metadata declares supports_charged_systems=False, a non-zero charge raises."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # Synthetically inject the family-narrowing metadata (aimnet2 does not declare it
+    # natively; this mirrors what an aimnet2-rxn .pt would carry).
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata["supports_charged_systems"] = False
+
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(-1.0)}
+
+    with pytest.raises(ValueError, match=r"net-charged systems"):
+        calc(data)
+
+    # Bypass works
+    calc(data, validate_species=False)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v`
+Expected: FAIL — no charge guard yet.
+
+- [ ] **Step 3: Add the charge guard inside `eval`**
+
+Edit `aimnet/calculators/calculator.py`. Locate the species-validation block added in Task 10 (still inside the `if validate_species:` clause). After the species check raises, append (still inside the `if validate_species:` outer block):
+
+```python
+            meta = self.metadata or {}
+            if meta.get("supports_charged_systems") is False:
+                charge_val = float(data.get("charge", 0.0))
+                if abs(charge_val) > 1e-6:
+                    raise ValueError(
+                        f"This model does not support net-charged systems "
+                        f"(got charge={charge_val}). Net-neutral zwitterions are supported. "
+                        f"For ions use `isayevlab/aimnet2-wb97m-d3`. "
+                        f"Pass validate_species=False to bypass."
+                    )
+```
+
+(`charge` may arrive as a tensor; `float(tensor)` returns a Python float for 0-d tensors. For batched 1-d charge tensors, `float(...)` will raise — that's correct behavior because per-system charge mixing requires per-system validation, which is out of scope for this guard.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_calculator.py::test_calculator_rejects_charged_input_when_unsupported -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): add charge guard for models that declare supports_charged_systems=False"
+```
+
+---
+
+## Task 12: Add `hessian + compile_model` guard
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py` (`eval` — guard added after the validate_species block)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_hessian_with_compile_raises():
+    """Calling with hessian=True on a calculator constructed with compile_model=True
+    must raise RuntimeError instead of hanging (Dynamo + double-backward on GELU)."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # Don't actually torch.compile (slow + may need GPU); just flip the flag.
+    calc._was_compiled = True
+
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    with pytest.raises(RuntimeError, match=r"Hessian computation is incompatible with compile_model=True"):
+        calc(data, hessian=True)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v`
+Expected: FAIL — no guard yet (test hangs OR proceeds to the hessian path).
+
+- [ ] **Step 3: Add the guard in `eval`**
+
+Edit `aimnet/calculators/calculator.py`. The Task-11 charge-guard block ends inside `if validate_species:`. Just AFTER that whole `if validate_species:` block (i.e. unconditional — the Hessian guard always fires regardless of `validate_species`), and BEFORE `data = self.prepare_input(data)`, insert:
+
+```python
+        # Hessian + torch.compile is known to hang on the double-backward
+        # path through GELU activations. Fail fast instead.
+        if hessian and getattr(self, "_was_compiled", False):
+            raise RuntimeError(
+                "Hessian computation is incompatible with compile_model=True "
+                "(Dynamo + double-backward through GELU hangs). Reconstruct calculator "
+                "with compile_model=False."
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_calculator.py::test_hessian_with_compile_raises -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): raise RuntimeError on hessian=True + compile_model=True (was: silent hang)"
+```
+
+---
+
+## Task 13: Add `set_lrcoulomb_method` rxn-family cutoff guard
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py:601-670` (`set_lrcoulomb_method`)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_set_lrcoulomb_method_warns_on_rxn_cutoff_change():
+    """For family='rxn', changing the coulomb cutoff away from coulomb_sr_rc
+    (4.6 A) must emit a UserWarning about SR/LR matching."""
+    import pytest
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata["family"] = "rxn"
+    calc.model._metadata["coulomb_sr_rc"] = 4.6
+
+    with pytest.warns(UserWarning, match=r"SR/LR"):
+        calc.set_lrcoulomb_method("dsf", cutoff=10.0)
+
+
+def test_set_lrcoulomb_method_no_warn_on_matching_cutoff():
+    """No warning when cutoff matches coulomb_sr_rc, or for non-rxn families."""
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    # Non-rxn family: never warn about SR/LR.
+    calc1 = AIMNet2Calculator("aimnet2", device="cpu")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        calc1.set_lrcoulomb_method("dsf", cutoff=10.0)
+    sr_lr_warnings = [w for w in caught if "SR/LR" in str(w.message)]
+    assert sr_lr_warnings == []
+```
+
+- [ ] **Step 2: Run tests to verify the first fails**
+
+Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v`
+Expected: First test FAILs (no warning raised); second test PASSes already (no warning is the current behavior).
+
+- [ ] **Step 3: Add the rxn guard at the top of `set_lrcoulomb_method`**
+
+Edit `aimnet/calculators/calculator.py`. Locate `def set_lrcoulomb_method(...)` at line 601. After the existing `if method not in (...): raise ValueError` validation (around line 635-636), and before the `# Warn if model has embedded Coulomb` block (around line 638), insert:
+
+```python
+        # rxn-family guard: the 4.6 A SR/LR cancellation point is physically
+        # frozen for this family. Changing the cutoff silently breaks matching.
+        meta = self.metadata or {}
+        if meta.get("family") == "rxn":
+            sr_rc = meta.get("coulomb_sr_rc")
+            if sr_rc is not None and method in ("dsf", "ewald") and abs(cutoff - float(sr_rc)) > 1e-6:
+                warnings.warn(
+                    f"Setting Coulomb {method} cutoff to {cutoff} A on aimnet2-rxn breaks "
+                    f"the SR/LR cancellation matching (this family was trained with a "
+                    f"physically frozen crossover at coulomb_sr_rc={sr_rc} A). Use the "
+                    f"matching cutoff or revert to the default external Coulomb.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_calculator.py::test_set_lrcoulomb_method_warns_on_rxn_cutoff_change tests/test_calculator.py::test_set_lrcoulomb_method_no_warn_on_matching_cutoff -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): warn on set_lrcoulomb_method cutoff mismatch for rxn family"
+```
+
+---
+
+## Task 14: Add cross-family mixing detection
+
+**Files:**
+- Modify: `aimnet/calculators/calculator.py` (add ClassVar + record-and-warn at end of `__init__`)
+- Test: `tests/test_calculator.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_calculator.py`:
+
+```python
+def test_constructing_two_families_warns_once(monkeypatch):
+    """Constructing calculators from two different families in one process must
+    emit a UserWarning about energy-scale incompatibility."""
+    import pytest
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    # Reset the class-level set so test order does not pollute it.
+    AIMNet2Calculator._constructed_families.clear()
+    monkeypatch.delenv("AIMNET_QUIET_FAMILY_MIX", raising=False)
+
+    # First calculator: synthetic 'family-A'.
+    calc_a = AIMNet2Calculator("aimnet2", device="cpu")
+    calc_a.model._metadata = dict(calc_a.model._metadata)
+    calc_a.model._metadata["family"] = "family-A"
+    AIMNet2Calculator._constructed_families.add("family-A")  # mimic what __init__ does
+
+    # Second calculator: a different family — should warn.
+    with pytest.warns(UserWarning, match=r"different families"):
+        calc_b = AIMNet2Calculator("aimnet2", device="cpu")
+        # The constructor itself must add the (synthetic) family. Since we cannot
+        # change metadata before __init__ finishes, simulate by constructing then
+        # injecting+re-running the warn step. For this PR's purposes the warn
+        # logic lives in __init__ AFTER load. Test it by direct invocation:
+        calc_b.model._metadata = dict(calc_b.model._metadata)
+        calc_b.model._metadata["family"] = "family-B"
+        # Call the production helper that __init__ calls (see Step 3).
+        calc_b._maybe_warn_family_mix("family-B")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v`
+Expected: FAIL — `_constructed_families` and `_maybe_warn_family_mix` do not exist.
+
+- [ ] **Step 3: Add the ClassVar and helper, and call from `__init__`**
+
+Edit `aimnet/calculators/calculator.py`. Inside the `class AIMNet2Calculator:` body, find the existing class-level declarations (e.g. the `_HF_ID_RE` line is local to `__init__` — the right place is alongside other class attributes). Add right above `def __init__(`:
+
+```python
+    _constructed_families: ClassVar[set[str]] = set()
+```
+
+Then add the helper method just after the `metadata` property (added in Task 9):
+
+```python
+    def _maybe_warn_family_mix(self, family: str | None) -> None:
+        """If multiple distinct families have been constructed in this process,
+        emit a one-time UserWarning about energy-scale incompatibility.
+
+        Bypass: set the AIMNET_QUIET_FAMILY_MIX environment variable to '1'.
+        """
+        if family is None:
+            return
+        if os.environ.get("AIMNET_QUIET_FAMILY_MIX") == "1":
+            self._constructed_families.add(family)
+            return
+        already_warned = family in self._constructed_families
+        self._constructed_families.add(family)
+        if not already_warned and len(self._constructed_families) > 1:
+            others = sorted(self._constructed_families - {family})
+            warnings.warn(
+                f"AIMNet2Calculator instances from different families have been "
+                f"constructed in this process: {sorted(self._constructed_families)}. "
+                f"Energy scales differ across families (e.g. rxn uses a learned "
+                f"shifted-electronic scale; aimnet2-wb97m-d3 uses absolute "
+                f"electronic energies on the ~-1100 eV scale). Do not mix or compare "
+                f"energies across families. Set AIMNET_QUIET_FAMILY_MIX=1 to silence.",
+                UserWarning,
+                stacklevel=2,
+            )
+```
+
+Then near the END of `__init__` (after metadata is fully resolved, e.g. just before any final return), add:
+
+```python
+        self._maybe_warn_family_mix((metadata or {}).get("family") if metadata else None)
+```
+
+The right place is at the very end of `__init__` — find the last line of the constructor body and append the call after it. Ensure `import os` exists at module top (if not, add `import os` to the import block).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_calculator.py::test_constructing_two_families_warns_once -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test_calculator.py to catch regressions**
+
+Run: `pytest tests/test_calculator.py -v -m "not gpu and not hf"`
+Expected: All non-skipped tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/calculator.py tests/test_calculator.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(calculator): warn once on cross-family construction (energy-scale incompatibility)"
+```
+
+---
+
+## Task 15: Propagate `validate_species` through `AIMNet2ASE`
+
+**Files:**
+- Modify: `aimnet/calculators/aimnet2ase.py:24-45` (`__init__`) and `aimnet2ase.py:121-145` (`calculate`)
+- Test: `tests/test_ase.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_ase.py` (do this only if ASE is importable — guard with the existing pattern in the file):
+
+```python
+@pytest.mark.ase
+def test_aimnet2ase_propagates_validate_species(monkeypatch):
+    """AIMNet2ASE.calculate(..., validate_species=False) must propagate the kwarg
+    through to the underlying AIMNet2Calculator.__call__."""
+    from ase import Atoms
+    from aimnet.calculators.aimnet2ase import AIMNet2ASE
+
+    calc = AIMNet2ASE("aimnet2")
+    # H2O — only H, O which are supported. Use validate_species=False to verify the
+    # kwarg flows through (the call should succeed regardless).
+    atoms = Atoms("H2O", positions=[[0,0,0],[0,0,1],[0,1,0]])
+    atoms.calc = calc
+
+    # Fast path: just access energy. This exercises the full pipeline.
+    _ = atoms.get_potential_energy()  # baseline default validate_species=True
+    # Re-run with the explicit kwarg via the constructor escape hatch:
+    calc2 = AIMNet2ASE("aimnet2", validate_species=False)
+    atoms.calc = calc2
+    _ = atoms.get_potential_energy()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v`
+Expected: FAIL — `AIMNet2ASE.__init__` does not accept `validate_species`.
+
+- [ ] **Step 3: Add `validate_species` to `AIMNet2ASE.__init__`**
+
+Edit `aimnet/calculators/aimnet2ase.py`. Locate `def __init__(self, base_calc: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1):` at line 24.
+
+Replace with:
+```python
+    def __init__(
+        self,
+        base_calc: AIMNet2Calculator | str = "aimnet2",
+        charge=0,
+        mult=1,
+        validate_species: bool = True,
+    ):
+```
+
+After the existing assignment of `base_calc` to `self.base_calc` (around line 27-28), add:
+```python
+        self.validate_species = validate_species
+```
+
+- [ ] **Step 4: Pass it through in `calculate`**
+
+Locate the `results = self.base_calc(_in, forces="forces" in properties, stress="stress" in properties)` line (around line 145).
+
+Replace with:
+```python
+        results = self.base_calc(
+            _in,
+            forces="forces" in properties,
+            stress="stress" in properties,
+            validate_species=self.validate_species,
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_ase.py::test_aimnet2ase_propagates_validate_species -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/aimnet2ase.py tests/test_ase.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(ase): propagate validate_species kwarg through AIMNet2ASE"
+```
+
+---
+
+## Task 16: Propagate `validate_species` through `AIMNet2Pysis`
+
+**Files:**
+- Modify: `aimnet/calculators/aimnet2pysis.py:21-65` (`__init__` + the call site that invokes `self.base_calc`)
+- Test: NOT added — pysisyphus is heavy and behind a marker; manual smoke is sufficient. Skip a test for this wrapper.
+
+- [ ] **Step 1: Inspect the current pysisyphus call site**
+
+Run: `grep -n "self.base_calc\|self\.calc\|base_calc(" /home/olexandr/aimnetcentral/aimnet/calculators/aimnet2pysis.py`
+
+Read the printed lines to identify the single point where the wrapper invokes the underlying calculator.
+
+- [ ] **Step 2: Add `validate_species` to `__init__`**
+
+Edit `aimnet/calculators/aimnet2pysis.py`. Locate `def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1, **kwargs):` at line 21.
+
+Replace with:
+```python
+    def __init__(self, model: AIMNet2Calculator | str = "aimnet2", charge=0, mult=1,
+                 validate_species: bool = True, **kwargs):
+```
+
+Right after the existing model assignment block (look for `self.base_calc = model` or equivalent — around line 24-25), add:
+```python
+        self.validate_species = validate_species
+```
+
+- [ ] **Step 3: Pass `validate_species=self.validate_species` at the call site**
+
+Find the location identified in Step 1 (the single `self.base_calc(...)` invocation). Add `validate_species=self.validate_species` to its kwargs.
+
+For example, if the call looks like `results = self.base_calc(in_data, forces=True)`, change to `results = self.base_calc(in_data, forces=True, validate_species=self.validate_species)`.
+
+- [ ] **Step 4: Smoke-import the module to catch syntax errors**
+
+Run: `python -c "from aimnet.calculators.aimnet2pysis import AIMNet2Pysis; print('OK')"`
+Expected: `OK` (no exception).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add aimnet/calculators/aimnet2pysis.py
+git -C /home/olexandr/aimnetcentral commit -m "feat(pysis): propagate validate_species kwarg through AIMNet2Pysis"
+```
+
+---
+
+## Task 17: Alias end-to-end test for `aimnet2rxn`
+
+**Files:**
+- Test: `tests/test_calculator.py` (append)
+
+This test exercises Tasks 7 + 8 + 9 together: the alias resolves, the .pt downloads (or hits cache), the calculator constructs cleanly, and the metadata carries the rxn-specific fields. Network-gated because it needs the GCS object — only meaningful AFTER the maintainer has uploaded the re-converted .pt files.
+
+- [ ] **Step 1: Write the test (with skip if GCS file is missing)**
+
+Append to `tests/test_calculator.py`:
+
+```python
+@pytest.mark.network
+def test_aimnet2rxn_alias_calculator_e2e():
+    """Alias 'aimnet2rxn' must resolve through the registry, the .pt must load,
+    and the calculator must expose rxn-specific metadata fields."""
+    import urllib.error
+    import pytest
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    try:
+        calc = AIMNet2Calculator("aimnet2rxn", device="cpu")
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        pytest.skip(f"GCS .pt for aimnet2rxn not yet uploaded: {e}")
+
+    assert calc.metadata is not None
+    assert calc.metadata.get("family") == "rxn"
+    assert calc.metadata.get("supports_charged_systems") is False
+    assert calc.metadata.get("implemented_species") == [1, 6, 7, 8]
+    assert abs(calc.metadata.get("cutoff") - 5.0) < 1e-6
+```
+
+- [ ] **Step 2: Add `network` marker to `pyproject.toml` if not present**
+
+Check: `grep -n "network" /home/olexandr/aimnetcentral/pyproject.toml`
+If `"network: ..."` is not in the markers list, add to the `markers = [...]` block in `[tool.pytest.ini_options]`:
+
+```toml
+    "network: marks tests that hit external services (deselect with: -m 'not network')",
+```
+
+- [ ] **Step 3: Run the test (will skip if GCS not yet populated)**
+
+Run: `pytest tests/test_calculator.py::test_aimnet2rxn_alias_calculator_e2e -v`
+Expected: SKIPPED with "GCS .pt for aimnet2rxn not yet uploaded" (acceptable for CI before maintainer uploads), or PASS if GCS objects already exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add tests/test_calculator.py pyproject.toml
+git -C /home/olexandr/aimnetcentral commit -m "test(calculator): add aimnet2rxn alias end-to-end test (network-gated)"
+```
+
+---
+
+## Task 18: HF end-to-end test for aimnet2-rxn
+
+**Files:**
+- Test: `tests/test_hf_hub.py` (append)
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_hf_hub.py`:
+
+```python
+@pytest.mark.hf
+def test_aimnet2_rxn_hf_load_matches_gcs_metadata():
+    """Loading aimnet2-rxn from the HF repo must produce metadata equivalent
+    to what the GCS .pt path would produce: same implemented_species, cutoff,
+    family, and supports_charged_systems.
+
+    This test EXPECTS the HF repo's config.json to have been updated with
+    `family: rxn` and `supports_charged_systems: false` (out-of-band task)."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0, device="cpu")
+
+    assert calc.metadata.get("implemented_species") == [1, 6, 7, 8]
+    assert abs(calc.metadata.get("cutoff") - 5.0) < 1e-6
+    assert calc.metadata.get("coulomb_mode") == "sr_embedded"
+    assert calc.metadata.get("needs_coulomb") is True
+    assert calc.metadata.get("needs_dispersion") is False
+
+    # The next two assertions REQUIRE the HF config.json to have the new fields.
+    # If they fail with None, the maintainer needs to update the HF config.json.
+    assert calc.metadata.get("family") == "rxn", (
+        "HF config.json missing `family: rxn` — maintainer must update HF repo."
+    )
+    assert calc.metadata.get("supports_charged_systems") is False, (
+        "HF config.json missing `supports_charged_systems: false` — maintainer must update HF repo."
+    )
+```
+
+- [ ] **Step 2: Run the test (network-gated, requires HF deps)**
+
+Run: `pytest tests/test_hf_hub.py::test_aimnet2_rxn_hf_load_matches_gcs_metadata -v -m hf`
+Expected: PASS if HF repo's `config.json` has been updated; otherwise FAIL with the explicit "maintainer must update HF repo" message — that failure is informative, not a real bug.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add tests/test_hf_hub.py
+git -C /home/olexandr/aimnetcentral commit -m "test(hf_hub): add aimnet2-rxn HF end-to-end metadata test"
+```
+
+---
+
+## Task 19: Add docs page for aimnet2-rxn
+
+**Files:**
+- Create: `docs/models/aimnet2_rxn.md`
+- Modify: `mkdocs.yml` (add nav entry)
+
+- [ ] **Step 1: Create the docs page**
+
+Create `docs/models/aimnet2_rxn.md` with this content:
+
+```markdown
+# AIMNet2-rxn
+
+A neural network interatomic potential specialized for **closed-shell organic reactions** (H, C, N, O), trained on ~4.7M reaction-relevant geometries at ωB97M-V/def2-TZVPP. Use for transition-state searches, NEB / batched-NEB, IRC profiles, and reaction-coordinate energy work.
+
+## Loading
+
+```python
+from aimnet.calculators import AIMNet2Calculator
+
+# From the GCS-backed registry (alias):
+calc = AIMNet2Calculator("aimnet2rxn", ensemble_member=0)
+
+# From Hugging Face Hub:
+calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0)
+```
+
+Both paths produce equivalent calculators. The HF path requires `pip install "aimnet[hf]"`.
+
+## Calculator-enforced safeguards (this family)
+
+The calculator applies the following checks automatically when `validate_species=True` (the default). Each can be bypassed with `validate_species=False`:
+
+- **Element scope**: input atomic numbers must be a subset of `[1, 6, 7, 8]`. Other elements raise `ValueError` with pointers to alternative families.
+- **Net charge**: only net-neutral systems (zwitterions OK). Non-zero `charge` raises `ValueError` pointing at `aimnet2-wb97m-d3` for ions.
+- **AFV row sanitization**: at conversion time, atomic-feature-vector rows for elements outside `[1, 6, 7, 8]` are NaN-padded so `validate_species=False` produces NaN-propagation rather than plausible-looking nonsense.
+
+Two further safeguards fire regardless of `validate_species`:
+
+- **Hessian + `torch.compile`**: setting both raises `RuntimeError` (Dynamo + double-backward through GELU is known to hang). Reconstruct with `compile_model=False` for TS / IRC / vibrational work.
+- **Coulomb cutoff lock**: calling `set_lrcoulomb_method(method, cutoff=…)` with a cutoff different from the model's `coulomb_sr_rc` (4.6 Å) emits a `UserWarning` because the SR/LR cancellation point was physically frozen during training.
+
+A separate one-time `UserWarning` fires if the same Python process constructs calculators from two different AIMNet2 families (rxn vs. wb97m-d3 etc.), because the energy scales are not comparable.
+
+## Canonical model card
+
+Full content (energy convention, training data details, full limitations list, citation) lives at the Hugging Face model card:
+
+[https://huggingface.co/isayevlab/aimnet2-rxn](https://huggingface.co/isayevlab/aimnet2-rxn)
+
+The HF README is the canonical source — this page summarizes only the integration mechanics.
+```
+
+- [ ] **Step 2: Add the nav entry to `mkdocs.yml`**
+
+Open `mkdocs.yml`. Locate the existing model entries (around lines 15-19):
+
+```yaml
+          - AIMNet2 (wB97M-D3): models/aimnet2.md
+          - AIMNet2-B97-3c: models/aimnet2_b973c.md
+          - AIMNet2-2025: models/aimnet2_2025.md
+          - AIMNet2-NSE: models/aimnet2nse.md
+          - AIMNet2-Pd: models/aimnet2pd.md
+```
+
+Append immediately after the `AIMNet2-Pd` line, with the same indentation:
+
+```yaml
+          - AIMNet2-rxn: models/aimnet2_rxn.md
+```
+
+- [ ] **Step 3: Verify mkdocs builds**
+
+Run: `mkdocs build --strict --site-dir /tmp/aimnet-mkdocs-test`
+Expected: build succeeds, no warnings, no broken links. The test directory `/tmp/aimnet-mkdocs-test` will contain the generated site; you can `rm -rf /tmp/aimnet-mkdocs-test` afterward.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /home/olexandr/aimnetcentral add docs/models/aimnet2_rxn.md mkdocs.yml
+git -C /home/olexandr/aimnetcentral commit -m "docs(models): add aimnet2-rxn page (stub linking to HF model card)"
+```
+
+---
+
+## Task 20: Final test suite + branch summary
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the entire affected test surface**
+
+Run:
+```bash
+pytest tests/test_model.py tests/test_calculator.py tests/test_model_registry.py tests/test_hf_hub.py tests/test_ase.py -v -m "not gpu"
+```
+Expected: All non-skipped tests PASS. Skipped tests are acceptable (`hf`, `network`, `pysis`, missing `_tmp/` data, missing GCS upload).
+
+- [ ] **Step 2: Run the full suite once to catch unrelated regressions**
+
+Run: `pytest -v -m "not gpu and not hf and not network and not pysis"`
+Expected: green or pre-existing-yellow only.
+
+- [ ] **Step 3: Show the branch's commit graph**
+
+Run: `git -C /home/olexandr/aimnetcentral log main..HEAD --oneline`
+Expected: ~17-18 commits, each labeled with `feat(...)`, `fix(...)`, `test(...)`, or `docs(...)`. Verify no commit message contains "Claude", "Anthropic", or "Co-Authored-By".
+
+- [ ] **Step 4: Stop and surface the out-of-band tasks before any push/PR**
+
+The following must be done by the maintainer before the PR can be considered ready:
+1. Upload `_tmp/aimnet2_rxn_v2_gcs.zip`'s four `.pt` files to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/` (sha256s: see `_tmp/aimnet2_rxn_v2_gcs.zip`).
+2. Update the HF repo `isayevlab/aimnet2-rxn`'s `config.json` to add `"family": "rxn"` and `"supports_charged_systems": false`.
+
+After both: `test_aimnet2rxn_alias_calculator_e2e` and `test_aimnet2_rxn_hf_load_matches_gcs_metadata` will both PASS in their network-gated environments.
+
+- [ ] **Step 5: Hand back to the user**
+
+Print: "Branch `feat/aimnet2-rxn-integration` ready. ~18 commits applied. Out-of-band tasks pending: GCS upload + HF config.json update."
+
+---
+
+## Spec Coverage Self-Review
+
+| Spec section | Covered by |
+| --- | --- |
+| Component 1 — Registry entries | Task 8 |
+| Component 2 — Architecture YAML | Task 7 |
+| Component 3 — `load_v1_model` overrides + AFV sanitization + .double() reorder + ModelMetadata schema | Tasks 1, 2, 3, 4, 5 |
+| Component 4 — Calculator validation API (species + charge + Hessian) | Tasks 10, 11, 12 |
+| Component 5 — ASE / Pysis wrapper propagation | Tasks 15, 16 |
+| Component 6 — `set_lrcoulomb_method` rxn guard | Task 13 |
+| Component 7 — Cross-family mixing detection | Task 14 |
+| Component 8 — `metadata` property | Task 9 |
+| Component 9 — Conversion (docstring example) | Task 6 |
+| Docs page | Task 19 |
+| Out-of-band tasks (GCS upload, HF config update) | Surfaced in Task 20 |
+
+All nine components and the docs page have a dedicated implementing task. The two out-of-band steps are flagged as maintainer actions, not part of the executable plan.

--- a/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
+++ b/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
@@ -1,0 +1,279 @@
+# aimnet2-rxn Integration — Design Spec
+
+**Date:** 2026-04-25
+**Status:** Approved (pending implementation plan)
+**Scope:** One bundled PR registering the `aimnet2-rxn` model family in `aimnetcentral`, with the orthogonal cleanups required to make it correct end-to-end.
+
+## Goal
+
+Land `aimnet2-rxn` as a first-class member of the model registry, available via two distribution channels:
+
+- **GCS** as `.pt` files at `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_{0..3}.pt`, loadable via `AIMNet2Calculator("aimnet2rxn")` (alias) or `AIMNet2Calculator("aimnet2_rxn_<i>")`.
+- **HF** as `safetensors` at `isayevlab/aimnet2-rxn`, loadable via `AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=<i>)`.
+
+GCS load automatically falls back to HF if the GCS object cannot be retrieved or read.
+
+In the same PR, fix the upstream gaps that the rxn integration surfaced: the `extract_species` heuristic doesn't work for this model, the calculator silently produces undefined output for unsupported elements, the `load_v1_model` `.double()` call ordering is wrong, and external consumers reach into private attributes (`model._metadata`) and private modules (`aimnet.models.utils.load_v1_model`).
+
+## Non-goals
+
+- A first-class ensemble-aggregation API (mean/std across members). Existing convention: 4 separate calculators, caller aggregates. Out of scope.
+- A new `aimnet.deployment` namespace. Top-level re-export of `load_v1_model` is sufficient for now.
+- HF-as-canonical-distribution policy. Both channels remain supported.
+- Migration of other families to the `hf_fallback` mechanism. Per-entry opt-in; only rxn declares it in this PR.
+- GCS upload of the produced `.pt` files. Performed manually by the maintainer; not a CI step.
+
+## Background — what the rxn JIT looks like
+
+Probed `_tmp/model_1.jpt` directly:
+
+- `cutoff = 5.0`; one `lrcoulomb` child module; no `dftd3` / `d3bj` / `d3ts`.
+- `afv.weight` shape `(64, 256)`. Rows 1–63 are **all populated** (no NaN, no all-zero). Only row 0 is zero (the placeholder index).
+- The existing four families (`aimnet2_wb97m_d3_0` etc.) NaN-pad unused rows: 49 NaN rows + 1 zero row + 14 trained rows. `extract_species` correctly returns the 14-element list.
+- For rxn, `extract_species` would return `[1..63]` — wrong. The true scope is `[1, 6, 7, 8]`.
+
+**Implication:** implemented species for rxn cannot be derived from `afv.weight`. It must be passed explicitly at conversion time.
+
+## Components
+
+### 1. Registry entries
+
+`aimnet/calculators/model_registry.yaml` gains four `aimnet2_rxn_{0..3}` entries and one alias `aimnet2rxn → aimnet2_rxn_0`. Each entry declares an `hf_fallback` block:
+
+```yaml
+aimnet2_rxn_0:
+    file: aimnet2_rxn_0.pt
+    url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
+    hf_fallback:
+        repo_id: isayevlab/aimnet2-rxn
+        ensemble_member: 0
+```
+
+`hf_fallback` is an optional, schema-additive field. Existing entries are untouched.
+
+### 2. Architecture YAML
+
+`aimnet/models/aimnet2_rxn.yaml` is a new file co-located with `aimnet2.yaml` and `aimnet2_dftd3_wb97m.yaml`. Its body matches the `model_yaml` already embedded in the per-member `.pt` metadata and in the HF `config.json`. The file lives in the upstream package so any future change to `aimnet.models.AIMNet2`'s constructor is caught at upstream PR time.
+
+### 3. `extract_species` — `sentinel="auto"`
+
+`aimnet/models/utils.py::extract_species` gains a keyword-only `sentinel` parameter:
+
+```python
+def extract_species(model: nn.Module, *, sentinel: str = "auto") -> list[int]:
+```
+
+Values:
+- `"nan"` — legacy: row is unused if all-NaN.
+- `"zero"` — row is unused if all-zero.
+- `"auto"` (new default) — row is unused if all-NaN OR all-zero.
+
+For the existing four families, `auto` returns the same set as `nan`. For aimnet2-rxn, `auto` still returns `[1..63]` (no row is empty by either criterion); the override below covers that case.
+
+### 4. `load_v1_model` — explicit species override + `.double()` ordering fix
+
+Two changes in `aimnet/models/utils.py::load_v1_model`:
+
+```python
+def load_v1_model(jpt_path, yaml_config_path, output_path=None, *,
+                  implemented_species: list[int] | None = None,
+                  verbose=True) -> tuple[nn.Module, dict]:
+    ...
+    if implemented_species is not None:
+        metadata["implemented_species"] = list(implemented_species)
+    else:
+        metadata["implemented_species"] = extract_species(jit_model)
+    ...
+```
+
+And the `.double()` block is reordered:
+
+```python
+# Cast atomic_shift to float64 BEFORE load_state_dict so the destination
+# can hold full precision when copy_ runs internally.
+if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
+    core_model.outputs.atomic_shift.double()
+
+load_result = core_model.load_state_dict(jit_sd, strict=False)
+# (drop the redundant .copy_ block — load_state_dict now preserves precision)
+```
+
+For current JIT models (atomic_shift is float32 in source), the numerical output is byte-identical. For any future JIT shipping float64 atomic_shift, precision is preserved.
+
+### 5. Calculator validation API
+
+The check goes in `aimnet/calculators/calculator.py::AIMNet2Calculator.eval` (the implementation `__call__` delegates to via `*args, **kwargs`). New parameter is keyword-only — existing `forces`/`stress`/`hessian` stay positional-OK so the HF README example `calc(data, forces=True)` and any existing positional callers are unaffected:
+
+```python
+def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
+         *, validate_species: bool = True) -> dict[str, Tensor]:
+    if validate_species:
+        impl = (self.metadata or {}).get("implemented_species") or []
+        if impl:
+            seen = {int(z) for z in data["numbers"].flatten().tolist() if int(z) > 0}
+            unsupported = sorted(seen - set(impl))
+            if unsupported:
+                raise ValueError(
+                    f"Atomic numbers {unsupported} are not in this model's "
+                    f"implemented_species {sorted(impl)}. Pass validate_species=False "
+                    f"to bypass (output will be undefined)."
+                )
+    data = self.prepare_input(data)
+    # ... existing forward path unchanged ...
+```
+
+`__call__` is the existing one-line `return self.eval(*args, **kwargs)`; the new kwarg flows through automatically. Default-on; silent no-op when the model didn't declare any species (older `.pt`, raw `nn.Module`); padding zeros are filtered out before the diff. The single `.flatten().tolist()` GPU→CPU sync fires once per call when enabled.
+
+### 6. Public API
+
+**6a. `AIMNet2Calculator.metadata` property** — a read-only view replacing the three internal `getattr(self.model, "_metadata", None)` reads at `calculator.py:284, 490, 515`. External consumers stop reaching into `model._metadata`:
+
+```python
+@property
+def metadata(self) -> dict | None:
+    return getattr(self.model, "_metadata", None)
+```
+
+**6b. Top-level re-export** in `aimnet/__init__.py`:
+
+```python
+from aimnet.models.utils import load_v1_model
+__all__ = ["__version__", "load_v1_model"]
+```
+
+External consumers write `from aimnet import load_v1_model` and pin to a release tag instead of reaching into a `utils` module.
+
+### 7. GCS → HF fallback
+
+New function in `aimnet/calculators/model_registry.py`:
+
+```python
+def load_model_with_fallback(name: str, device: str = "cpu") -> tuple[nn.Module, dict]:
+    registry = load_model_registry()
+    resolved = registry["aliases"].get(name, name)
+    entry = registry["models"].get(resolved)
+    if entry is None:
+        raise KeyError(f"Unknown model '{name}' (resolved to '{resolved}').")
+
+    try:
+        path = get_model_path(resolved)
+        return load_model(path, device=device)
+    except (urllib.error.URLError, urllib.error.HTTPError,
+            OSError, RuntimeError) as gcs_err:
+        fb = entry.get("hf_fallback")
+        if fb is None:
+            raise
+        warnings.warn(
+            f"GCS load failed for '{resolved}' ({gcs_err.__class__.__name__}: {gcs_err}); "
+            f"falling back to HF repo '{fb['repo_id']}' member {fb['ensemble_member']}.",
+            UserWarning, stacklevel=2,
+        )
+        from aimnet.calculators.hf_hub import load_from_hf_repo
+        return load_from_hf_repo(
+            fb["repo_id"],
+            ensemble_member=fb.get("ensemble_member", 0),
+            device=device,
+        )
+```
+
+`AIMNet2Calculator.__init__`'s non-HF branch (currently `calculator.py:277-280`) calls this in place of the direct `get_model_path` + `load_model` pair. The HF-repo-id branch (`isayevlab/aimnet2-rxn` as input) is unchanged.
+
+**Failure-mode boundary:**
+
+- **Caught (triggers fallback):** `URLError`/`HTTPError` (network down, 404, 5xx); `OSError` (corrupt cache); `RuntimeError` (`torch.load` on a bad file).
+- **Not caught:** `KeyError` (unknown model), `ImportError` (`huggingface_hub` not installed — re-raises with install hint), errors after a successful GCS load (those are real bugs).
+- **One warning per fallback.** No retry loop. No sticky state — next call retries GCS first.
+
+### 8. Conversion artifact
+
+`scripts/convert_aimnet2_rxn.py` — one-shot maintainer script. Reads `_tmp/model_{1..4}.jpt` + `_tmp/config.yaml`, calls `load_v1_model(..., implemented_species=[1, 6, 7, 8])`, writes `aimnet2_rxn_{0..3}.pt`. Not imported by package code; not part of the public API. Documented in the script's docstring with the GCS upload paths.
+
+The four `.pt` files for the initial GCS upload were already produced during this design session (sha256s in the conversion log) and bundled into `_tmp/aimnet2_rxn_v2_gcs.zip`.
+
+## Data flow
+
+**GCS path (default for registry-known names):**
+
+```
+"aimnet2rxn" → alias → "aimnet2_rxn_0"
+            → load_model_with_fallback
+            → get_model_path → ~/.cache/aimnet/aimnet2_rxn_0.pt (download from GCS if missing)
+            → load_model → (model, metadata)
+            → metadata.implemented_species = [1, 6, 7, 8]
+            → AIMNet2Calculator state set up
+```
+
+**HF path (explicit repo ID input):**
+
+```
+"isayevlab/aimnet2-rxn" → AIMNet2Calculator detects org/name pattern
+                       → load_from_hf_repo
+                       → snapshot_download (config.json + ensemble_<i>.safetensors)
+                       → build_module + load_state_dict
+                       → metadata.implemented_species = [1, 6, 7, 8]  (from config.json)
+                       → AIMNet2Calculator state set up
+```
+
+**Fallback path (GCS unreachable):**
+
+```
+"aimnet2rxn" → load_model_with_fallback
+            → get_model_path raises HTTPError
+            → entry has hf_fallback → warn + load_from_hf_repo("isayevlab/aimnet2-rxn", member=0)
+            → returns (model, metadata)
+```
+
+## Error handling
+
+| Condition | Behavior |
+| --- | --- |
+| Unknown model name | `KeyError` from `load_model_with_fallback` |
+| GCS down, no fallback declared | original `URLError`/`HTTPError` propagates |
+| GCS down, fallback declared, HF also down | `UserWarning` for the GCS failure, then HF exception propagates |
+| `huggingface_hub` not installed, fallback declared | `ImportError` with install hint |
+| Unsupported atomic numbers, `validate_species=True` | `ValueError` listing unsupported numbers and the supported set |
+| Unsupported atomic numbers, `validate_species=False` | undefined output (documented escape hatch) |
+| Model with no `implemented_species` field | validation is a silent no-op |
+
+## Testing
+
+| Concern | Test | File |
+| --- | --- | --- |
+| Registry alias resolves; .pt loads | `test_aimnet2_rxn_alias_resolves`, `test_aimnet2_rxn_pt_loads` | `tests/test_model_registry.py` |
+| Architecture YAML builds | `test_aimnet2_rxn_yaml_loads` | `tests/test_model.py` |
+| `extract_species(sentinel="auto")` | `test_extract_species_handles_zero_init`, `test_extract_species_handles_nan` | `tests/test_model.py` |
+| `load_v1_model` species override | `test_load_v1_model_species_override` (skipped if `_tmp/model_1.jpt` absent) | `tests/test_model.py` |
+| Calculator validates species | `test_calculator_rejects_unsupported_species`, `test_calculator_validate_species_false_bypasses` | `tests/test_calculator.py` |
+| `metadata` property | `test_calculator_metadata_property_round_trips` | `tests/test_calculator.py` |
+| Top-level re-export | `test_load_v1_model_importable_from_top` | `tests/test_model.py` |
+| `.double()` ordering | `test_load_v1_model_atomic_shift_is_float64` | `tests/test_model.py` |
+| Fallback on GCS failure | `test_load_model_with_fallback_uses_hf_on_failure` (monkeypatch `get_model_path` to raise) | `tests/test_model_registry.py` |
+| Fallback not declared | `test_load_model_with_fallback_propagates_when_no_fallback` | `tests/test_model_registry.py` |
+| HF end-to-end | `test_aimnet2_rxn_hf_load_matches_gcs` (network-gated `@pytest.mark.hf`) | `tests/test_hf_hub.py` |
+
+Network-gated tests use the existing `@pytest.mark.hf` marker (already excluded from CI). Tests requiring a JIT model gracefully `pytest.skip` when `_tmp/` is absent — fresh clones stay green.
+
+## Docs
+
+- `docs/models/aimnet2_rxn.md` — mirror of the HF model card at `https://huggingface.co/isayevlab/aimnet2-rxn`. The HF README is the canonical user-facing content (scope, energy convention, dispersion handling, dual-source loading, ensemble usage, the `compile_model=False` Hessian caveat, citation). The docs page is a copy maintained in sync with the HF README — no new authoring beyond a one-line "this model is also distributed via GCS as `aimnet2rxn`" addendum to make the dual-source story discoverable from the docs site.
+- `mkdocs.yml` nav — one entry pointing at the new page.
+
+No tutorial — existing `docs/tutorials/*.md` examples don't change.
+
+## Resolved facts grounded in the HF model card
+
+- **Element scope:** H, C, N, O — drives the `validate_species` `ValueError` content.
+- **Cutoff:** 5.0 Å — matches the JIT probe.
+- **Coulomb:** SR embedded ≤4.6 Å + external LR ≥4.6 Å. The 4.6 Å crossover is physically frozen (SR/LR cancellation point used during training); calculator must not let users alter `coulomb_sr_rc` for this family.
+- **Dispersion:** none added at inference. VV10 is baked into the ωB97M-V reference; `needs_dispersion: false` in `config.json`. No `external_dftd3` plumbing needed.
+- **Hessian / TS workflow:** requires `compile_model=False` (Dynamo + double-backward through GELU). The docs page surfaces this; no code change in this PR.
+- **Net charge:** zwitterions in scope; net anions/cations out of scope (calculator does not need a charge-validation guard for this PR).
+
+## Open assumptions to verify in implementation
+
+- Whether `AIMNet2ASE` and `AIMNet2Pysis` need their own `validate_species=` knob. Assumed: no for this PR; users disable by calling `AIMNet2Calculator` directly if needed.
+
+## Out-of-band tasks
+
+- Upload `aimnet2_rxn_{0..3}.pt` to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/`. Done by maintainer before merge so the registry URLs resolve.
+- Verify HF fallback works in the field by deleting the local GCS cache and running `AIMNet2Calculator("aimnet2rxn")` once.

--- a/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
+++ b/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
@@ -1,8 +1,6 @@
 # aimnet2-rxn Integration — Design Spec
 
-**Date:** 2026-04-25
-**Status:** Revised after multi-review (2 critical, 10 major, 5 minor findings addressed)
-**Scope:** One bundled PR registering the `aimnet2-rxn` model family in `aimnetcentral`, with the orthogonal cleanups required to make it correct end-to-end. Engineering speculation cut; chemistry safeguards added in their lightest form.
+**Date:** 2026-04-25 **Status:** Revised after multi-review (2 critical, 10 major, 5 minor findings addressed) **Scope:** One bundled PR registering the `aimnet2-rxn` model family in `aimnetcentral`, with the orthogonal cleanups required to make it correct end-to-end. Engineering speculation cut; chemistry safeguards added in their lightest form.
 
 ## Goal
 
@@ -43,12 +41,12 @@ Probed `_tmp/model_1.jpt` directly:
 
 ```yaml
 aimnet2_rxn_0:
-    file: aimnet2_rxn_0.pt
-    url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
+  file: aimnet2_rxn_0.pt
+  url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
 # _1, _2, _3 mirror with member index.
 
 aliases:
-    aimnet2rxn: aimnet2_rxn_0
+  aimnet2rxn: aimnet2_rxn_0
 ```
 
 No new YAML fields. No `hf_fallback` block (deferred — see Non-goals).

--- a/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
+++ b/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
@@ -1,26 +1,27 @@
 # aimnet2-rxn Integration — Design Spec
 
 **Date:** 2026-04-25
-**Status:** Approved (pending implementation plan)
-**Scope:** One bundled PR registering the `aimnet2-rxn` model family in `aimnetcentral`, with the orthogonal cleanups required to make it correct end-to-end.
+**Status:** Revised after multi-review (2 critical, 10 major, 5 minor findings addressed)
+**Scope:** One bundled PR registering the `aimnet2-rxn` model family in `aimnetcentral`, with the orthogonal cleanups required to make it correct end-to-end. Engineering speculation cut; chemistry safeguards added in their lightest form.
 
 ## Goal
 
-Land `aimnet2-rxn` as a first-class member of the model registry, available via two distribution channels:
+Land `aimnet2-rxn` as a first-class member of the model registry. The model is distributed via two channels:
 
-- **GCS** as `.pt` files at `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_{0..3}.pt`, loadable via `AIMNet2Calculator("aimnet2rxn")` (alias) or `AIMNet2Calculator("aimnet2_rxn_<i>")`.
-- **HF** as `safetensors` at `isayevlab/aimnet2-rxn`, loadable via `AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=<i>)`.
+- **GCS** as `.pt` files at `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_{0..3}.pt`, loaded via `AIMNet2Calculator("aimnet2rxn")` (alias) or `AIMNet2Calculator("aimnet2_rxn_<i>")`.
+- **HF** as `safetensors` at `isayevlab/aimnet2-rxn`, loaded via `AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=<i>)`. The HF path already works on `main` (verified).
 
-GCS load automatically falls back to HF if the GCS object cannot be retrieved or read.
+The two channels are independent. Users select per call; there is no automatic fallback.
 
-In the same PR, fix the upstream gaps that the rxn integration surfaced: the `extract_species` heuristic doesn't work for this model, the calculator silently produces undefined output for unsupported elements, the `load_v1_model` `.double()` call ordering is wrong, and external consumers reach into private attributes (`model._metadata`) and private modules (`aimnet.models.utils.load_v1_model`).
+In the same PR, fix the upstream gaps that the rxn integration surfaced (silent garbage on out-of-scope inputs, `.double()` ordering bug in `load_v1_model`, calculator's private-attribute coupling) and add the chemistry safeguards rxn requires (charge validation, AFV row sanitization, Coulomb-cutoff lock, cross-family mixing detection, Hessian + `torch.compile` interaction guard).
 
 ## Non-goals
 
-- A first-class ensemble-aggregation API (mean/std across members). Existing convention: 4 separate calculators, caller aggregates. Out of scope.
-- A new `aimnet.deployment` namespace. Top-level re-export of `load_v1_model` is sufficient for now.
+- A first-class ensemble-aggregation API (mean/std across members). Existing convention: 4 separate calculators, caller aggregates.
+- A new `aimnet.deployment` namespace; or a top-level re-export of `load_v1_model`. Both deferred until a real external consumer asks.
+- An `extract_species(sentinel="auto")` parameter. The `implemented_species` override on `load_v1_model` is sufficient for rxn; no other model in this PR benefits from a sentinel change.
+- A GCS→HF automatic fallback. The HF path already works for users who pass the repo ID directly; auto-fallback added significant code surface (broad exception catches, `hf_fallback` registry schema, lazy imports) for marginal benefit.
 - HF-as-canonical-distribution policy. Both channels remain supported.
-- Migration of other families to the `hf_fallback` mechanism. Per-entry opt-in; only rxn declares it in this PR.
 - GCS upload of the produced `.pt` files. Performed manually by the maintainer; not a CI step.
 
 ## Background — what the rxn JIT looks like
@@ -30,67 +31,70 @@ Probed `_tmp/model_1.jpt` directly:
 - `cutoff = 5.0`; one `lrcoulomb` child module; no `dftd3` / `d3bj` / `d3ts`.
 - `afv.weight` shape `(64, 256)`. Rows 1–63 are **all populated** (no NaN, no all-zero). Only row 0 is zero (the placeholder index).
 - The existing four families (`aimnet2_wb97m_d3_0` etc.) NaN-pad unused rows: 49 NaN rows + 1 zero row + 14 trained rows. `extract_species` correctly returns the 14-element list.
-- For rxn, `extract_species` would return `[1..63]` — wrong. The true scope is `[1, 6, 7, 8]`.
+- For rxn, `extract_species` returns `[1..63]` — wrong. The true scope is `[1, 6, 7, 8]`.
 
-**Implication:** implemented species for rxn cannot be derived from `afv.weight`. It must be passed explicitly at conversion time.
+**Implication:** implemented species for rxn cannot be derived from `afv.weight`. It must be passed explicitly at conversion time. Worse, the populated-but-untrained rows are a **chemistry footgun**: with `validate_species=False`, a user passing P (Z=15) gets numerically plausible nonsense from a populated AFV row, instead of an immediate NaN-poisoning. The conversion-time AFV sanitization (Component 5) addresses this by NaN-padding rows ∉ implemented_species, restoring the fail-fast property the other families have by construction.
 
 ## Components
 
 ### 1. Registry entries
 
-`aimnet/calculators/model_registry.yaml` gains four `aimnet2_rxn_{0..3}` entries and one alias `aimnet2rxn → aimnet2_rxn_0`. Each entry declares an `hf_fallback` block:
+`aimnet/calculators/model_registry.yaml` gains four `aimnet2_rxn_{0..3}` entries and one alias `aimnet2rxn → aimnet2_rxn_0`. Mirrors the schema of the four existing families exactly:
 
 ```yaml
 aimnet2_rxn_0:
     file: aimnet2_rxn_0.pt
     url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
-    hf_fallback:
-        repo_id: isayevlab/aimnet2-rxn
-        ensemble_member: 0
+# _1, _2, _3 mirror with member index.
+
+aliases:
+    aimnet2rxn: aimnet2_rxn_0
 ```
 
-`hf_fallback` is an optional, schema-additive field. Existing entries are untouched.
+No new YAML fields. No `hf_fallback` block (deferred — see Non-goals).
 
 ### 2. Architecture YAML
 
-`aimnet/models/aimnet2_rxn.yaml` is a new file co-located with `aimnet2.yaml` and `aimnet2_dftd3_wb97m.yaml`. Its body matches the `model_yaml` already embedded in the per-member `.pt` metadata and in the HF `config.json`. The file lives in the upstream package so any future change to `aimnet.models.AIMNet2`'s constructor is caught at upstream PR time.
+`aimnet/models/aimnet2_rxn.yaml` — co-located with `aimnet2.yaml` and `aimnet2_dftd3_wb97m.yaml`. Body matches the `model_yaml` already embedded in the per-member `.pt` metadata and in the HF `config.json`. No top-level extras (architecture-only); family-specific facts (`family`, `implemented_species`, `supports_charged_systems`) are passed at conversion time as explicit kwargs to `load_v1_model` and persisted to `.pt` metadata. Three copies of the architecture across `.pt` / HF `config.json` / upstream YAML is a known cost; the upstream copy is the tripwire that catches `aimnet.models.AIMNet2.__init__` signature drift at upstream PR time, before deploy.
 
-### 3. `extract_species` — `sentinel="auto"`
+### 3. `load_v1_model` — species override + AFV sanitization + family metadata + `.double()` fix
 
-`aimnet/models/utils.py::extract_species` gains a keyword-only `sentinel` parameter:
-
-```python
-def extract_species(model: nn.Module, *, sentinel: str = "auto") -> list[int]:
-```
-
-Values:
-- `"nan"` — legacy: row is unused if all-NaN.
-- `"zero"` — row is unused if all-zero.
-- `"auto"` (new default) — row is unused if all-NaN OR all-zero.
-
-For the existing four families, `auto` returns the same set as `nan`. For aimnet2-rxn, `auto` still returns `[1..63]` (no row is empty by either criterion); the override below covers that case.
-
-### 4. `load_v1_model` — explicit species override + `.double()` ordering fix
-
-Two changes in `aimnet/models/utils.py::load_v1_model`:
+Three changes in `aimnet/models/utils.py::load_v1_model`. The species override and AFV sanitization are coupled by design — declaring scope and enforcing scope happen in one call:
 
 ```python
 def load_v1_model(jpt_path, yaml_config_path, output_path=None, *,
                   implemented_species: list[int] | None = None,
+                  family: str | None = None,
+                  supports_charged_systems: bool | None = None,
                   verbose=True) -> tuple[nn.Module, dict]:
     ...
     if implemented_species is not None:
-        metadata["implemented_species"] = list(implemented_species)
+        species_set = set(implemented_species)
+        metadata["implemented_species"] = sorted(species_set)
+        # Sanitize AFV rows for elements outside the supported set: NaN-pad them
+        # so validate_species=False still produces NaN-propagating output instead
+        # of plausible-looking nonsense from populated-but-untrained rows.
+        afv = core_model.afv.weight.data
+        for z in range(1, afv.shape[0]):
+            if z not in species_set:
+                afv[z] = float("nan")
     else:
         metadata["implemented_species"] = extract_species(jit_model)
+
+    if family is not None:
+        metadata["family"] = family
+    if supports_charged_systems is not None:
+        metadata["supports_charged_systems"] = bool(supports_charged_systems)
     ...
 ```
 
-And the `.double()` block is reordered:
+All three new kwargs are keyword-only and default `None` — backward-compatible for the existing four families' conversions, which omit them and continue to use `extract_species(jit_model)` and no family/charge metadata. The HF `config.json` for rxn carries the same fields (`family`, `supports_charged_systems`) so both load paths produce equivalent metadata.
+
+`.double()` ordering fix (unchanged from review):
 
 ```python
-# Cast atomic_shift to float64 BEFORE load_state_dict so the destination
-# can hold full precision when copy_ runs internally.
+# Cast atomic_shift to float64 BEFORE load_state_dict so the destination can
+# hold full precision when copy_ runs internally.
 if hasattr(core_model, "outputs") and hasattr(core_model.outputs, "atomic_shift"):
     core_model.outputs.atomic_shift.double()
 
@@ -98,14 +102,14 @@ load_result = core_model.load_state_dict(jit_sd, strict=False)
 # (drop the redundant .copy_ block — load_state_dict now preserves precision)
 ```
 
-For current JIT models (atomic_shift is float32 in source), the numerical output is byte-identical. For any future JIT shipping float64 atomic_shift, precision is preserved.
+For current JIT models the numerical output is byte-identical (atomic_shift in source is float32). For any future float64 JIT, precision is preserved.
 
-### 5. Calculator validation API
+### 4. Calculator validation API
 
-The check goes in `aimnet/calculators/calculator.py::AIMNet2Calculator.eval` (the implementation `__call__` delegates to via `*args, **kwargs`). New parameter is keyword-only — existing `forces`/`stress`/`hessian` stay positional-OK so the HF README example `calc(data, forces=True)` and any existing positional callers are unaffected:
+In `aimnet/calculators/calculator.py::AIMNet2Calculator.eval` (where `__call__` delegates via `*args, **kwargs` at line 414). New parameter is keyword-only — existing `forces`/`stress`/`hessian` stay positional-OK so the HF README example `calc(data, forces=True)` keeps working:
 
 ```python
-def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
+def eval(self, data, forces=False, stress=False, hessian=False,
          *, validate_species: bool = True) -> dict[str, Tensor]:
     if validate_species:
         impl = (self.metadata or {}).get("implemented_species") or []
@@ -115,18 +119,58 @@ def eval(self, data: dict[str, Any], forces=False, stress=False, hessian=False,
             if unsupported:
                 raise ValueError(
                     f"Atomic numbers {unsupported} are not in this model's "
-                    f"implemented_species {sorted(impl)}. Pass validate_species=False "
-                    f"to bypass (output will be undefined)."
+                    f"implemented_species {sorted(impl)}. This model was trained on "
+                    f"a restricted element set; passing other elements yields undefined "
+                    f"output. For broader element coverage on equilibrium structures use "
+                    f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
+                    f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
                 )
+    # Charge guard — defensive for models that declare narrow charge support.
+    if validate_species:
+        meta = self.metadata or {}
+        if meta.get("supports_charged_systems") is False:
+            charge_val = float(data.get("charge", 0.0))
+            if abs(charge_val) > 1e-6:
+                raise ValueError(
+                    f"This model does not support net-charged systems "
+                    f"(got charge={charge_val}). Net-neutral zwitterions are supported. "
+                    f"For ions use `isayevlab/aimnet2-wb97m-d3`. "
+                    f"Pass validate_species=False to bypass."
+                )
+    # Hessian + torch.compile guard — fails fast instead of hanging.
+    if hessian and getattr(self, "_was_compiled", False):
+        raise RuntimeError(
+            "Hessian computation is incompatible with compile_model=True "
+            "(Dynamo + double-backward through GELU hangs). Reconstruct calculator "
+            "with compile_model=False."
+        )
     data = self.prepare_input(data)
     # ... existing forward path unchanged ...
 ```
 
-`__call__` is the existing one-line `return self.eval(*args, **kwargs)`; the new kwarg flows through automatically. Default-on; silent no-op when the model didn't declare any species (older `.pt`, raw `nn.Module`); padding zeros are filtered out before the diff. The single `.flatten().tolist()` GPU→CPU sync fires once per call when enabled.
+`__call__` is the existing one-line `return self.eval(*args, **kwargs)`; the new kwarg flows through automatically. The single `.flatten().tolist()` GPU→CPU sync fires once per call when validation is enabled.
 
-### 6. Public API
+`AIMNet2Calculator.__init__` sets `self._was_compiled = bool(compile_model)` so the Hessian guard has a flag to read.
 
-**6a. `AIMNet2Calculator.metadata` property** — a read-only view replacing the three internal `getattr(self.model, "_metadata", None)` reads at `calculator.py:284, 490, 515`. External consumers stop reaching into `model._metadata`:
+`rxn`-family `.pt` metadata declares `supports_charged_systems: false`. Other families do not declare the field; the guard is a silent no-op for them.
+
+### 5. ASE / Pysis wrapper propagation
+
+`AIMNet2ASE.calculate` and `AIMNet2Pysis.eval_orca` (or equivalent) gain a `validate_species: bool = True` kwarg that passes through to the underlying `AIMNet2Calculator.__call__`. Resolves the open-assumption footgun (a user hitting `ValueError` via ASE has no escape hatch). Two-line change per wrapper.
+
+### 6. `set_lrcoulomb_method` rxn-family guard
+
+`AIMNet2Calculator.set_lrcoulomb_method(method, cutoff=...)` (existing API at `calculator.py:601`) emits a `UserWarning` when `family == "rxn"` and the requested cutoff differs from `coulomb_sr_rc` (4.6 Å for rxn). The 4.6 Å SR/LR cancellation point is physically frozen for this family; replacing it silently breaks the matching. One-line check using `self.metadata`.
+
+### 7. Cross-family mixing detection
+
+`AIMNet2Calculator` gains a class-level `_constructed_families: ClassVar[set[str]] = set()`. The constructor records the loaded family. When `len(_constructed_families) > 1`, the constructor emits a one-time `UserWarning` per unique family addition explaining that energy scales differ across families (rxn uses a learned shifted-electronic scale; wb97m-d3 family uses absolute electronic energies on the −1100 eV scale). ~10 lines total.
+
+The warning fires on construction, not on `eval`, so the cost is paid once per calculator. Bypass: set `family = None` in metadata or set `os.environ["AIMNET_QUIET_FAMILY_MIX"] = "1"`.
+
+### 8. `metadata` property
+
+`AIMNet2Calculator.metadata` — read-only view replacing the `getattr(self.model, "_metadata", None)` reads at `calculator.py:490, 515`. Line 284 stays as `getattr` (it's inside `__init__` before the property is meaningful):
 
 ```python
 @property
@@ -134,61 +178,28 @@ def metadata(self) -> dict | None:
     return getattr(self.model, "_metadata", None)
 ```
 
-**6b. Top-level re-export** in `aimnet/__init__.py`:
+Externalises a stable accessor so downstream consumers (`aimnet-solvate`, `protonator`, `LoQI`) stop reaching into `model._metadata`.
+
+### 9. Conversion (no script artifact)
+
+The four `.pt` files are produced by a four-line example in `load_v1_model`'s docstring:
 
 ```python
-from aimnet.models.utils import load_v1_model
-__all__ = ["__version__", "load_v1_model"]
+>>> from aimnet.models.utils import load_v1_model
+>>> for i in range(4):
+...     load_v1_model(
+...         f"_tmp/model_{i+1}.jpt",
+...         "aimnet/models/aimnet2_rxn.yaml",
+...         output_path=f"aimnet2_rxn_{i}.pt",
+...         implemented_species=[1, 6, 7, 8],
+...         family="rxn",
+...         supports_charged_systems=False,
+...     )
 ```
 
-External consumers write `from aimnet import load_v1_model` and pin to a release tag instead of reaching into a `utils` module.
+No `scripts/convert_aimnet2_rxn.py` is added — single-use scripts in `scripts/` rot. The conversion is reproducible from the docstring + the `_tmp/` source files.
 
-### 7. GCS → HF fallback
-
-New function in `aimnet/calculators/model_registry.py`:
-
-```python
-def load_model_with_fallback(name: str, device: str = "cpu") -> tuple[nn.Module, dict]:
-    registry = load_model_registry()
-    resolved = registry["aliases"].get(name, name)
-    entry = registry["models"].get(resolved)
-    if entry is None:
-        raise KeyError(f"Unknown model '{name}' (resolved to '{resolved}').")
-
-    try:
-        path = get_model_path(resolved)
-        return load_model(path, device=device)
-    except (urllib.error.URLError, urllib.error.HTTPError,
-            OSError, RuntimeError) as gcs_err:
-        fb = entry.get("hf_fallback")
-        if fb is None:
-            raise
-        warnings.warn(
-            f"GCS load failed for '{resolved}' ({gcs_err.__class__.__name__}: {gcs_err}); "
-            f"falling back to HF repo '{fb['repo_id']}' member {fb['ensemble_member']}.",
-            UserWarning, stacklevel=2,
-        )
-        from aimnet.calculators.hf_hub import load_from_hf_repo
-        return load_from_hf_repo(
-            fb["repo_id"],
-            ensemble_member=fb.get("ensemble_member", 0),
-            device=device,
-        )
-```
-
-`AIMNet2Calculator.__init__`'s non-HF branch (currently `calculator.py:277-280`) calls this in place of the direct `get_model_path` + `load_model` pair. The HF-repo-id branch (`isayevlab/aimnet2-rxn` as input) is unchanged.
-
-**Failure-mode boundary:**
-
-- **Caught (triggers fallback):** `URLError`/`HTTPError` (network down, 404, 5xx); `OSError` (corrupt cache); `RuntimeError` (`torch.load` on a bad file).
-- **Not caught:** `KeyError` (unknown model), `ImportError` (`huggingface_hub` not installed — re-raises with install hint), errors after a successful GCS load (those are real bugs).
-- **One warning per fallback.** No retry loop. No sticky state — next call retries GCS first.
-
-### 8. Conversion artifact
-
-`scripts/convert_aimnet2_rxn.py` — one-shot maintainer script. Reads `_tmp/model_{1..4}.jpt` + `_tmp/config.yaml`, calls `load_v1_model(..., implemented_species=[1, 6, 7, 8])`, writes `aimnet2_rxn_{0..3}.pt`. Not imported by package code; not part of the public API. Documented in the script's docstring with the GCS upload paths.
-
-The four `.pt` files for the initial GCS upload were already produced during this design session (sha256s in the conversion log) and bundled into `_tmp/aimnet2_rxn_v2_gcs.zip`.
+**The four `.pt` files produced earlier in this design session DO NOT yet have AFV row sanitization or `family: rxn` metadata.** They need re-conversion under the revised spec before GCS upload. See "Out-of-band tasks" below.
 
 ## Data flow
 
@@ -196,11 +207,11 @@ The four `.pt` files for the initial GCS upload were already produced during thi
 
 ```
 "aimnet2rxn" → alias → "aimnet2_rxn_0"
-            → load_model_with_fallback
             → get_model_path → ~/.cache/aimnet/aimnet2_rxn_0.pt (download from GCS if missing)
             → load_model → (model, metadata)
-            → metadata.implemented_species = [1, 6, 7, 8]
-            → AIMNet2Calculator state set up
+            → metadata = {implemented_species: [1,6,7,8], family: "rxn",
+                          supports_charged_systems: false, coulomb_sr_rc: 4.6, ...}
+            → AIMNet2Calculator state set up; _constructed_families.add("rxn")
 ```
 
 **HF path (explicit repo ID input):**
@@ -210,70 +221,92 @@ The four `.pt` files for the initial GCS upload were already produced during thi
                        → load_from_hf_repo
                        → snapshot_download (config.json + ensemble_<i>.safetensors)
                        → build_module + load_state_dict
-                       → metadata.implemented_species = [1, 6, 7, 8]  (from config.json)
+                       → metadata read from config.json (must include the same
+                          family / supports_charged_systems fields — see below)
                        → AIMNet2Calculator state set up
 ```
 
-**Fallback path (GCS unreachable):**
-
-```
-"aimnet2rxn" → load_model_with_fallback
-            → get_model_path raises HTTPError
-            → entry has hf_fallback → warn + load_from_hf_repo("isayevlab/aimnet2-rxn", member=0)
-            → returns (model, metadata)
-```
+**HF config.json update (out-of-band):** the existing HF repo's `config.json` needs `family: "rxn"` and `supports_charged_systems: false` added so the HF path's safety nets match the GCS path's. One-time edit by maintainer; both paths converge.
 
 ## Error handling
 
 | Condition | Behavior |
 | --- | --- |
-| Unknown model name | `KeyError` from `load_model_with_fallback` |
-| GCS down, no fallback declared | original `URLError`/`HTTPError` propagates |
-| GCS down, fallback declared, HF also down | `UserWarning` for the GCS failure, then HF exception propagates |
-| `huggingface_hub` not installed, fallback declared | `ImportError` with install hint |
-| Unsupported atomic numbers, `validate_species=True` | `ValueError` listing unsupported numbers and the supported set |
-| Unsupported atomic numbers, `validate_species=False` | undefined output (documented escape hatch) |
+| Unknown model name | `KeyError` from `get_model_path` |
+| GCS down | `URLError`/`HTTPError` propagates. Workaround: pass `"isayevlab/aimnet2-rxn"` directly. |
+| Unsupported atomic numbers, `validate_species=True` | `ValueError` with chemistry context + alternative model pointers |
+| Unsupported atomic numbers, `validate_species=False` | NaN propagation from sanitized AFV rows (immediate NaN, not silent garbage) |
+| `charge != 0` on rxn (`supports_charged_systems: false`), `validate_species=True` | `ValueError` pointing at `aimnet2-wb97m-d3` |
+| `hessian=True` with `compile_model=True` | `RuntimeError` with reconstruct hint (instead of hanging) |
+| `set_lrcoulomb_method(cutoff != 4.6)` on rxn | `UserWarning` about SR/LR matching |
+| Two different families constructed in one process | `UserWarning` once about cross-family energy-scale incompatibility |
 | Model with no `implemented_species` field | validation is a silent no-op |
 
 ## Testing
 
 | Concern | Test | File |
 | --- | --- | --- |
-| Registry alias resolves; .pt loads | `test_aimnet2_rxn_alias_resolves`, `test_aimnet2_rxn_pt_loads` | `tests/test_model_registry.py` |
-| Architecture YAML builds | `test_aimnet2_rxn_yaml_loads` | `tests/test_model.py` |
-| `extract_species(sentinel="auto")` | `test_extract_species_handles_zero_init`, `test_extract_species_handles_nan` | `tests/test_model.py` |
-| `load_v1_model` species override | `test_load_v1_model_species_override` (skipped if `_tmp/model_1.jpt` absent) | `tests/test_model.py` |
-| Calculator validates species | `test_calculator_rejects_unsupported_species`, `test_calculator_validate_species_false_bypasses` | `tests/test_calculator.py` |
-| `metadata` property | `test_calculator_metadata_property_round_trips` | `tests/test_calculator.py` |
-| Top-level re-export | `test_load_v1_model_importable_from_top` | `tests/test_model.py` |
-| `.double()` ordering | `test_load_v1_model_atomic_shift_is_float64` | `tests/test_model.py` |
-| Fallback on GCS failure | `test_load_model_with_fallback_uses_hf_on_failure` (monkeypatch `get_model_path` to raise) | `tests/test_model_registry.py` |
-| Fallback not declared | `test_load_model_with_fallback_propagates_when_no_fallback` | `tests/test_model_registry.py` |
-| HF end-to-end | `test_aimnet2_rxn_hf_load_matches_gcs` (network-gated `@pytest.mark.hf`) | `tests/test_hf_hub.py` |
+| Registry alias resolves; `.pt` loads via calculator end-to-end | `test_aimnet2rxn_alias_calculator_e2e` | `tests/test_calculator.py` |
+| `load_v1_model` species override sanitizes AFV rows | `test_load_v1_model_species_override_nan_pads_other_rows` (uses `_tmp/model_1.jpt` if present, else `pytest.skip`) | `tests/test_model.py` |
+| Calculator rejects unsupported species; bypass works | `test_calculator_rejects_unsupported_species`, `test_calculator_validate_species_false_bypasses_with_nan_propagation` | `tests/test_calculator.py` |
+| Calculator rejects `charge != 0` for `supports_charged_systems: false` | `test_calculator_rejects_charged_input_for_rxn` | `tests/test_calculator.py` |
+| `hessian=True + compile_model=True` raises | `test_hessian_with_compile_raises` | `tests/test_calculator.py` |
+| `set_lrcoulomb_method(cutoff != 4.6)` on rxn warns | `test_set_lrcoulomb_method_warns_on_rxn_cutoff_change` | `tests/test_calculator.py` |
+| Cross-family construction warns once | `test_constructing_two_families_warns_once` | `tests/test_calculator.py` |
+| `.double()` ordering preserves precision (regression-only assertion) | folded into `test_load_v1_model_species_override_nan_pads_other_rows` | `tests/test_model.py` |
+| HF end-to-end (matches GCS metadata for rxn) | `test_aimnet2_rxn_hf_load_matches_gcs_metadata` (network-gated `@pytest.mark.hf`) | `tests/test_hf_hub.py` |
 
 Network-gated tests use the existing `@pytest.mark.hf` marker (already excluded from CI). Tests requiring a JIT model gracefully `pytest.skip` when `_tmp/` is absent — fresh clones stay green.
 
+Test count: **9** (down from 11 in the original spec). Cuts: `test_extract_species_handles_zero_init` (component dropped), `test_load_v1_model_importable_from_top` (component dropped), the two fallback tests (component dropped), the dedicated `metadata` property test (a one-line `@property` wrapping `getattr` does not need its own test — coverage from `test_aimnet2rxn_alias_calculator_e2e` is sufficient), the dedicated `.double()` test (folded into the species-override test). Adds: alias E2E, charge guard, Hessian+compile guard, Coulomb cutoff guard, family-mixing warn.
+
 ## Docs
 
-- `docs/models/aimnet2_rxn.md` — mirror of the HF model card at `https://huggingface.co/isayevlab/aimnet2-rxn`. The HF README is the canonical user-facing content (scope, energy convention, dispersion handling, dual-source loading, ensemble usage, the `compile_model=False` Hessian caveat, citation). The docs page is a copy maintained in sync with the HF README — no new authoring beyond a one-line "this model is also distributed via GCS as `aimnet2rxn`" addendum to make the dual-source story discoverable from the docs site.
-- `mkdocs.yml` nav — one entry pointing at the new page.
+`docs/models/aimnet2_rxn.md` — short stub page (≤30 lines):
+
+- One-line description of scope (H/C/N/O closed-shell organic reactions).
+- The two load snippets (`AIMNet2Calculator("aimnet2rxn")` and `AIMNet2Calculator("isayevlab/aimnet2-rxn")`).
+- The list of safety nets the calculator enforces for this family (so users know what protections they have without reading the code).
+- A canonical link to the HF model card (`https://huggingface.co/isayevlab/aimnet2-rxn`) for full content (energy convention, training data, citation, full limitations list).
+
+No mirroring. The HF README is the canonical user-facing copy; duplicating it in repo docs would drift within a release cycle.
+
+`mkdocs.yml` nav — one entry pointing at the new page.
 
 No tutorial — existing `docs/tutorials/*.md` examples don't change.
 
 ## Resolved facts grounded in the HF model card
 
-- **Element scope:** H, C, N, O — drives the `validate_species` `ValueError` content.
-- **Cutoff:** 5.0 Å — matches the JIT probe.
-- **Coulomb:** SR embedded ≤4.6 Å + external LR ≥4.6 Å. The 4.6 Å crossover is physically frozen (SR/LR cancellation point used during training); calculator must not let users alter `coulomb_sr_rc` for this family.
-- **Dispersion:** none added at inference. VV10 is baked into the ωB97M-V reference; `needs_dispersion: false` in `config.json`. No `external_dftd3` plumbing needed.
-- **Hessian / TS workflow:** requires `compile_model=False` (Dynamo + double-backward through GELU). The docs page surfaces this; no code change in this PR.
-- **Net charge:** zwitterions in scope; net anions/cations out of scope (calculator does not need a charge-validation guard for this PR).
+Each fact below is enforced in code unless marked **(documented only)**:
 
-## Open assumptions to verify in implementation
+- **Element scope:** H, C, N, O. Enforced via `validate_species` (Component 4) AND AFV row NaN-padding at conversion time (Component 3).
+- **Net charge:** zwitterions in scope; net anions/cations out of scope. Enforced via `supports_charged_systems: false` metadata + charge guard in `eval` (Component 4).
+- **Coulomb crossover:** 4.6 Å SR/LR cancellation point physically frozen. Enforced via `set_lrcoulomb_method` warning (Component 6).
+- **Cross-family energy-scale mixing:** rxn uses a learned shifted-electronic scale (~few eV for methane); wb97m-d3 family uses absolute electronic energies (~−1100 eV). Detected via `_constructed_families` warning (Component 7).
+- **Hessian + `torch.compile`:** Dynamo + double-backward through GELU hangs. Enforced via `RuntimeError` in `eval` when `hessian=True` and `_was_compiled=True` (Component 4).
+- **Cutoff:** 5.0 Å — matches the JIT probe. Read from `.pt` metadata; no code-level enforcement needed (the value is data, not a contract).
+- **Dispersion:** none added at inference. VV10 baked into ωB97M-V; `needs_dispersion: false` in metadata. The existing calculator code respects this cleanly (`external_dftd3` is not constructed when `needs_dispersion=False`); confirmed during review. **(no-op — no change required)**
 
-- Whether `AIMNet2ASE` and `AIMNet2Pysis` need their own `validate_species=` knob. Assumed: no for this PR; users disable by calling `AIMNet2Calculator` directly if needed.
+## Open assumptions
+
+None remaining. The ASE/Pysis `validate_species` propagation is now Component 5.
 
 ## Out-of-band tasks
 
-- Upload `aimnet2_rxn_{0..3}.pt` to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/`. Done by maintainer before merge so the registry URLs resolve.
-- Verify HF fallback works in the field by deleting the local GCS cache and running `AIMNet2Calculator("aimnet2rxn")` once.
+- **Re-convert the four `.pt` files** under the revised `load_v1_model` (with `implemented_species=[1,6,7,8]`, `family="rxn"`, `supports_charged_systems=False`, AFV sanitization). The files produced earlier in this design session (`_tmp/aimnet2_rxn_v2_gcs.zip`, sha256 `beca299c…`) are stale relative to the revised spec.
+- **Update the HF repo's `config.json`** to add `family: "rxn"` and `supports_charged_systems: false`, so the HF path enforces the same safeguards as the GCS path.
+- **Upload the re-converted `.pt` files** to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/`.
+
+## Architectural note (deferred decision)
+
+The architect-reviewer recommended splitting this PR into two: PR-A (registration-only: registry, YAML, `load_v1_model` overrides, conversion, docs) and PR-B (cleanups: validation, metadata property, ASE/Pysis propagation, the four chemistry safeguards). The user's chosen approach is bundled (Approach A from brainstorming). The bundle is now smaller after the multi-review cuts; if reviewer load proves blocking, splitting per the architect's suggestion is a clean fallback.
+
+## Revisions from multi-review
+
+Removed (engineering speculation, no current consumer): `extract_species(sentinel="auto")`, top-level `load_v1_model` re-export, GCS→HF auto-fallback (with its registry schema, lazy import, broad exception catch), `scripts/convert_aimnet2_rxn.py`, docs page mirroring of the HF README.
+
+Added (chemistry safety, smallest viable form): AFV row NaN-padding at conversion (Critical — fail-fast for `validate_species=False`), `supports_charged_systems` charge guard (Critical — silent garbage on ions), `set_lrcoulomb_method` cutoff guard (Major — SR/LR matching), cross-family mixing warning (Major — energy scale incompatibility), Hessian + `torch.compile` raise instead of hang (Minor — silent process hang), improved `validate_species` error message with alternative-model pointers (Major).
+
+Fixed: clarified that `metadata` property replaces `getattr` only at lines 490/515 (line 284 keeps `getattr`); added the alias-end-to-end test that was missing; resolved the ASE/Pysis open assumption inline as Component 5.
+
+Net effect: spec is leaner (8 tests vs 11; 9 components vs 8 components but each smaller), more correct (chemistry safeguards close 4 silent-failure modes), and avoids 3 over-engineered features that had no concrete consumer.

--- a/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
+++ b/docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md
@@ -90,6 +90,26 @@ def load_v1_model(jpt_path, yaml_config_path, output_path=None, *,
 
 All three new kwargs are keyword-only and default `None` — backward-compatible for the existing four families' conversions, which omit them and continue to use `extract_species(jit_model)` and no family/charge metadata. The HF `config.json` for rxn carries the same fields (`family`, `supports_charged_systems`) so both load paths produce equivalent metadata.
 
+**Schema propagation (mandatory companion change):** `aimnet/models/base.py::ModelMetadata` (TypedDict) and `load_model` (which constructs the dict and assigns it to `model._metadata`) silently drop unknown fields. Two additions are required so the calculator can actually read `family` and `supports_charged_systems`:
+
+```python
+class ModelMetadata(TypedDict):
+    ...
+    implemented_species: list[int]
+    family: NotRequired[str | None]                       # NEW
+    supports_charged_systems: NotRequired[bool | None]    # NEW
+
+# Inside load_model's v2-format branch:
+metadata: ModelMetadata = {
+    ...
+    "implemented_species": data.get("implemented_species", []),
+    "family": data.get("family"),
+    "supports_charged_systems": data.get("supports_charged_systems"),
+}
+```
+
+The same two-line addition goes into `aimnet/calculators/hf_hub.py::load_from_hf_repo` where it constructs its `ModelMetadata`. Both load paths converge on equivalent metadata for rxn.
+
 `.double()` ordering fix (unchanged from review):
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
           - AIMNet2-2025: models/aimnet2_2025.md
           - AIMNet2-NSE: models/aimnet2nse.md
           - AIMNet2-Pd: models/aimnet2pd.md
+          - AIMNet2-rxn: models/aimnet2_rxn.md
     - Tutorials:
           - First Calculation: tutorials/single_point.md
           - Geometry Optimization: tutorials/geometry_optimization.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ include = [
 "aimnet/calculators/model_registry.yaml" = "aimnet/calculators/model_registry.yaml"
 "aimnet/models/aimnet2.yaml" = "aimnet/models/aimnet2.yaml"
 "aimnet/models/aimnet2_dftd3_wb97m.yaml" = "aimnet/models/aimnet2_dftd3_wb97m.yaml"
+"aimnet/models/aimnet2_rxn.yaml" = "aimnet/models/aimnet2_rxn.yaml"
 "aimnet/train/default_train.yaml" = "aimnet/train/default_train.yaml"
 
 # UV configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ markers = [
     "ase: marks tests that require ASE (deselect with: -m 'not ase')",
     "gpu: marks tests that require GPU/CUDA (deselect with: -m 'not gpu')",
     "hf: marks tests that require Hugging Face extras (deselect with: -m 'not hf')",
+    "network: marks tests that hit external services (deselect with: -m 'not network')",
     "pysis: marks tests that require PySisyphus (deselect with: -m 'not pysis')",
     "train: marks tests that require training dependencies (deselect with: -m 'not train')",
 ]

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -445,12 +445,13 @@ def test_aimnet2ase_propagates_validate_species(monkeypatch):
     """AIMNet2ASE.calculate(..., validate_species=False) must propagate the kwarg
     through to the underlying AIMNet2Calculator.__call__."""
     from ase import Atoms
+
     from aimnet.calculators.aimnet2ase import AIMNet2ASE
 
     calc = AIMNet2ASE("aimnet2")
     # H2O — only H, O which are supported. Use validate_species=False to verify the
     # kwarg flows through (the call should succeed regardless).
-    atoms = Atoms("H2O", positions=[[0,0,0],[0,0,1],[0,1,0]])
+    atoms = Atoms("H2O", positions=[[0, 0, 0], [0, 0, 1], [0, 1, 0]])
     atoms.calc = calc
 
     # Fast path: just access energy. This exercises the full pipeline.

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -438,3 +438,24 @@ class TestAtomsInfoChargeSpin:
         atoms.get_potential_energy()
 
         assert atoms.calc.charge == 1.0
+
+
+@pytest.mark.ase
+def test_aimnet2ase_propagates_validate_species(monkeypatch):
+    """AIMNet2ASE.calculate(..., validate_species=False) must propagate the kwarg
+    through to the underlying AIMNet2Calculator.__call__."""
+    from ase import Atoms
+    from aimnet.calculators.aimnet2ase import AIMNet2ASE
+
+    calc = AIMNet2ASE("aimnet2")
+    # H2O — only H, O which are supported. Use validate_species=False to verify the
+    # kwarg flows through (the call should succeed regardless).
+    atoms = Atoms("H2O", positions=[[0,0,0],[0,0,1],[0,1,0]])
+    atoms.calc = calc
+
+    # Fast path: just access energy. This exercises the full pipeline.
+    _ = atoms.get_potential_energy()  # baseline default validate_species=True
+    # Re-run with the explicit kwarg via the constructor escape hatch:
+    calc2 = AIMNet2ASE("aimnet2", validate_species=False)
+    atoms.calc = calc2
+    _ = atoms.get_potential_energy()

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -997,3 +997,21 @@ def test_relative_path_with_slash_loads_correctly(tmp_path, monkeypatch):
     calc = AIMNet2Calculator("mymodels/aimnet2.pt")
     assert hasattr(calc, "model")
     assert calc.cutoff > 0
+
+
+def test_calculator_metadata_property_returns_model_metadata():
+    """AIMNet2Calculator.metadata must return the same dict as model._metadata."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    assert calc.metadata is calc.model._metadata
+    # Existing aimnet2 family declares neither family nor supports_charged_systems.
+    assert calc.metadata.get("family") is None
+    assert calc.metadata.get("supports_charged_systems") is None
+
+
+def test_calculator_was_compiled_flag_default_false():
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    assert calc._was_compiled is False

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1075,3 +1075,23 @@ def test_calculator_rejects_charged_input_when_unsupported(monkeypatch):
 
     # Bypass works
     calc(data, validate_species=False)
+
+
+def test_hessian_with_compile_raises():
+    """Calling with hessian=True on a calculator constructed with compile_model=True
+    must raise RuntimeError instead of hanging (Dynamo + double-backward on GELU)."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # Don't actually torch.compile (slow + may need GPU); just flip the flag.
+    calc._was_compiled = True
+
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    with pytest.raises(RuntimeError, match=r"Hessian computation is incompatible with compile_model=True"):
+        calc(data, hessian=True)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1095,3 +1095,35 @@ def test_hessian_with_compile_raises():
 
     with pytest.raises(RuntimeError, match=r"Hessian computation is incompatible with compile_model=True"):
         calc(data, hessian=True)
+
+
+def test_set_lrcoulomb_method_warns_on_rxn_cutoff_change():
+    """For family='rxn', changing the coulomb cutoff away from coulomb_sr_rc
+    (4.6 A) must emit a UserWarning about SR/LR matching."""
+    import pytest
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata["family"] = "rxn"
+    calc.model._metadata["coulomb_sr_rc"] = 4.6
+
+    with pytest.warns(UserWarning, match=r"SR/LR"):
+        calc.set_lrcoulomb_method("dsf", cutoff=10.0)
+
+
+def test_set_lrcoulomb_method_no_warn_on_matching_cutoff():
+    """No warning when cutoff matches coulomb_sr_rc, or for non-rxn families."""
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    # Non-rxn family: never warn about SR/LR.
+    calc1 = AIMNet2Calculator("aimnet2", device="cpu")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        calc1.set_lrcoulomb_method("dsf", cutoff=10.0)
+    sr_lr_warnings = [w for w in caught if "SR/LR" in str(w.message)]
+    assert sr_lr_warnings == []

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1077,6 +1077,30 @@ def test_calculator_rejects_charged_input_when_unsupported(monkeypatch):
     calc(data, validate_species=False)
 
 
+def test_calculator_charge_guard_handles_batched_charges():
+    """Batched 1-d charge tensors (e.g. per-system in batched-NEB) must raise the
+    documented chemistry ValueError — NOT the misleading 'only one element
+    tensors can be converted...' RuntimeError that the old `float(tensor)` path
+    produced for multi-element tensors."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata["supports_charged_systems"] = False
+
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    # Batched: two systems, one neutral one anionic. The guard must raise the
+    # documented ValueError (not a generic float() RuntimeError on multi-element).
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor([0.0, -1.0])}
+
+    with pytest.raises(ValueError, match=r"net-charged systems"):
+        calc(data)
+
+
 def test_hessian_with_compile_raises():
     """Calling with hessian=True on a calculator constructed with compile_model=True
     must raise RuntimeError instead of hanging (Dynamo + double-backward on GELU)."""

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1127,3 +1127,34 @@ def test_set_lrcoulomb_method_no_warn_on_matching_cutoff():
         calc1.set_lrcoulomb_method("dsf", cutoff=10.0)
     sr_lr_warnings = [w for w in caught if "SR/LR" in str(w.message)]
     assert sr_lr_warnings == []
+
+
+def test_constructing_two_families_warns_once(monkeypatch):
+    """Constructing calculators from two different families in one process must
+    emit a UserWarning about energy-scale incompatibility."""
+    import pytest
+    import warnings
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    # Reset the class-level set so test order does not pollute it.
+    AIMNet2Calculator._constructed_families.clear()
+    monkeypatch.delenv("AIMNET_QUIET_FAMILY_MIX", raising=False)
+
+    # First calculator: synthetic 'family-A'.
+    calc_a = AIMNet2Calculator("aimnet2", device="cpu")
+    calc_a.model._metadata = dict(calc_a.model._metadata)
+    calc_a.model._metadata["family"] = "family-A"
+    AIMNet2Calculator._constructed_families.add("family-A")  # mimic what __init__ does
+
+    # Second calculator: a different family — should warn.
+    with pytest.warns(UserWarning, match=r"different families"):
+        calc_b = AIMNet2Calculator("aimnet2", device="cpu")
+        # The constructor itself must add the (synthetic) family. Since we cannot
+        # change metadata before __init__ finishes, simulate by constructing then
+        # injecting+re-running the warn step. For this PR's purposes the warn
+        # logic lives in __init__ AFTER load. Test it by direct invocation:
+        calc_b.model._metadata = dict(calc_b.model._metadata)
+        calc_b.model._metadata["family"] = "family-B"
+        # Call the production helper that __init__ calls (see Step 3).
+        calc_b._maybe_warn_family_mix("family-B")

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1015,3 +1015,39 @@ def test_calculator_was_compiled_flag_default_false():
 
     calc = AIMNet2Calculator("aimnet2", device="cpu")
     assert calc._was_compiled is False
+
+
+def test_calculator_rejects_unsupported_species():
+    """Calling the calculator with an unsupported atomic number must raise ValueError
+    with chemistry context and pointers to alternative models."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # aimnet2's implemented_species does NOT include Z=92 (uranium).
+    coords = torch.tensor([[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]])
+    numbers = torch.tensor([1, 92])  # H + U; U is unsupported
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    with pytest.raises(ValueError, match=r"implemented_species"):
+        calc(data)
+
+
+def test_calculator_validate_species_false_bypasses():
+    """Passing validate_species=False must skip the species check (no ValueError)."""
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # H is supported by aimnet2, so this should not raise even without bypass;
+    # the test asserts the kwarg flows through and does not itself raise.
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    # Both calls should succeed; validate_species=False is the explicit bypass path.
+    calc(data, validate_species=True)
+    calc(data, validate_species=False)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1158,3 +1158,30 @@ def test_constructing_two_families_warns_once(monkeypatch):
         calc_b.model._metadata["family"] = "family-B"
         # Call the production helper that __init__ calls (see Step 3).
         calc_b._maybe_warn_family_mix("family-B")
+
+
+@pytest.mark.network
+def test_aimnet2rxn_alias_calculator_e2e():
+    """Alias 'aimnet2rxn' must resolve through the registry, the .pt must load,
+    and the calculator must expose rxn-specific metadata fields."""
+    import urllib.error
+
+    import requests
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    try:
+        calc = AIMNet2Calculator("aimnet2rxn", device="cpu")
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        requests.exceptions.HTTPError,
+        requests.exceptions.ConnectionError,
+    ) as e:
+        pytest.skip(f"GCS .pt for aimnet2rxn not yet uploaded: {e}")
+
+    assert calc.metadata is not None
+    assert calc.metadata.get("family") == "rxn"
+    assert calc.metadata.get("supports_charged_systems") is False
+    assert calc.metadata.get("implemented_species") == [1, 6, 7, 8]
+    assert abs(calc.metadata.get("cutoff") - 5.0) < 1e-6

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1124,8 +1124,8 @@ def test_hessian_with_compile_raises():
 def test_set_lrcoulomb_method_warns_on_rxn_cutoff_change():
     """For family='rxn', changing the coulomb cutoff away from coulomb_sr_rc
     (4.6 A) must emit a UserWarning about SR/LR matching."""
+
     import pytest
-    import warnings
 
     from aimnet.calculators import AIMNet2Calculator
 
@@ -1156,8 +1156,8 @@ def test_set_lrcoulomb_method_no_warn_on_matching_cutoff():
 def test_constructing_two_families_warns_once(monkeypatch):
     """Constructing calculators from two different families in one process must
     emit a UserWarning about energy-scale incompatibility."""
+
     import pytest
-    import warnings
 
     from aimnet.calculators import AIMNet2Calculator
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1051,3 +1051,27 @@ def test_calculator_validate_species_false_bypasses():
     # Both calls should succeed; validate_species=False is the explicit bypass path.
     calc(data, validate_species=True)
     calc(data, validate_species=False)
+
+
+def test_calculator_rejects_charged_input_when_unsupported(monkeypatch):
+    """When metadata declares supports_charged_systems=False, a non-zero charge raises."""
+    import pytest
+    import torch
+
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    # Synthetically inject the family-narrowing metadata (aimnet2 does not declare it
+    # natively; this mirrors what an aimnet2-rxn .pt would carry).
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata["supports_charged_systems"] = False
+
+    coords = torch.tensor([[0.0, 0.0, 0.0]])
+    numbers = torch.tensor([1])
+    data = {"coord": coords, "numbers": numbers, "charge": torch.tensor(-1.0)}
+
+    with pytest.raises(ValueError, match=r"net-charged systems"):
+        calc(data)
+
+    # Bypass works
+    calc(data, validate_species=False)

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -106,3 +106,45 @@ def test_calculator_with_hf_repo(fake_hf_repo):
     assert "forces" in results
     assert "charges" in results
     assert results["forces"].shape == (5, 3)
+
+
+@pytest.fixture
+def fake_hf_repo_with_family(tmp_path):
+    """A fake HF repo whose config.json declares family + supports_charged_systems."""
+    from aimnet.calculators.model_registry import get_model_path
+
+    pt_path = get_model_path("aimnet2")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", ".*weights_only.*")
+        raw = torch.load(pt_path, map_location="cpu", weights_only=False)
+
+    state_dict = raw["state_dict"]
+    save_file(state_dict, str(tmp_path / "ensemble_0.safetensors"))
+
+    config = {
+        "config_schema_version": 1,
+        "family_name": "fake-family",
+        "ensemble_size": 1,
+        "member_names": ["fake_0"],
+        "cutoff": float(raw["cutoff"]),
+        "needs_coulomb": raw.get("needs_coulomb", False),
+        "needs_dispersion": raw.get("needs_dispersion", False),
+        "coulomb_mode": raw.get("coulomb_mode", "none"),
+        "implemented_species": raw.get("implemented_species", []),
+        "model_yaml": raw["model_yaml"],
+        "format_version": 2,
+        "coulomb_sr_rc": raw.get("coulomb_sr_rc"),
+        "coulomb_sr_envelope": raw.get("coulomb_sr_envelope"),
+        "has_embedded_lr": raw.get("has_embedded_lr", False),
+        # NEW fields under test:
+        "family": "test-family",
+        "supports_charged_systems": False,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    return tmp_path
+
+
+def test_load_from_hf_repo_propagates_family_and_charge_fields(fake_hf_repo_with_family):
+    _, metadata = load_from_hf_repo(str(fake_hf_repo_with_family), ensemble_member=0, device="cpu")
+    assert metadata.get("family") == "test-family"
+    assert metadata.get("supports_charged_systems") is False

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -148,3 +148,31 @@ def test_load_from_hf_repo_propagates_family_and_charge_fields(fake_hf_repo_with
     _, metadata = load_from_hf_repo(str(fake_hf_repo_with_family), ensemble_member=0, device="cpu")
     assert metadata.get("family") == "test-family"
     assert metadata.get("supports_charged_systems") is False
+
+
+@pytest.mark.hf
+def test_aimnet2_rxn_hf_load_matches_gcs_metadata():
+    """Loading aimnet2-rxn from the HF repo must produce metadata equivalent
+    to what the GCS .pt path would produce: same implemented_species, cutoff,
+    family, and supports_charged_systems.
+
+    This test EXPECTS the HF repo's config.json to have been updated with
+    `family: rxn` and `supports_charged_systems: false` (out-of-band task)."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0, device="cpu")
+
+    assert calc.metadata.get("implemented_species") == [1, 6, 7, 8]
+    assert abs(calc.metadata.get("cutoff") - 5.0) < 1e-6
+    assert calc.metadata.get("coulomb_mode") == "sr_embedded"
+    assert calc.metadata.get("needs_coulomb") is True
+    assert calc.metadata.get("needs_dispersion") is False
+
+    # The next two assertions REQUIRE the HF config.json to have the new fields.
+    # If they fail with None, the maintainer needs to update the HF config.json.
+    assert calc.metadata.get("family") == "rxn", (
+        "HF config.json missing `family: rxn` — maintainer must update HF repo."
+    )
+    assert calc.metadata.get("supports_charged_systems") is False, (
+        "HF config.json missing `supports_charged_systems: false` — maintainer must update HF repo."
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -510,18 +510,18 @@ class TestNewFormat:
 def test_model_metadata_typeddict_includes_family_and_charge_fields():
     """ModelMetadata must declare family and supports_charged_systems as optional fields."""
     from typing import get_type_hints
+
     from aimnet.models.base import ModelMetadata
 
     hints = get_type_hints(ModelMetadata, include_extras=False)
     assert "family" in hints, "ModelMetadata missing 'family' field"
-    assert "supports_charged_systems" in hints, (
-        "ModelMetadata missing 'supports_charged_systems' field"
-    )
+    assert "supports_charged_systems" in hints, "ModelMetadata missing 'supports_charged_systems' field"
 
 
 def test_load_model_propagates_family_and_charge_fields(tmp_path):
     """load_model must include family/supports_charged_systems in metadata when present in .pt."""
     import torch
+
     from aimnet.calculators.model_registry import get_model_path
     from aimnet.models.base import load_model
 
@@ -607,6 +607,7 @@ def test_load_v1_model_without_overrides_is_backward_compatible():
 def test_aimnet2_rxn_yaml_builds():
     """The architecture YAML for aimnet2-rxn must be loadable and produce a real AIMNet2 module."""
     import importlib.resources
+
     import yaml
 
     from aimnet.config import build_module

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -517,3 +517,23 @@ def test_model_metadata_typeddict_includes_family_and_charge_fields():
     assert "supports_charged_systems" in hints, (
         "ModelMetadata missing 'supports_charged_systems' field"
     )
+
+
+def test_load_model_propagates_family_and_charge_fields(tmp_path):
+    """load_model must include family/supports_charged_systems in metadata when present in .pt."""
+    import torch
+    from aimnet.calculators.model_registry import get_model_path
+    from aimnet.models.base import load_model
+
+    # Take the existing aimnet2 .pt as a template; add the new fields; save; reload.
+    src = get_model_path("aimnet2")
+    raw = torch.load(src, map_location="cpu", weights_only=False)
+    raw["family"] = "test-family"
+    raw["supports_charged_systems"] = False
+
+    out = tmp_path / "with_family.pt"
+    torch.save(raw, str(out))
+
+    _, metadata = load_model(str(out), device="cpu")
+    assert metadata.get("family") == "test-family"
+    assert metadata.get("supports_charged_systems") is False

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -505,3 +505,15 @@ class TestNewFormat:
         # Verify shape is now (64, 2)
         assert module.disp_param0.shape == (64, 2)
         assert torch.allclose(module.disp_param0, disp_params)
+
+
+def test_model_metadata_typeddict_includes_family_and_charge_fields():
+    """ModelMetadata must declare family and supports_charged_systems as optional fields."""
+    from typing import get_type_hints
+    from aimnet.models.base import ModelMetadata
+
+    hints = get_type_hints(ModelMetadata, include_extras=False)
+    assert "family" in hints, "ModelMetadata missing 'family' field"
+    assert "supports_charged_systems" in hints, (
+        "ModelMetadata missing 'supports_charged_systems' field"
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -537,3 +537,69 @@ def test_load_model_propagates_family_and_charge_fields(tmp_path):
     _, metadata = load_model(str(out), device="cpu")
     assert metadata.get("family") == "test-family"
     assert metadata.get("supports_charged_systems") is False
+
+
+def test_load_v1_model_species_override_nan_pads_other_rows():
+    """load_v1_model with implemented_species override must NaN-pad AFV rows
+    for elements outside the supported set, write family/supports_charged_systems
+    to metadata, AND keep atomic_shift in float64 (regression on .double() ordering)."""
+    import math
+    from pathlib import Path
+
+    import pytest
+    import torch
+
+    src_jpt = Path("_tmp/model_1.jpt")
+    src_yaml = Path("_tmp/config.yaml")
+    if not src_jpt.exists() or not src_yaml.exists():
+        pytest.skip("aimnet2-rxn JIT source not available in _tmp/; skipping override test")
+
+    from aimnet.models.utils import load_v1_model
+
+    species = [1, 6, 7, 8]
+    model, metadata = load_v1_model(
+        str(src_jpt),
+        str(src_yaml),
+        output_path=None,
+        implemented_species=species,
+        family="rxn",
+        supports_charged_systems=False,
+        verbose=False,
+    )
+
+    assert metadata["implemented_species"] == species
+    assert metadata.get("family") == "rxn"
+    assert metadata.get("supports_charged_systems") is False
+
+    afv = model.afv.weight.data
+    species_set = set(species)
+    for z in range(1, afv.shape[0]):
+        row = afv[z]
+        if z in species_set:
+            assert not torch.isnan(row).any(), f"row {z} (in species) must not be NaN"
+        else:
+            assert torch.isnan(row).all(), f"row {z} (out of species) must be all-NaN"
+
+    # .double() ordering regression: atomic_shift dtype is float64.
+    assert hasattr(model, "outputs") and hasattr(model.outputs, "atomic_shift")
+    assert model.outputs.atomic_shift.shifts.weight.dtype == torch.float64
+
+
+def test_load_v1_model_without_overrides_is_backward_compatible():
+    """Existing four families' conversions must still work when the new kwargs are omitted."""
+    from pathlib import Path
+
+    import pytest
+
+    src_jpt = Path("_tmp/model_1.jpt")
+    src_yaml = Path("_tmp/config.yaml")
+    if not src_jpt.exists() or not src_yaml.exists():
+        pytest.skip("JIT source not available")
+
+    from aimnet.models.utils import load_v1_model
+
+    _, metadata = load_v1_model(str(src_jpt), str(src_yaml), output_path=None, verbose=False)
+    # No overrides → species derived from afv.weight (which for rxn means [1..63]).
+    assert isinstance(metadata["implemented_species"], list)
+    assert metadata.get("family") is None
+    assert metadata.get("supports_charged_systems") is None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -602,3 +602,24 @@ def test_load_v1_model_without_overrides_is_backward_compatible():
     assert isinstance(metadata["implemented_species"], list)
     assert metadata.get("family") is None
     assert metadata.get("supports_charged_systems") is None
+
+
+def test_aimnet2_rxn_yaml_builds():
+    """The architecture YAML for aimnet2-rxn must be loadable and produce a real AIMNet2 module."""
+    import importlib.resources
+    import yaml
+
+    from aimnet.config import build_module
+
+    yaml_text = importlib.resources.files("aimnet.models").joinpath("aimnet2_rxn.yaml").read_text()
+    cfg = yaml.safe_load(yaml_text)
+    model = build_module(cfg)
+
+    # The reconstructed module must have the rxn output heads.
+    assert hasattr(model, "outputs")
+    assert hasattr(model.outputs, "energy_mlp")
+    assert hasattr(model.outputs, "atomic_shift")
+    assert hasattr(model.outputs, "atomic_sum")
+    assert hasattr(model.outputs, "dipole")
+    assert hasattr(model.outputs, "quadrupole")
+    assert hasattr(model.outputs, "lrcoulomb")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -543,7 +543,6 @@ def test_load_v1_model_species_override_nan_pads_other_rows():
     """load_v1_model with implemented_species override must NaN-pad AFV rows
     for elements outside the supported set, write family/supports_charged_systems
     to metadata, AND keep atomic_shift in float64 (regression on .double() ordering)."""
-    import math
     from pathlib import Path
 
     import pytest

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -18,3 +18,23 @@ def test_load_model_registry_uses_default_when_no_param():
     result = load_model_registry()
     assert "models" in result
     assert "aimnet2" in result.get("aliases", {})
+
+
+def test_aimnet2rxn_registry_entries_and_alias():
+    """All four aimnet2-rxn members must be registered with the canonical GCS URL,
+    and the `aimnet2rxn` alias must resolve to member 0."""
+    from aimnet.calculators.model_registry import load_model_registry
+
+    registry = load_model_registry()
+    models = registry["models"]
+
+    base_url = "https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn"
+    for i in range(4):
+        name = f"aimnet2_rxn_{i}"
+        assert name in models, f"missing registry entry: {name}"
+        entry = models[name]
+        assert entry["file"] == f"{name}.pt"
+        assert entry["url"] == f"{base_url}/{name}.pt"
+
+    aliases = registry["aliases"]
+    assert aliases.get("aimnet2rxn") == "aimnet2_rxn_0"


### PR DESCRIPTION
## Summary

- Registers `aimnet2-rxn` as a first-class model family. `AIMNet2Calculator("aimnet2rxn")` (GCS alias) and `AIMNet2Calculator("isayevlab/aimnet2-rxn")` (HF) both produce equivalent calculators with `family="rxn"`, `supports_charged_systems=False`, `implemented_species=[1, 6, 7, 8]`, `cutoff=5.0`.
- Adds five family-aware chemistry safeguards to the calculator (default-on; species/charge guards bypass with `validate_species=False`):
  - **Element scope** — `ValueError` on atomic numbers ∉ `implemented_species`, with pointers to `aimnet2-wb97m-d3` (broader elements) and `aimnet2-nse` (radicals)
  - **Net charge** — `ValueError` on `charge != 0` for models that declare `supports_charged_systems: false` (zwitterions are still in scope)
  - **Hessian + `torch.compile`** — `RuntimeError` (was: silent process hang on Dynamo + GELU double-backward)
  - **Coulomb cutoff lock** — `UserWarning` from `set_lrcoulomb_method` if the cutoff diverges from the model's `coulomb_sr_rc` for the rxn family (4.6 Å SR/LR crossover is physically frozen during training)
  - **Cross-family mixing** — one-time `UserWarning` per process when calculators from two different AIMNet2 families are constructed (rxn ~few-eV shifted-electronic scale vs. wb97m-d3 ~−1100 eV absolute electronic — not comparable)
- Three orthogonal cleanups surfaced during the integration:
  - `load_v1_model` `.double()` ordering fix (cast atomic_shift to float64 BEFORE `load_state_dict` so the destination buffer can hold the precision; preserves byte-equality for current float32 sources, future-proofs for float64)
  - `AIMNet2Calculator.metadata` read-only property (replaces `model._metadata` reaches in two internal sites; gives downstream consumers a stable accessor)
  - `validate_species` propagation through `AIMNet2ASE.calculate` and `AIMNet2Pysis.{get_energy,get_forces,get_hessian}`
- Closes the silent-garbage failure mode for AIMNet2-rxn under `validate_species=False`: `load_v1_model(implemented_species=…)` NaN-pads `afv.weight` rows for elements outside the supported set, so unsupported inputs produce immediate NaN propagation rather than plausible-looking nonsense from populated-but-untrained rows.

## Architecture (two layers)

**Bottom layer (metadata schema)**: `aimnet/models/base.py::ModelMetadata` and the two metadata-construction sites (`base.py::load_model`, `hf_hub.py::load_from_hf_repo`) gain optional `family` and `supports_charged_systems` fields. `aimnet/models/utils.py::load_v1_model` gains keyword-only `implemented_species`, `family`, `supports_charged_systems` overrides plus AFV-row NaN-padding when species are declared.

**Top layer (calculator)**: `AIMNet2Calculator` reads the new metadata via the new `metadata` property and enforces the safeguards inside `eval` and `set_lrcoulomb_method`. Wrappers (`AIMNet2ASE`, `AIMNet2Pysis`) propagate `validate_species`. Registry and architecture YAML are pure additions.

## Files

| Concern | Files |
|---|---|
| Schema + load paths | `aimnet/models/base.py`, `aimnet/calculators/hf_hub.py`, `aimnet/models/utils.py` |
| Calculator safeguards | `aimnet/calculators/calculator.py` |
| Wrapper propagation | `aimnet/calculators/aimnet2ase.py`, `aimnet/calculators/aimnet2pysis.py` |
| Registry + architecture YAML | `aimnet/calculators/model_registry.yaml`, `aimnet/models/aimnet2_rxn.yaml` |
| Tests | `tests/test_model.py`, `tests/test_calculator.py`, `tests/test_model_registry.py`, `tests/test_hf_hub.py`, `tests/test_ase.py` |
| Docs | `docs/models/aimnet2_rxn.md`, `mkdocs.yml`, `pyproject.toml` (network marker) |
| Spec + plan | `docs/superpowers/specs/2026-04-25-aimnet2-rxn-integration-design.md`, `docs/superpowers/plans/2026-04-25-aimnet2-rxn-integration.md` |

26 commits total (4 design/plan + 22 implementation), +722 / −23 lines.

## Test plan

- [x] Full affected test surface green: `pytest tests/test_model.py tests/test_calculator.py tests/test_model_registry.py tests/test_hf_hub.py tests/test_ase.py -m "not gpu"` → **125 passed**, 1 skipped, 1 failed (both intentional tripwires — see Out-of-band tasks)
- [x] mkdocs strict build green: `mkdocs build --strict`
- [x] No regressions in existing test suites
- [ ] After GCS upload of the four `aimnet2_rxn_{0..3}.pt` files: `pytest tests/test_calculator.py::test_aimnet2rxn_alias_calculator_e2e -v -m network` flips from SKIPPED to PASSED
- [ ] After HF `config.json` adds `family: "rxn"` and `supports_charged_systems: false` (and safetensors are re-exported from sanitized state_dicts): `pytest tests/test_hf_hub.py::test_aimnet2_rxn_hf_load_matches_gcs_metadata -v -m hf` flips from FAILED to PASSED

## Out-of-band tasks (maintainer)

These are required before the two tripwire tests pass; nothing in the codebase blocks merge.

1. **Re-convert the four `.pt` files** under the new `load_v1_model(implemented_species=[1, 6, 7, 8], family="rxn", supports_charged_systems=False)` API. The four-line example is in the function's docstring (`Examples` section).
2. **Upload `aimnet2_rxn_{0..3}.pt`** to `gs://aimnetcentral/aimnet2v2/AIMNet2rxn/`.
3. **Edit HF `isayevlab/aimnet2-rxn`'s `config.json`** to add `"family": "rxn"` and `"supports_charged_systems": false`.
4. **Re-export the four HF `ensemble_{0..3}.safetensors`** from the AFV-sanitized `.pt` state_dicts so both load paths produce equivalent metadata and behavior under `validate_species=False`.

## Notes

- All commits authored solely by Olexandr Isayev per repo authorship policy.
- Existing four AIMNet2 families (`aimnet2_wb97m_d3`, `aimnet2_b973c_d3`, `aimnet2_b973c_2025_d3`, `aimnet2nse`, `aimnet2-pd`) are unaffected — none declare `family` or `supports_charged_systems`, so all new safeguards are silent no-ops for them.