### PR TITLE
fix(calculator): detect embedded D3TS via explicit metadata flag (closes #48)

### DIFF
--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -524,7 +524,10 @@ class AIMNet2Calculator:
     def _has_embedded_dispersion(self) -> bool:
         """Check if model has embedded dispersion (not externalized).
 
-        Uses model metadata when available, otherwise returns False (unknown).
+        Reads `has_embedded_d3ts` from metadata when present (the authoritative
+        source for new conversions). Falls back to heuristics for legacy .pt
+        files that don't carry the explicit flag. Returns False when no metadata
+        is available.
 
         Returns
         -------
@@ -535,15 +538,19 @@ class AIMNet2Calculator:
         if meta is None:
             return False  # Unknown, assume no embedded dispersion
 
-        # New format: Check for embedded D3TS via has_embedded_lr
-        # If has_embedded_lr=True and coulomb_mode != "sr_embedded", it's D3TS
-        if meta.get("has_embedded_lr", False):
-            coulomb_mode = meta.get("coulomb_mode", "none")
-            if coulomb_mode != "sr_embedded":
-                return True  # Must be D3TS (embedded dispersion)
+        # Authoritative path (new conversions): explicit flag.
+        if meta.get("has_embedded_d3ts", False):
+            return True
 
-        # Legacy format: If needs_dispersion=False and d3_params exist, dispersion is embedded
-        # (legacy JIT models have dispersion embedded)
+        # Legacy heuristic (pre-explicit-flag .pt files): if has_embedded_lr=True
+        # AND coulomb_mode != "sr_embedded", the LR module must be D3TS — but
+        # this misses the both-set case (D3TS + SRCoulomb), which is exactly the
+        # bug fixed by the explicit flag above. Kept here only as a fallback for
+        # legacy files; new conversions take the path above.
+        if meta.get("has_embedded_lr", False) and meta.get("coulomb_mode", "none") != "sr_embedded":
+            return True
+
+        # Legacy JIT format: needs_dispersion=False + d3_params present means dispersion is embedded.
         return not meta.get("needs_dispersion", False) and meta.get("d3_params") is not None
 
     def _has_embedded_coulomb(self) -> bool:

--- a/aimnet/calculators/hf_hub.py
+++ b/aimnet/calculators/hf_hub.py
@@ -281,6 +281,7 @@ def load_from_hf_repo(
         "implemented_species": _cfg("implemented_species", []),
         "family": _cfg("family"),
         "supports_charged_systems": _cfg("supports_charged_systems"),
+        "has_embedded_d3ts": _cfg("has_embedded_d3ts", False),
     }
 
     model._metadata = metadata

--- a/aimnet/models/base.py
+++ b/aimnet/models/base.py
@@ -46,6 +46,8 @@ class ModelMetadata(TypedDict):
 
     family: NotRequired[str | None]  # e.g. "rxn"; None for legacy/families that don't declare
     supports_charged_systems: NotRequired[bool | None]  # False for rxn; None for legacy
+    has_embedded_d3ts: NotRequired[bool]  # True when D3TS module is embedded (distinct from has_embedded_lr,
+    # which conflates D3TS with SRCoulomb — see _has_embedded_dispersion)
 
 
 def load_model(path: str, device: str = "cpu") -> tuple[nn.Module, ModelMetadata]:
@@ -124,6 +126,7 @@ def load_model(path: str, device: str = "cpu") -> tuple[nn.Module, ModelMetadata
             "implemented_species": data.get("implemented_species", []),
             "family": data.get("family"),
             "supports_charged_systems": data.get("supports_charged_systems"),
+            "has_embedded_d3ts": data.get("has_embedded_d3ts", False),
         }
 
         # Attach metadata to model for easy access

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -761,6 +761,7 @@ def load_v1_model(
         "coulomb_sr_envelope": coulomb_sr_envelope if needs_coulomb else None,
         "d3_params": d3_params if needs_dispersion else None,
         "has_embedded_lr": has_embedded_lr,
+        "has_embedded_d3ts": has_embedded_d3ts,
         "implemented_species": implemented_species_list,
     }
     if family is not None:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1184,6 +1184,39 @@ def test_constructing_two_families_warns_once(monkeypatch):
         calc_b._maybe_warn_family_mix("family-B")
 
 
+def test_has_embedded_dispersion_explicit_d3ts_flag():
+    """Calculator must detect embedded D3TS via the explicit `has_embedded_d3ts`
+    metadata flag — even when `coulomb_mode == 'sr_embedded'` (the both-set
+    case from PR #48 that the legacy heuristic missed)."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    calc.model._metadata = dict(calc.model._metadata)
+    # Reproduce the PR #48 failing combination: D3TS AND SRCoulomb both embedded.
+    calc.model._metadata["has_embedded_d3ts"] = True
+    calc.model._metadata["has_embedded_lr"] = True
+    calc.model._metadata["coulomb_mode"] = "sr_embedded"
+    calc.model._metadata["d3_params"] = None  # D3TS uses learned params, not tabulated
+    calc.model._metadata["needs_dispersion"] = False
+    assert calc._has_embedded_dispersion() is True
+
+
+def test_has_embedded_dispersion_legacy_heuristic_fallback():
+    """For pre-explicit-flag .pt files (no `has_embedded_d3ts` key), the legacy
+    heuristic still detects D3TS-only models (has_embedded_lr=True with
+    coulomb_mode != 'sr_embedded')."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    calc.model._metadata = dict(calc.model._metadata)
+    calc.model._metadata.pop("has_embedded_d3ts", None)  # legacy: flag absent
+    calc.model._metadata["has_embedded_lr"] = True
+    calc.model._metadata["coulomb_mode"] = "none"  # D3TS-only, no SRCoulomb
+    calc.model._metadata["d3_params"] = None
+    calc.model._metadata["needs_dispersion"] = False
+    assert calc._has_embedded_dispersion() is True
+
+
 @pytest.mark.network
 def test_aimnet2rxn_alias_calculator_e2e():
     """Alias 'aimnet2rxn' must resolve through the registry, the .pt must load,


### PR DESCRIPTION
## Summary

Fixes the bug @k-s-n reported in #48: `AIMNet2Calculator._has_embedded_dispersion()` returns `False` for v2 `.pt` files that have **both** embedded D3TS dispersion AND embedded SRCoulomb (`has_embedded_lr=True` AND `coulomb_mode='sr_embedded'`). The calculator then skips building the long-range neighbor list and `D3TS.forward()` later raises `KeyError('No neighbor matrix found for any suffix in [\"_dftd3\", \"_lr\"]')`.

## Why a different fix from #48

PR #48 introduces a `for m in self.model.modules(): m.__class__.__name__ == \"D3TS\"` runtime check on every `eval()` call. That works but:

- O(modules) iteration on every inference call (called from `_run_external_modules`).
- Brittle string match on `__class__.__name__` (no FQN; doesn't survive a class rename).
- Leaves the previous function as a 22-line commented-out block (which is what failed the `quality` CI check on #48).

This PR uses the same metadata-driven pattern just landed for `family` / `supports_charged_systems` (#66): add an explicit `has_embedded_d3ts: bool` to `ModelMetadata`, populate it at conversion time from the local variable that `load_v1_model` already computes (line 711), and read it directly in `_has_embedded_dispersion`. O(1) per call, no introspection, no fragile string match.

## Changes

| File | Change |
|---|---|
| `aimnet/models/base.py` | Add `has_embedded_d3ts: NotRequired[bool]` to `ModelMetadata`; propagate in `load_model` |
| `aimnet/calculators/hf_hub.py` | Propagate in `load_from_hf_repo` |
| `aimnet/models/utils.py` | Write `has_embedded_d3ts` to metadata in `load_v1_model` (one-line addition; the local was already there) |
| `aimnet/calculators/calculator.py` | `_has_embedded_dispersion` reads the explicit flag first; legacy heuristic kept only as fallback for pre-flag `.pt` files |
| `tests/test_calculator.py` | Two regression tests (the both-set case + back-compat for legacy `.pt`) |

## Backward compatibility

Existing `.pt` files in the registry that don't carry `has_embedded_d3ts` continue to behave as before — the legacy heuristic stays as a fallback. No regression on the standard `aimnet2_wb97m_d3` family (uses externalized DFTD3, never affected). The bug bites custom models exported from `aimnet2_dftd3_wb97m.yaml`-shaped configs (D3TS + SRCoulomb both embedded). For those, re-conversion against this PR will set the flag correctly.

## Test plan

- [x] `test_has_embedded_dispersion_explicit_d3ts_flag` — synthesizes the both-set metadata combo from #48 and asserts the function returns `True`.
- [x] `test_has_embedded_dispersion_legacy_heuristic_fallback` — verifies pre-flag `.pt` files (no `has_embedded_d3ts` key) still detect D3TS-only models via the heuristic.
- [x] All previously-added metadata tests still pass (family / supports_charged_systems / type_dict propagation).
- [x] `ruff check` + `ruff format` + `prettier` all clean (no `quality` CI failure expected).

## Credit

Bug reported by @k-s-n in #48. Closing #48 in favor of this PR.