### PR TITLE
docs: add External Packages section; park GROMACS NNPot wrapper

### DIFF
--- a/aimnet/interfaces/__init__.py
+++ b/aimnet/interfaces/__init__.py
@@ -1,16 +1,4 @@
 """Wrappers exposing AIMNet2 to external MD/QM packages.
 
-Public integrations:
-    * ASE        -- aimnet.calculators.aimnet2ase.AIMNet2ASE
-    * pysisyphus -- aimnet.calculators.aimnet2pysis.AIMNet2Pysis
-
-Work-in-progress integrations live in this package but are intentionally
-not re-exported here until they are functional end-to-end. See:
-    * gromacs.py -- TorchScript export wrapper for GROMACS NNPot
-                    (parked: blocked by upstream TorchScript-export issues
-                    in the core AIMNet2 module and DFTD3 autograd; see
-                    docs/external/gromacs.md and the planning doc at
-                    docs/superpowers/plans/2026-04-26-torchscript-export.md)
+Currently parked. See ``docs/external/`` for the status of each integration.
 """
-
-__all__: list[str] = []

--- a/aimnet/interfaces/__init__.py
+++ b/aimnet/interfaces/__init__.py
@@ -1,0 +1,16 @@
+"""Wrappers exposing AIMNet2 to external MD/QM packages.
+
+Public integrations:
+    * ASE        -- aimnet.calculators.aimnet2ase.AIMNet2ASE
+    * pysisyphus -- aimnet.calculators.aimnet2pysis.AIMNet2Pysis
+
+Work-in-progress integrations live in this package but are intentionally
+not re-exported here until they are functional end-to-end. See:
+    * gromacs.py -- TorchScript export wrapper for GROMACS NNPot
+                    (parked: blocked by upstream TorchScript-export issues
+                    in the core AIMNet2 module and DFTD3 autograd; see
+                    docs/external/gromacs.md and the planning doc at
+                    docs/superpowers/plans/2026-04-26-torchscript-export.md)
+"""
+
+__all__: list[str] = []

--- a/aimnet/interfaces/gromacs.py
+++ b/aimnet/interfaces/gromacs.py
@@ -7,8 +7,6 @@ See ``docs/external/gromacs.md`` for blocker details and the plan at
 ``docs/superpowers/plans/2026-04-26-torchscript-export.md``.
 """
 
-from typing import Optional
-
 import torch
 from torch import Tensor, nn
 
@@ -52,8 +50,8 @@ class AIMNet2Gromacs(nn.Module):
         self,
         positions: Tensor,
         atomic_numbers: Tensor,
-        box: Optional[Tensor] = None,
-        pbc: Optional[Tensor] = None,
+        box: Tensor | None = None,
+        pbc: Tensor | None = None,
     ) -> Tensor:
         n = positions.shape[0]
         # n==1 produces a (1, 0) nbmat which is degenerate downstream.
@@ -61,14 +59,9 @@ class AIMNet2Gromacs(nn.Module):
         # PBC is out of scope for v1. Refuse non-trivial box/pbc rather than
         # silently producing open-boundary energies for a periodic GROMACS run.
         if box is not None:
-            assert torch.all(box == 0), (
-                "AIMNet2Gromacs does not support periodic systems; "
-                "pass box=None or zeros"
-            )
+            assert torch.all(box == 0), "AIMNet2Gromacs does not support periodic systems; pass box=None or zeros"
         if pbc is not None:
-            assert not bool(pbc.any()), (
-                "AIMNet2Gromacs does not support periodic boundary conditions"
-            )
+            assert not bool(pbc.any()), "AIMNet2Gromacs does not support periodic boundary conditions"
         device = positions.device
 
         # GROMACS may feed float64 positions in double-precision builds; the
@@ -117,7 +110,7 @@ def build_gromacs_nnpot_model(
     model_name: str = "aimnet2",
     *,
     charge: float = 0.0,
-    output_path: Optional[str] = None,
+    output_path: str | None = None,
 ) -> torch.jit.ScriptModule:
     """Stub. Always raises ``NotImplementedError``.
 

--- a/aimnet/interfaces/gromacs.py
+++ b/aimnet/interfaces/gromacs.py
@@ -1,0 +1,165 @@
+"""TorchScript wrapper exposing AIMNet2 via the GROMACS NNPot interface.
+
+STATUS: PARKED / WORK IN PROGRESS. Do not import this module for production
+use. ``build_gromacs_nnpot_model`` will raise for every shipped AIMNet2
+model because the upstream pipeline is not currently ``torch.jit.script``-
+able. Specifically:
+
+    * the core ``AIMNet2`` module uses ``tensor.data_ptr()`` in
+      ``aimnet/nbops.py`` for neighbor-cache identity, which TorchScript
+      rejects;
+    * the ``DFTD3`` external module uses an ``aten::grad`` call signature
+      that TorchScript cannot match;
+    * shipped v2 ``.pt`` assets are plain ``torch.save`` state dicts
+      (loaded into Python ``nn.Module``s), not TorchScript archives.
+
+Tracking issue / plan:
+    docs/superpowers/plans/2026-04-26-torchscript-export.md
+Status doc:
+    docs/external/gromacs.md
+
+The code below is preserved as a starting point for the eventual GROMACS
+NNPot wrapper once the scriptability blockers are resolved. The forward
+contract, unit conversions, and all-pairs neighbor-list construction were
+sanity-checked against a dummy inner ScriptModule and round-trip via
+``torch.jit.save`` / ``torch.jit.load``.
+
+Intended limitations (v1, when unblocked):
+    * non-PBC only -- the QM region in QM/MM is the realistic use case
+    * single QM region with a fixed total charge (set at construction)
+    * returns energy only; GROMACS autograds forces from ``positions``
+    * NSE / open-shell models are not supported here
+"""
+
+from typing import Optional
+
+import torch
+from torch import Tensor, nn
+
+# Exact-SI conversion: e * NA / 1000 (post-2019 SI fixed values).
+_EV_TO_KJ_MOL: float = 96.48533212331
+_NM_TO_ANG: float = 10.0
+
+
+class GromacsNNPotWrapper(nn.Module):
+    """TorchScript-able adapter around an AIMNet2 ScriptModule.
+
+    Parameters
+    ----------
+    model : torch.jit.ScriptModule
+        Inner AIMNet2 scripted model loaded from a v2 ``.pt`` asset.
+    charge : float, optional
+        Total charge of the QM region. Default ``0.0``.
+    """
+
+    length_conversion: float
+    energy_conversion: float
+
+    def __init__(self, model: torch.jit.ScriptModule, charge: float = 0.0) -> None:
+        super().__init__()
+        self.model = model
+        self.length_conversion = _NM_TO_ANG
+        self.energy_conversion = _EV_TO_KJ_MOL
+        # Buffer survives jit.script + jit.save; serialized with the model.
+        self.register_buffer(
+            "_charge",
+            torch.tensor([float(charge)], dtype=torch.float32),
+        )
+
+    def forward(
+        self,
+        positions: Tensor,
+        atomic_numbers: Tensor,
+        box: Optional[Tensor] = None,
+        pbc: Optional[Tensor] = None,
+    ) -> Tensor:
+        # box / pbc accepted for GROMACS interface compatibility but ignored:
+        # PBC is out of scope for the v1 wrapper.
+        n = positions.shape[0]
+        device = positions.device
+
+        coord = (positions * self.length_conversion).to(torch.float32)
+        numbers = atomic_numbers.to(torch.int32)
+
+        # All-pairs neighbor list, shape (N, N-1). Inner model masks
+        # contributions from index N (padding) and uses internal cutoff
+        # functions to zero distant interactions, so passing every other
+        # atom is correct for any cutoff.
+        idx = torch.arange(n, device=device, dtype=torch.int32)
+        full = idx.unsqueeze(0).expand(n, n)
+        mask = idx.unsqueeze(0) != idx.unsqueeze(1)
+        nbmat = full[mask].view(n, n - 1)
+        # Add padding row at index N filled with N (the calculator's convention).
+        pad_row = torch.full((1, n - 1), n, dtype=torch.int32, device=device)
+        nbmat = torch.cat([nbmat, pad_row], dim=0)
+
+        coord_p = torch.cat(
+            [coord, torch.zeros(1, 3, dtype=coord.dtype, device=device)],
+            dim=0,
+        )
+        numbers_p = torch.cat(
+            [numbers, torch.zeros(1, dtype=torch.int32, device=device)],
+            dim=0,
+        )
+        mol_idx = torch.zeros(n + 1, dtype=torch.int32, device=device)
+
+        data: dict[str, Tensor] = {
+            "coord": coord_p,
+            "numbers": numbers_p,
+            "charge": self._charge.to(coord.dtype),
+            "mol_idx": mol_idx,
+            "nbmat": nbmat,
+            "nbmat_lr": nbmat,
+        }
+        out = self.model(data)
+        return out["energy"][0] * self.energy_conversion
+
+
+def build_gromacs_nnpot_model(
+    model_name: str = "aimnet2",
+    *,
+    charge: float = 0.0,
+    output_path: Optional[str] = None,
+) -> torch.jit.ScriptModule:
+    """Build, script, and optionally save a GROMACS-ready ``.pt`` file.
+
+    Parameters
+    ----------
+    model_name : str, optional
+        Registry alias (e.g. ``"aimnet2"``), HF repo id, or path to a v2
+        ``.pt`` file. Default ``"aimnet2"``.
+    charge : float, optional
+        Total charge of the QM region. Default ``0.0``.
+    output_path : str | None, optional
+        If given, the scripted wrapper is written to this path via
+        ``torch.jit.save``.
+
+    Returns
+    -------
+    torch.jit.ScriptModule
+        The scripted ``GromacsNNPotWrapper``.
+    """
+    from aimnet.calculators import AIMNet2Calculator
+
+    base = AIMNet2Calculator(model_name, device="cpu")
+    inner = base.model
+    if not isinstance(inner, torch.jit.ScriptModule):
+        raise TypeError(
+            f"Model '{model_name}' did not load as a TorchScript ScriptModule "
+            f"(got {type(inner).__name__}). The GROMACS wrapper requires a "
+            f"v2 .pt asset."
+        )
+    if base.has_external_coulomb or base.has_external_dftd3:
+        raise RuntimeError(
+            f"Model '{model_name}' uses external long-range modules "
+            f"(coulomb={base.has_external_coulomb}, dftd3={base.has_external_dftd3}). "
+            f"Only models with all long-range terms baked into the scripted "
+            f"asset are supported by the GROMACS wrapper. The v2 .pt assets "
+            f"shipped with this package satisfy this constraint."
+        )
+
+    wrapper = GromacsNNPotWrapper(inner.cpu(), charge=charge).cpu().eval()
+    scripted = torch.jit.script(wrapper)
+    if output_path is not None:
+        scripted.save(output_path)
+    return scripted

--- a/aimnet/interfaces/gromacs.py
+++ b/aimnet/interfaces/gromacs.py
@@ -1,34 +1,10 @@
 """TorchScript wrapper exposing AIMNet2 via the GROMACS NNPot interface.
 
-STATUS: PARKED / WORK IN PROGRESS. Do not import this module for production
-use. ``build_gromacs_nnpot_model`` will raise for every shipped AIMNet2
-model because the upstream pipeline is not currently ``torch.jit.script``-
-able. Specifically:
-
-    * the core ``AIMNet2`` module uses ``tensor.data_ptr()`` in
-      ``aimnet/nbops.py`` for neighbor-cache identity, which TorchScript
-      rejects;
-    * the ``DFTD3`` external module uses an ``aten::grad`` call signature
-      that TorchScript cannot match;
-    * shipped v2 ``.pt`` assets are plain ``torch.save`` state dicts
-      (loaded into Python ``nn.Module``s), not TorchScript archives.
-
-Tracking issue / plan:
-    docs/superpowers/plans/2026-04-26-torchscript-export.md
-Status doc:
-    docs/external/gromacs.md
-
-The code below is preserved as a starting point for the eventual GROMACS
-NNPot wrapper once the scriptability blockers are resolved. The forward
-contract, unit conversions, and all-pairs neighbor-list construction were
-sanity-checked against a dummy inner ScriptModule and round-trip via
-``torch.jit.save`` / ``torch.jit.load``.
-
-Intended limitations (v1, when unblocked):
-    * non-PBC only -- the QM region in QM/MM is the realistic use case
-    * single QM region with a fixed total charge (set at construction)
-    * returns energy only; GROMACS autograds forces from ``positions``
-    * NSE / open-shell models are not supported here
+Status: parked. ``build_gromacs_nnpot_model`` raises ``NotImplementedError``
+because the upstream pipeline is not yet ``torch.jit.script``-able. The class
+definition below is preserved as a starting point for the eventual wrapper.
+See ``docs/external/gromacs.md`` for blocker details and the plan at
+``docs/superpowers/plans/2026-04-26-torchscript-export.md``.
 """
 
 from typing import Optional
@@ -41,15 +17,21 @@ _EV_TO_KJ_MOL: float = 96.48533212331
 _NM_TO_ANG: float = 10.0
 
 
-class GromacsNNPotWrapper(nn.Module):
-    """TorchScript-able adapter around an AIMNet2 ScriptModule.
+class AIMNet2Gromacs(nn.Module):
+    """TorchScript-able adapter around an AIMNet2 ScriptModule for GROMACS NNPot.
 
-    Parameters
-    ----------
-    model : torch.jit.ScriptModule
-        Inner AIMNet2 scripted model loaded from a v2 ``.pt`` asset.
-    charge : float, optional
-        Total charge of the QM region. Default ``0.0``.
+    Currently unreachable in production -- ``build_gromacs_nnpot_model`` raises
+    ``NotImplementedError``. The class is preserved as a starting point for
+    the eventual export pathway. The forward() body has been verified to
+    ``torch.jit.script`` cleanly with a dummy inner ScriptModule and to
+    round-trip via ``torch.jit.save`` / ``torch.jit.load``.
+
+    Intended limitations (when unblocked):
+        * non-PBC only
+        * single QM region with a fixed total charge
+        * returns energy only; GROMACS autograds forces from positions
+        * float32 precision (positions are downcast internally)
+        * NSE / open-shell models not supported
     """
 
     length_conversion: float
@@ -60,9 +42,9 @@ class GromacsNNPotWrapper(nn.Module):
         self.model = model
         self.length_conversion = _NM_TO_ANG
         self.energy_conversion = _EV_TO_KJ_MOL
-        # Buffer survives jit.script + jit.save; serialized with the model.
+        # Buffer survives jit.script + jit.save; serialized with the saved .pt.
         self.register_buffer(
-            "_charge",
+            "total_charge",
             torch.tensor([float(charge)], dtype=torch.float32),
         )
 
@@ -73,18 +55,32 @@ class GromacsNNPotWrapper(nn.Module):
         box: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
     ) -> Tensor:
-        # box / pbc accepted for GROMACS interface compatibility but ignored:
-        # PBC is out of scope for the v1 wrapper.
         n = positions.shape[0]
+        # n==1 produces a (1, 0) nbmat which is degenerate downstream.
+        assert n >= 2, "AIMNet2Gromacs requires at least 2 atoms"
+        # PBC is out of scope for v1. Refuse non-trivial box/pbc rather than
+        # silently producing open-boundary energies for a periodic GROMACS run.
+        if box is not None:
+            assert torch.all(box == 0), (
+                "AIMNet2Gromacs does not support periodic systems; "
+                "pass box=None or zeros"
+            )
+        if pbc is not None:
+            assert not bool(pbc.any()), (
+                "AIMNet2Gromacs does not support periodic boundary conditions"
+            )
         device = positions.device
 
+        # GROMACS may feed float64 positions in double-precision builds; the
+        # inner AIMNet2 model expects float32. Downcast costs ~7 decimal digits
+        # in the autograd-derived forces path -- documented v1 limitation.
         coord = (positions * self.length_conversion).to(torch.float32)
         numbers = atomic_numbers.to(torch.int32)
 
         # All-pairs neighbor list, shape (N, N-1). Inner model masks
-        # contributions from index N (padding) and uses internal cutoff
-        # functions to zero distant interactions, so passing every other
-        # atom is correct for any cutoff.
+        # contributions from the padding row (index N) and applies internal
+        # cutoff functions to zero distant interactions, so passing every
+        # other atom is correct for any cutoff (short-range or long-range).
         idx = torch.arange(n, device=device, dtype=torch.int32)
         full = idx.unsqueeze(0).expand(n, n)
         mask = idx.unsqueeze(0) != idx.unsqueeze(1)
@@ -103,10 +99,12 @@ class GromacsNNPotWrapper(nn.Module):
         )
         mol_idx = torch.zeros(n + 1, dtype=torch.int32, device=device)
 
+        # nbmat_lr aliases nbmat -- safe only because both are all-pairs lists
+        # that already cover any LR cutoff for a small QM region.
         data: dict[str, Tensor] = {
             "coord": coord_p,
             "numbers": numbers_p,
-            "charge": self._charge.to(coord.dtype),
+            "charge": self.total_charge,
             "mol_idx": mol_idx,
             "nbmat": nbmat,
             "nbmat_lr": nbmat,
@@ -121,45 +119,17 @@ def build_gromacs_nnpot_model(
     charge: float = 0.0,
     output_path: Optional[str] = None,
 ) -> torch.jit.ScriptModule:
-    """Build, script, and optionally save a GROMACS-ready ``.pt`` file.
+    """Stub. Always raises ``NotImplementedError``.
 
-    Parameters
-    ----------
-    model_name : str, optional
-        Registry alias (e.g. ``"aimnet2"``), HF repo id, or path to a v2
-        ``.pt`` file. Default ``"aimnet2"``.
-    charge : float, optional
-        Total charge of the QM region. Default ``0.0``.
-    output_path : str | None, optional
-        If given, the scripted wrapper is written to this path via
-        ``torch.jit.save``.
-
-    Returns
-    -------
-    torch.jit.ScriptModule
-        The scripted ``GromacsNNPotWrapper``.
+    The wrapper is parked because the upstream AIMNet2 pipeline is not
+    currently ``torch.jit.script``-able end-to-end. See
+    ``docs/external/gromacs.md`` for blocker details and
+    ``docs/superpowers/plans/2026-04-26-torchscript-export.md`` for the
+    remediation plan.
     """
-    from aimnet.calculators import AIMNet2Calculator
-
-    base = AIMNet2Calculator(model_name, device="cpu")
-    inner = base.model
-    if not isinstance(inner, torch.jit.ScriptModule):
-        raise TypeError(
-            f"Model '{model_name}' did not load as a TorchScript ScriptModule "
-            f"(got {type(inner).__name__}). The GROMACS wrapper requires a "
-            f"v2 .pt asset."
-        )
-    if base.has_external_coulomb or base.has_external_dftd3:
-        raise RuntimeError(
-            f"Model '{model_name}' uses external long-range modules "
-            f"(coulomb={base.has_external_coulomb}, dftd3={base.has_external_dftd3}). "
-            f"Only models with all long-range terms baked into the scripted "
-            f"asset are supported by the GROMACS wrapper. The v2 .pt assets "
-            f"shipped with this package satisfy this constraint."
-        )
-
-    wrapper = GromacsNNPotWrapper(inner.cpu(), charge=charge).cpu().eval()
-    scripted = torch.jit.script(wrapper)
-    if output_path is not None:
-        scripted.save(output_path)
-    return scripted
+    del model_name, charge, output_path
+    raise NotImplementedError(
+        "GROMACS NNPot wrapper is parked: AIMNet2 is not currently "
+        "torch.jit.script-able end-to-end. See docs/external/gromacs.md "
+        "and docs/superpowers/plans/2026-04-26-torchscript-export.md."
+    )

--- a/docs/external/amber.md
+++ b/docs/external/amber.md
@@ -1,0 +1,95 @@
+# AMBER (`torchani-amber`)
+
+**Status: supported upstream with caveats.**
+
+AIMNet2 (and Nutmeg) are supported in AMBER through the
+[`torchani-amber`](https://github.com/roitberg-group/torchani-amber)
+integration from the Roitberg group. Despite the `torchani-` prefix the
+project explicitly handles AimNet2 and Nutmeg models in addition to
+ANI-family potentials. Reference paper:
+[Bridging neural network potentials and classical biomolecular simulations](https://doi.org/10.1021/acs.jpcb.5c05725).
+
+## Mechanism
+
+`torchani-amber` is a **compiled-in C++/Fortran integration**, not a
+plugin. It hooks into AMBER's existing external-potential paths:
+
+| Mode | AMBER mechanism | Use case |
+|---|---|---|
+| Full ML | `iextpot = 1` + `&extpot` (`extprog = "TORCHANI"`) | All-atom ML simulation |
+| ML/MM | `ifqnt = 1` + `&qmmm` (`qm_theory = 'EXTERN'`) | QM/MM with the QM region treated by the NNP |
+
+Both modes are pure mdin-file configuration -- no Python code at runtime.
+
+## Install
+
+Not pip-installable. The integration must be **built into AMBER from
+source**:
+
+1. Clone `torchani-amber` (`git clone --recurse-submodules ...`).
+2. Build its bundled `torchani_sandbox` plus the C++ extensions
+   (`run-cmake`).
+3. Build AmberTools 25/26 from source with `CMAKE_PREFIX_PATH` pointing
+   at the `torchani-amber` install. AMBER auto-links it.
+4. For ML/MM with charged systems on AimNet2 and Nutmeg, AmberTools 25
+   needs an additional patch (replace
+   `amber_src/AmberTools/sander/qm2_extern_torchani_module.F90`).
+   AmberTools 26 includes the patch.
+
+A conda environment recipe (PyTorch, CUDA, GFortran, OpenMPI) is
+provided in the upstream repo.
+
+## User-facing input
+
+Minimal AIMNet2 example (full ML):
+
+```
+&cntrl
+    iextpot = 1,
+/
+&extpot
+    extprog = "TORCHANI",
+/
+&ani
+    model_type = "aimnet2",
+    use_double_precision = .true.,
+    use_cuda_device = .true.,
+/
+```
+
+ML/MM example with charge-coupled embedding:
+
+```
+&cntrl
+    ifqnt = 1,
+/
+&qmmm
+    qm_theory = "EXTERN",
+/
+&ani
+    model_type = "aimnet2",
+    mlmm_coupling = 1,
+/
+```
+
+Custom `.pt` files can be loaded by passing a full path as `model_type`,
+which is where the [TorchScript-export work](../superpowers/plans/2026-04-26-torchscript-export.md)
+in this repo would let users ship a self-contained AIMNet2 jit asset for
+`torchani-amber` rather than relying on the upstream-bundled model.
+
+## Caveats
+
+- Hard rebuild of AmberTools required. Once linked, the AMBER binaries
+  depend on the torchani libraries even for non-ML runs.
+- Supported AMBER versions: AmberTools 25 (with patch) and 26.
+- The integration is tied to the `torchani_sandbox` build; the AIMNet2
+  model selection is constrained to what `torchani-amber` exposes
+  upstream until a custom jit `.pt` path is provided.
+
+## Alternatives
+
+If a full AmberTools rebuild is not acceptable, classical "AMBER force
+field plus ML region" workflows can sometimes be done via
+[OpenMM + openmm-ml](openmm.md) on AMBER-format topologies (loaded via
+ParmEd / OpenMM's `AmberPrmtopFile`). That route is pip-installable and
+needs no AMBER source build.

--- a/docs/external/amber.md
+++ b/docs/external/amber.md
@@ -31,8 +31,9 @@ source**:
    (`run-cmake`).
 3. Build AmberTools 25/26 from source with `CMAKE_PREFIX_PATH` pointing
    at the `torchani-amber` install. AMBER auto-links it.
-4. For ML/MM with charged systems on AimNet2 and Nutmeg, AmberTools 25
-   needs an additional patch (replace
+4. For ML/MM where the QM region has a non-zero net charge (i.e.
+   `qm_charge != 0`) with AimNet2 or Nutmeg, AmberTools 25 needs an
+   additional patch (replace
    `amber_src/AmberTools/sander/qm2_extern_torchani_module.F90`).
    AmberTools 26 includes the patch.
 
@@ -57,7 +58,8 @@ Minimal AIMNet2 example (full ML):
 /
 ```
 
-ML/MM example with charge-coupled embedding:
+ML/MM example with electrostatic embedding via AIMNet2's predicted
+atomic charges:
 
 ```
 &cntrl
@@ -72,10 +74,18 @@ ML/MM example with charge-coupled embedding:
 /
 ```
 
-Custom `.pt` files can be loaded by passing a full path as `model_type`,
-which is where the [TorchScript-export work](../superpowers/plans/2026-04-26-torchscript-export.md)
-in this repo would let users ship a self-contained AIMNet2 jit asset for
-`torchani-amber` rather than relying on the upstream-bundled model.
+The `mlmm_coupling` keyword selects the QM/MM coupling scheme. The
+exact embedding details (which AIMNet2 charges are used, whether MM
+point charges polarise the QM region within a step, etc.) are
+documented in the upstream `torchani-amber` reference paper and source.
+
+`model_type` may also be a full path to a **TorchScript-jit-compiled**
+`.pt` file. The v2 `.pt` assets shipped in
+`aimnet/calculators/assets/` are `torch.save` state-dict archives, not
+TorchScript -- they cannot currently be passed as `model_type` directly.
+The [TorchScript-export work](../superpowers/plans/2026-04-26-torchscript-export.md)
+in this repo would unblock shipping a self-contained AIMNet2 jit asset
+for `torchani-amber` rather than relying on the upstream-bundled model.
 
 ## Caveats
 
@@ -85,6 +95,12 @@ in this repo would let users ship a self-contained AIMNet2 jit asset for
 - The integration is tied to the `torchani_sandbox` build; the AIMNet2
   model selection is constrained to what `torchani-amber` exposes
   upstream until a custom jit `.pt` path is provided.
+
+## Model coverage
+
+What `torchani-amber` exposes upstream as `model_type = "aimnet2"`. The
+NSE (open-shell) and rxn (reactive) AIMNet2 families are not currently
+exposed by the upstream integration.
 
 ## Alternatives
 

--- a/docs/external/amber.md
+++ b/docs/external/amber.md
@@ -2,20 +2,14 @@
 
 **Status: supported upstream with caveats.**
 
-AIMNet2 (and Nutmeg) are supported in AMBER through the
-[`torchani-amber`](https://github.com/roitberg-group/torchani-amber)
-integration from the Roitberg group. Despite the `torchani-` prefix the
-project explicitly handles AimNet2 and Nutmeg models in addition to
-ANI-family potentials. Reference paper:
-[Bridging neural network potentials and classical biomolecular simulations](https://doi.org/10.1021/acs.jpcb.5c05725).
+AIMNet2 (and Nutmeg) are supported in AMBER through the [`torchani-amber`](https://github.com/roitberg-group/torchani-amber) integration from the Roitberg group. Despite the `torchani-` prefix the project explicitly handles AimNet2 and Nutmeg models in addition to ANI-family potentials. Reference paper: [Bridging neural network potentials and classical biomolecular simulations](https://doi.org/10.1021/acs.jpcb.5c05725).
 
 ## Mechanism
 
-`torchani-amber` is a **compiled-in C++/Fortran integration**, not a
-plugin. It hooks into AMBER's existing external-potential paths:
+`torchani-amber` is a **compiled-in C++/Fortran integration**, not a plugin. It hooks into AMBER's existing external-potential paths:
 
 | Mode | AMBER mechanism | Use case |
-|---|---|---|
+| --- | --- | --- |
 | Full ML | `iextpot = 1` + `&extpot` (`extprog = "TORCHANI"`) | All-atom ML simulation |
 | ML/MM | `ifqnt = 1` + `&qmmm` (`qm_theory = 'EXTERN'`) | QM/MM with the QM region treated by the NNP |
 
@@ -23,22 +17,14 @@ Both modes are pure mdin-file configuration -- no Python code at runtime.
 
 ## Install
 
-Not pip-installable. The integration must be **built into AMBER from
-source**:
+Not pip-installable. The integration must be **built into AMBER from source**:
 
 1. Clone `torchani-amber` (`git clone --recurse-submodules ...`).
-2. Build its bundled `torchani_sandbox` plus the C++ extensions
-   (`run-cmake`).
-3. Build AmberTools 25/26 from source with `CMAKE_PREFIX_PATH` pointing
-   at the `torchani-amber` install. AMBER auto-links it.
-4. For ML/MM where the QM region has a non-zero net charge (i.e.
-   `qm_charge != 0`) with AimNet2 or Nutmeg, AmberTools 25 needs an
-   additional patch (replace
-   `amber_src/AmberTools/sander/qm2_extern_torchani_module.F90`).
-   AmberTools 26 includes the patch.
+2. Build its bundled `torchani_sandbox` plus the C++ extensions (`run-cmake`).
+3. Build AmberTools 25/26 from source with `CMAKE_PREFIX_PATH` pointing at the `torchani-amber` install. AMBER auto-links it.
+4. For ML/MM where the QM region has a non-zero net charge (i.e. `qm_charge != 0`) with AimNet2 or Nutmeg, AmberTools 25 needs an additional patch (replace `amber_src/AmberTools/sander/qm2_extern_torchani_module.F90`). AmberTools 26 includes the patch.
 
-A conda environment recipe (PyTorch, CUDA, GFortran, OpenMPI) is
-provided in the upstream repo.
+A conda environment recipe (PyTorch, CUDA, GFortran, OpenMPI) is provided in the upstream repo.
 
 ## User-facing input
 
@@ -58,8 +44,7 @@ Minimal AIMNet2 example (full ML):
 /
 ```
 
-ML/MM example with electrostatic embedding via AIMNet2's predicted
-atomic charges:
+ML/MM example with electrostatic embedding via AIMNet2's predicted atomic charges:
 
 ```
 &cntrl
@@ -74,38 +59,20 @@ atomic charges:
 /
 ```
 
-The `mlmm_coupling` keyword selects the QM/MM coupling scheme. The
-exact embedding details (which AIMNet2 charges are used, whether MM
-point charges polarise the QM region within a step, etc.) are
-documented in the upstream `torchani-amber` reference paper and source.
+The `mlmm_coupling` keyword selects the QM/MM coupling scheme. The exact embedding details (which AIMNet2 charges are used, whether MM point charges polarise the QM region within a step, etc.) are documented in the upstream `torchani-amber` reference paper and source.
 
-`model_type` may also be a full path to a **TorchScript-jit-compiled**
-`.pt` file. The v2 `.pt` assets shipped in
-`aimnet/calculators/assets/` are `torch.save` state-dict archives, not
-TorchScript -- they cannot currently be passed as `model_type` directly.
-The [TorchScript-export work](../superpowers/plans/2026-04-26-torchscript-export.md)
-in this repo would unblock shipping a self-contained AIMNet2 jit asset
-for `torchani-amber` rather than relying on the upstream-bundled model.
+`model_type` may also be a full path to a **TorchScript-jit-compiled** `.pt` file. The v2 `.pt` assets shipped in `aimnet/calculators/assets/` are `torch.save` state-dict archives, not TorchScript -- they cannot currently be passed as `model_type` directly. The [TorchScript-export work](../superpowers/plans/2026-04-26-torchscript-export.md) in this repo would unblock shipping a self-contained AIMNet2 jit asset for `torchani-amber` rather than relying on the upstream-bundled model.
 
 ## Caveats
 
-- Hard rebuild of AmberTools required. Once linked, the AMBER binaries
-  depend on the torchani libraries even for non-ML runs.
+- Hard rebuild of AmberTools required. Once linked, the AMBER binaries depend on the torchani libraries even for non-ML runs.
 - Supported AMBER versions: AmberTools 25 (with patch) and 26.
-- The integration is tied to the `torchani_sandbox` build; the AIMNet2
-  model selection is constrained to what `torchani-amber` exposes
-  upstream until a custom jit `.pt` path is provided.
+- The integration is tied to the `torchani_sandbox` build; the AIMNet2 model selection is constrained to what `torchani-amber` exposes upstream until a custom jit `.pt` path is provided.
 
 ## Model coverage
 
-What `torchani-amber` exposes upstream as `model_type = "aimnet2"`. The
-NSE (open-shell) and rxn (reactive) AIMNet2 families are not currently
-exposed by the upstream integration.
+What `torchani-amber` exposes upstream as `model_type = "aimnet2"`. The NSE (open-shell) and rxn (reactive) AIMNet2 families are not currently exposed by the upstream integration.
 
 ## Alternatives
 
-If a full AmberTools rebuild is not acceptable, classical "AMBER force
-field plus ML region" workflows can sometimes be done via
-[OpenMM + openmm-ml](openmm.md) on AMBER-format topologies (loaded via
-ParmEd / OpenMM's `AmberPrmtopFile`). That route is pip-installable and
-needs no AMBER source build.
+If a full AmberTools rebuild is not acceptable, classical "AMBER force field plus ML region" workflows can sometimes be done via [OpenMM + openmm-ml](openmm.md) on AMBER-format topologies (loaded via ParmEd / OpenMM's `AmberPrmtopFile`). That route is pip-installable and needs no AMBER source build.

--- a/docs/external/ams.md
+++ b/docs/external/ams.md
@@ -2,28 +2,16 @@
 
 **Status: supported upstream.**
 
-The [Amsterdam Modeling Suite](https://www.scm.com/amsterdam-modeling-suite/)
-ships first-class support for AIMNet2 through the
-[`MLPotential`](https://www.scm.com/doc/MLPotential/) engine, introduced
-in **AMS2024.1**. Two AIMNet2 variants are exposed as named models:
+The [Amsterdam Modeling Suite](https://www.scm.com/amsterdam-modeling-suite/) ships first-class support for AIMNet2 through the [`MLPotential`](https://www.scm.com/doc/MLPotential/) engine, introduced in **AMS2024.1**. Two AIMNet2 variants are exposed as named models:
 
 - `AIMNet2-wB97MD3`
 - `AIMNet2-B973c`
 
-Per the SCM documentation, "these are currently the only ML potential
-models that support charged systems (ions), and that predict atomic
-charges and dipole moments and that give IR intensities when calculating
-normal modes" -- a meaningful capability gap over the other backends in
-the same engine (TorchANI, M3GNet, MACE, NequIP, FAIRChem).
+Per the SCM documentation, "these are currently the only ML potential models that support charged systems (ions), and that predict atomic charges and dipole moments and that give IR intensities when calculating normal modes" -- a meaningful capability gap over the other backends in the same engine (TorchANI, M3GNet, MACE, NequIP, FAIRChem).
 
-Element coverage: H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I. The AMS
-integration exposes AIMNet2 for **aperiodic systems only** -- this is a
-property of AMS's `MLPotential` wrapper, not of AIMNet2 itself, which
-supports PBC via the in-tree `AIMNet2Calculator`.
+Element coverage: H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I. The AMS integration exposes AIMNet2 for **aperiodic systems only** -- this is a property of AMS's `MLPotential` wrapper, not of AIMNet2 itself, which supports PBC via the in-tree `AIMNet2Calculator`.
 
-**Model coverage in this engine**: AIMNet2-wB97MD3 and AIMNet2-B973c
-only. The NSE (open-shell) and rxn (reactive) AIMNet2 model families are
-not currently exposed by AMS.
+**Model coverage in this engine**: AIMNet2-wB97MD3 and AIMNet2-B973c only. The NSE (open-shell) and rxn (reactive) AIMNet2 model families are not currently exposed by AMS.
 
 ## Minimal AMS input
 
@@ -43,17 +31,11 @@ Engine MLPotential
 EndEngine
 ```
 
-The `Model` keyword is sufficient -- the AIMNet2 backend is activated
-implicitly when an AIMNet2-prefixed model is selected. Other backends
-in the same engine (FAIRChem, M3GNet, MACE, NequIP, TorchANI) are
-selected via `Backend` directly.
+The `Model` keyword is sufficient -- the AIMNet2 backend is activated implicitly when an AIMNet2-prefixed model is selected. Other backends in the same engine (FAIRChem, M3GNet, MACE, NequIP, TorchANI) are selected via `Backend` directly.
 
 ## Workflows
 
-`Engine MLPotential` works with the standard AMS driver tasks:
-single-point, geometry optimization, transition-state search, vibrational
-analysis, molecular dynamics. AIMNet2's atomic-charge and dipole
-predictions feed AMS's normal-mode IR intensity reporting.
+`Engine MLPotential` works with the standard AMS driver tasks: single-point, geometry optimization, transition-state search, vibrational analysis, molecular dynamics. AIMNet2's atomic-charge and dipole predictions feed AMS's normal-mode IR intensity reporting.
 
 ## See also
 

--- a/docs/external/ams.md
+++ b/docs/external/ams.md
@@ -16,8 +16,14 @@ charges and dipole moments and that give IR intensities when calculating
 normal modes" -- a meaningful capability gap over the other backends in
 the same engine (TorchANI, M3GNet, MACE, NequIP, FAIRChem).
 
-Element coverage: H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (aperiodic
-systems).
+Element coverage: H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I. The AMS
+integration exposes AIMNet2 for **aperiodic systems only** -- this is a
+property of AMS's `MLPotential` wrapper, not of AIMNet2 itself, which
+supports PBC via the in-tree `AIMNet2Calculator`.
+
+**Model coverage in this engine**: AIMNet2-wB97MD3 and AIMNet2-B973c
+only. The NSE (open-shell) and rxn (reactive) AIMNet2 model families are
+not currently exposed by AMS.
 
 ## Minimal AMS input
 

--- a/docs/external/ams.md
+++ b/docs/external/ams.md
@@ -1,0 +1,56 @@
+# SCM AMS (Amsterdam Modeling Suite)
+
+**Status: supported upstream.**
+
+The [Amsterdam Modeling Suite](https://www.scm.com/amsterdam-modeling-suite/)
+ships first-class support for AIMNet2 through the
+[`MLPotential`](https://www.scm.com/doc/MLPotential/) engine, introduced
+in **AMS2024.1**. Two AIMNet2 variants are exposed as named models:
+
+- `AIMNet2-wB97MD3`
+- `AIMNet2-B973c`
+
+Per the SCM documentation, "these are currently the only ML potential
+models that support charged systems (ions), and that predict atomic
+charges and dipole moments and that give IR intensities when calculating
+normal modes" -- a meaningful capability gap over the other backends in
+the same engine (TorchANI, M3GNet, MACE, NequIP, FAIRChem).
+
+Element coverage: H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (aperiodic
+systems).
+
+## Minimal AMS input
+
+```text
+Task SinglePoint
+
+System
+  Atoms
+    O 0.0 0.0 0.0
+    H 0.0 0.7 0.6
+    H 0.0 -0.7 0.6
+  End
+End
+
+Engine MLPotential
+  Model AIMNet2-wB97MD3
+EndEngine
+```
+
+The `Model` keyword is sufficient -- the AIMNet2 backend is activated
+implicitly when an AIMNet2-prefixed model is selected. Other backends
+in the same engine (FAIRChem, M3GNet, MACE, NequIP, TorchANI) are
+selected via `Backend` directly.
+
+## Workflows
+
+`Engine MLPotential` works with the standard AMS driver tasks:
+single-point, geometry optimization, transition-state search, vibrational
+analysis, molecular dynamics. AIMNet2's atomic-charge and dipole
+predictions feed AMS's normal-mode IR intensity reporting.
+
+## See also
+
+- [SCM MLPotential general docs](https://www.scm.com/doc/MLPotential/general.html)
+- [Models & backends](https://www.scm.com/doc/MLPotential/ModelsAndBackends.html)
+- [SCM webinar on AIMNet2 (2024)](https://www.scm.com/news/ams-webinar-2024-aimnet2/)

--- a/docs/external/ase.md
+++ b/docs/external/ase.md
@@ -2,9 +2,7 @@
 
 **Status: supported (in-tree calculator).**
 
-AIMNet2 ships an ASE `Calculator` implementation (`AIMNet2ASE`) that plugs
-directly into the standard ASE workflows: single-point energies, geometry
-optimization, vibrational analysis, MD, and NEB.
+AIMNet2 ships an ASE `Calculator` implementation (`AIMNet2ASE`) that plugs directly into the standard ASE workflows: single-point energies, geometry optimization, vibrational analysis, MD, and NEB.
 
 ## Install
 
@@ -26,10 +24,7 @@ forces = atoms.get_forces()                  # eV/A
 
 ## Charge and multiplicity
 
-`AIMNet2ASE` accepts `charge=` and `mult=` constructor arguments and also
-reads `atoms.info["charge"]` and `atoms.info["mult"]` (falling back to
-`atoms.info["spin"]`) on each call. `atoms.info` takes precedence over
-the constructor value.
+`AIMNet2ASE` accepts `charge=` and `mult=` constructor arguments and also reads `atoms.info["charge"]` and `atoms.info["mult"]` (falling back to `atoms.info["spin"]`) on each call. `atoms.info` takes precedence over the constructor value.
 
 ```python
 atoms.calc = AIMNet2ASE("aimnet2", charge=-1)
@@ -37,11 +32,10 @@ atoms.calc = AIMNet2ASE("aimnet2", charge=-1)
 
 ## Periodic systems
 
-The calculator handles PBC automatically when `atoms.pbc` is set and the
-cell is non-zero. Use `atoms.get_stress()` to obtain the stress tensor
-for periodic systems.
+The calculator handles PBC automatically when `atoms.pbc` is set and the cell is non-zero. Use `atoms.get_stress()` to obtain the stress tensor for periodic systems.
 
 See:
+
 - [Single point](../tutorials/single_point.md)
 - [Geometry optimization](../tutorials/geometry_optimization.md)
 - [Molecular dynamics](../tutorials/molecular_dynamics.md)
@@ -50,12 +44,8 @@ See:
 
 ## Implemented properties
 
-`energy`, `forces`, `free_energy`, `charges`, `stress`, `dipole_moment`,
-plus `spin_charges` for NSE models.
+`energy`, `forces`, `free_energy`, `charges`, `stress`, `dipole_moment`, plus `spin_charges` for NSE models.
 
 ## Model coverage
 
-All AIMNet2 model families are accessible via `AIMNet2ASE("<name>")`:
-wb97m-d3, b97-3c, NSE (open-shell), rxn (reactive PES, no net charge),
-Pd. Pick the right family for the system -- see
-[Models / Selection Guide](../models/guide.md).
+All AIMNet2 model families are accessible via `AIMNet2ASE("<name>")`: wb97m-d3, b97-3c, NSE (open-shell), rxn (reactive PES, no net charge), Pd. Pick the right family for the system -- see [Models / Selection Guide](../models/guide.md).

--- a/docs/external/ase.md
+++ b/docs/external/ase.md
@@ -1,5 +1,7 @@
 # ASE
 
+**Status: supported (in-tree calculator).**
+
 AIMNet2 ships an ASE `Calculator` implementation (`AIMNet2ASE`) that plugs
 directly into the standard ASE workflows: single-point energies, geometry
 optimization, vibrational analysis, MD, and NEB.
@@ -25,8 +27,9 @@ forces = atoms.get_forces()                  # eV/A
 ## Charge and multiplicity
 
 `AIMNet2ASE` accepts `charge=` and `mult=` constructor arguments and also
-reads `atoms.info["charge"]` / `atoms.info["spin"]` (or `["mult"]`) on
-each call, with `atoms.info` taking precedence over the constructor value.
+reads `atoms.info["charge"]` and `atoms.info["mult"]` (falling back to
+`atoms.info["spin"]`) on each call. `atoms.info` takes precedence over
+the constructor value.
 
 ```python
 atoms.calc = AIMNet2ASE("aimnet2", charge=-1)
@@ -35,7 +38,8 @@ atoms.calc = AIMNet2ASE("aimnet2", charge=-1)
 ## Periodic systems
 
 The calculator handles PBC automatically when `atoms.pbc` is set and the
-cell is non-zero. Stress requires `stress=True`-equivalent ASE calls.
+cell is non-zero. Use `atoms.get_stress()` to obtain the stress tensor
+for periodic systems.
 
 See:
 - [Single point](../tutorials/single_point.md)
@@ -48,3 +52,10 @@ See:
 
 `energy`, `forces`, `free_energy`, `charges`, `stress`, `dipole_moment`,
 plus `spin_charges` for NSE models.
+
+## Model coverage
+
+All AIMNet2 model families are accessible via `AIMNet2ASE("<name>")`:
+wb97m-d3, b97-3c, NSE (open-shell), rxn (reactive PES, no net charge),
+Pd. Pick the right family for the system -- see
+[Models / Selection Guide](../models/guide.md).

--- a/docs/external/ase.md
+++ b/docs/external/ase.md
@@ -1,0 +1,50 @@
+# ASE
+
+AIMNet2 ships an ASE `Calculator` implementation (`AIMNet2ASE`) that plugs
+directly into the standard ASE workflows: single-point energies, geometry
+optimization, vibrational analysis, MD, and NEB.
+
+## Install
+
+```bash
+pip install "aimnet[ase]"
+```
+
+## Quick start
+
+```python
+from ase.build import molecule
+from aimnet.calculators import AIMNet2ASE
+
+atoms = molecule("H2O")
+atoms.calc = AIMNet2ASE("aimnet2")           # registry alias
+energy = atoms.get_potential_energy()        # eV
+forces = atoms.get_forces()                  # eV/A
+```
+
+## Charge and multiplicity
+
+`AIMNet2ASE` accepts `charge=` and `mult=` constructor arguments and also
+reads `atoms.info["charge"]` / `atoms.info["spin"]` (or `["mult"]`) on
+each call, with `atoms.info` taking precedence over the constructor value.
+
+```python
+atoms.calc = AIMNet2ASE("aimnet2", charge=-1)
+```
+
+## Periodic systems
+
+The calculator handles PBC automatically when `atoms.pbc` is set and the
+cell is non-zero. Stress requires `stress=True`-equivalent ASE calls.
+
+See:
+- [Single point](../tutorials/single_point.md)
+- [Geometry optimization](../tutorials/geometry_optimization.md)
+- [Molecular dynamics](../tutorials/molecular_dynamics.md)
+- [Periodic systems](../tutorials/periodic_systems.md)
+- [Calculator API reference](../calculator.md)
+
+## Implemented properties
+
+`energy`, `forces`, `free_energy`, `charges`, `stress`, `dipole_moment`,
+plus `spin_charges` for NSE models.

--- a/docs/external/gromacs.md
+++ b/docs/external/gromacs.md
@@ -42,7 +42,15 @@ For QM/MM-style workflows that do not require GROMACS specifically:
 
 - `AIMNet2ASE` + ASE's MD drivers (Langevin, NVT, NVE) for pure ML
   trajectories, with [pysisyphus](pysis.md) for path following.
-- For QM/MM where AMBER is acceptable, the
-  [AMBER `sander` ML interface](amber.md) accepts Python callbacks and
-  does not require a TorchScript export. This route is unblocked but not
-  yet wrapped here.
+- [OpenMM via openmm-ml](openmm.md) -- pip-installable, runs the
+  AIMNet2 calculator behind `openmm.PythonForce` (no TorchScript
+  needed); supports periodic systems and `createMixedSystem` for QM/MM.
+- [AMBER via torchani-amber](amber.md) -- compiled-in C++/Fortran
+  integration for `sander` and `pmemd`; supports both full-ML and
+  ML/MM modes via the `&extpot` and `&qmmm` mdin namelists.
+
+A future GROMACS wrapper must include AIMNet2's D3 dispersion (the
+embedded D3 in the wb97m-d3 model is part of the published level of
+theory). A no-dispersion shortcut would silently shift conformer
+rankings, intermolecular binding, and torsion barriers by 1-10 kcal/mol
+vs the published numbers.

--- a/docs/external/gromacs.md
+++ b/docs/external/gromacs.md
@@ -1,0 +1,48 @@
+# GROMACS (NNPot)
+
+**Status: not currently supported.**
+
+GROMACS 2025.0 introduced the [NNPot](https://manual.gromacs.org/nightly/reference-manual/special/nnpot.html)
+interface, which loads a TorchScript `.pt` file via the `nnpot-modelfile`
+mdp option for QM-region energies and forces in QM/MM simulations. The
+2026 series expanded model compatibility.
+
+AIMNet2 cannot currently produce a `.pt` that the NNPot interface accepts.
+The reasons are upstream-internal, not a packaging gap:
+
+1. The shipped v2 `.pt` assets in `aimnet/calculators/assets/` are
+   `torch.save` state-dict archives, **not** TorchScript archives. They
+   are loaded into a Python `nn.Module` by `aimnet.models.base.load_model`.
+2. `torch.jit.script` on the in-memory `AIMNet2` model fails in
+   `aimnet/nbops.py` -- the code uses `tensor.data_ptr()` as a
+   neighbor-cache key, which TorchScript rejects.
+3. `torch.jit.script` on the external `DFTD3` module fails because its
+   custom autograd uses an `aten::grad` signature TorchScript cannot
+   resolve.
+4. The published `aimnet2` (wb97m-d3) model needs both external Coulomb
+   and external D3 added on top of the core, so even if the core
+   scripted, the wrapper would have to bundle all three pieces to match
+   `AIMNet2Calculator` energies.
+
+## Tracking
+
+A starter wrapper is parked at `aimnet/interfaces/gromacs.py` -- the
+forward signature, unit conversions (nm -> A on input; eV -> kJ/mol on
+output), and pure-PyTorch all-pairs neighbor list have been verified to
+`torch.jit.script` cleanly with a dummy inner model and to round-trip via
+`jit.save` / `jit.load`. It will become functional once the blockers
+above are resolved.
+
+The remediation plan lives at
+[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+
+## What works today instead
+
+For QM/MM-style workflows that do not require GROMACS specifically:
+
+- `AIMNet2ASE` + ASE's MD drivers (Langevin, NVT, NVE) for pure ML
+  trajectories, with [pysisyphus](pysis.md) for path following.
+- For QM/MM where AMBER is acceptable, the
+  [AMBER `sander` ML interface](amber.md) accepts Python callbacks and
+  does not require a TorchScript export. This route is unblocked but not
+  yet wrapped here.

--- a/docs/external/gromacs.md
+++ b/docs/external/gromacs.md
@@ -2,55 +2,27 @@
 
 **Status: not currently supported.**
 
-GROMACS 2025.0 introduced the [NNPot](https://manual.gromacs.org/nightly/reference-manual/special/nnpot.html)
-interface, which loads a TorchScript `.pt` file via the `nnpot-modelfile`
-mdp option for QM-region energies and forces in QM/MM simulations. The
-2026 series expanded model compatibility.
+GROMACS 2025.0 introduced the [NNPot](https://manual.gromacs.org/nightly/reference-manual/special/nnpot.html) interface, which loads a TorchScript `.pt` file via the `nnpot-modelfile` mdp option for QM-region energies and forces in QM/MM simulations. The 2026 series expanded model compatibility.
 
-AIMNet2 cannot currently produce a `.pt` that the NNPot interface accepts.
-The reasons are upstream-internal, not a packaging gap:
+AIMNet2 cannot currently produce a `.pt` that the NNPot interface accepts. The reasons are upstream-internal, not a packaging gap:
 
-1. The shipped v2 `.pt` assets in `aimnet/calculators/assets/` are
-   `torch.save` state-dict archives, **not** TorchScript archives. They
-   are loaded into a Python `nn.Module` by `aimnet.models.base.load_model`.
-2. `torch.jit.script` on the in-memory `AIMNet2` model fails in
-   `aimnet/nbops.py` -- the code uses `tensor.data_ptr()` as a
-   neighbor-cache key, which TorchScript rejects.
-3. `torch.jit.script` on the external `DFTD3` module fails because its
-   custom autograd uses an `aten::grad` signature TorchScript cannot
-   resolve.
-4. The published `aimnet2` (wb97m-d3) model needs both external Coulomb
-   and external D3 added on top of the core, so even if the core
-   scripted, the wrapper would have to bundle all three pieces to match
-   `AIMNet2Calculator` energies.
+1. The shipped v2 `.pt` assets in `aimnet/calculators/assets/` are `torch.save` state-dict archives, **not** TorchScript archives. They are loaded into a Python `nn.Module` by `aimnet.models.base.load_model`.
+2. `torch.jit.script` on the in-memory `AIMNet2` model fails in `aimnet/nbops.py` -- the code uses `tensor.data_ptr()` as a neighbor-cache key, which TorchScript rejects.
+3. `torch.jit.script` on the external `DFTD3` module fails because its custom autograd uses an `aten::grad` signature TorchScript cannot resolve.
+4. The published `aimnet2` (wb97m-d3) model needs both external Coulomb and external D3 added on top of the core, so even if the core scripted, the wrapper would have to bundle all three pieces to match `AIMNet2Calculator` energies.
 
 ## Tracking
 
-A starter wrapper is parked at `aimnet/interfaces/gromacs.py` -- the
-forward signature, unit conversions (nm -> A on input; eV -> kJ/mol on
-output), and pure-PyTorch all-pairs neighbor list have been verified to
-`torch.jit.script` cleanly with a dummy inner model and to round-trip via
-`jit.save` / `jit.load`. It will become functional once the blockers
-above are resolved.
+A starter wrapper is parked at `aimnet/interfaces/gromacs.py` -- the forward signature, unit conversions (nm -> A on input; eV -> kJ/mol on output), and pure-PyTorch all-pairs neighbor list have been verified to `torch.jit.script` cleanly with a dummy inner model and to round-trip via `jit.save` / `jit.load`. It will become functional once the blockers above are resolved.
 
-The remediation plan lives at
-[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+The remediation plan lives at [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
 
 ## What works today instead
 
 For QM/MM-style workflows that do not require GROMACS specifically:
 
-- `AIMNet2ASE` + ASE's MD drivers (Langevin, NVT, NVE) for pure ML
-  trajectories, with [pysisyphus](pysis.md) for path following.
-- [OpenMM via openmm-ml](openmm.md) -- pip-installable, runs the
-  AIMNet2 calculator behind `openmm.PythonForce` (no TorchScript
-  needed); supports periodic systems and `createMixedSystem` for QM/MM.
-- [AMBER via torchani-amber](amber.md) -- compiled-in C++/Fortran
-  integration for `sander` and `pmemd`; supports both full-ML and
-  ML/MM modes via the `&extpot` and `&qmmm` mdin namelists.
+- `AIMNet2ASE` + ASE's MD drivers (Langevin, NVT, NVE) for pure ML trajectories, with [pysisyphus](pysis.md) for path following.
+- [OpenMM via openmm-ml](openmm.md) -- pip-installable, runs the AIMNet2 calculator behind `openmm.PythonForce` (no TorchScript needed); supports periodic systems and `createMixedSystem` for QM/MM.
+- [AMBER via torchani-amber](amber.md) -- compiled-in C++/Fortran integration for `sander` and `pmemd`; supports both full-ML and ML/MM modes via the `&extpot` and `&qmmm` mdin namelists.
 
-A future GROMACS wrapper must include AIMNet2's D3 dispersion (the
-embedded D3 in the wb97m-d3 model is part of the published level of
-theory). A no-dispersion shortcut would silently shift conformer
-rankings, intermolecular binding, and torsion barriers by 1-10 kcal/mol
-vs the published numbers.
+A future GROMACS wrapper must include AIMNet2's D3 dispersion (the embedded D3 in the wb97m-d3 model is part of the published level of theory). A no-dispersion shortcut would silently shift conformer rankings, intermolecular binding, and torsion barriers by 1-10 kcal/mol vs the published numbers.

--- a/docs/external/index.md
+++ b/docs/external/index.md
@@ -1,0 +1,29 @@
+# External Packages
+
+AIMNet2 is consumed by several external simulation and analysis packages.
+This section is the entry point for users coming from one of those tools.
+
+## Available today
+
+| Package | Status | Page |
+|---|---|---|
+| ASE | Supported (in-tree calculator) | [ASE](ase.md) |
+| pysisyphus | Supported (in-tree calculator) | [pysisyphus](pysis.md) |
+| OpenMM (`openmmml`) | Supported upstream via `MLPotential('aimnet2')` (Python callback, no TorchScript needed) | [OpenMM](openmm.md) |
+| AMBER (`torchani-amber`) | Supported upstream for `sander` and `pmemd`; requires recompiling AmberTools 25/26 with the integration | [AMBER](amber.md) |
+| SCM AMS (`MLPotential` engine) | Supported upstream from AMS2024.1 via `Model AIMNet2-wB97MD3` / `AIMNet2-B973c` | [SCM AMS](ams.md) |
+| ORCA (`!ExtOpt`) | Supported upstream from ORCA 6.1 via the ORCA-External-Tools `aimnet2` wrapper | [ORCA](orca.md) |
+
+## In progress / blocked
+
+| Package | Status | Page |
+|---|---|---|
+| GROMACS NNPot (>=2025.0) | Blocked on TorchScript export | [GROMACS](gromacs.md) |
+| LAMMPS (`pair_style mliap`) | Blocked on TorchScript export | [LAMMPS](lammps.md) |
+
+The TorchScript-export blockers shared by GROMACS and LAMMPS are tracked
+in
+[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+Note: AMBER also consumes a TorchScript `.pt` (via `model_type = "..."`
+in the `&ani` namelist), so the same export work would let us ship a
+self-contained AIMNet2 jit asset for `torchani-amber` too.

--- a/docs/external/index.md
+++ b/docs/external/index.md
@@ -1,12 +1,9 @@
 # External Packages
 
-AIMNet2 is consumed by several external simulation and analysis packages.
-This section is the entry point for users coming from one of those tools.
-Each package's per-page banner is the canonical status; the table here
-is a navigation aid only.
+AIMNet2 is consumed by several external simulation and analysis packages. This section is the entry point for users coming from one of those tools. Each package's per-page banner is the canonical status; the table here is a navigation aid only.
 
 | Package | Status | Page |
-|---|---|---|
+| --- | --- | --- |
 | ASE | Supported | [ASE](ase.md) |
 | pysisyphus | Supported | [pysisyphus](pysis.md) |
 | OpenMM (`openmmml`) | Supported upstream | [OpenMM](openmm.md) |
@@ -16,9 +13,4 @@ is a navigation aid only.
 | GROMACS NNPot | Blocked on TorchScript export | [GROMACS](gromacs.md) |
 | LAMMPS (`pair_style mliap`) | Blocked on TorchScript export | [LAMMPS](lammps.md) |
 
-The TorchScript-export blockers shared by GROMACS and LAMMPS are tracked
-in
-[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
-AMBER also benefits from that work -- `torchani-amber` accepts a
-TorchScript `.pt` via the `model_type` keyword, so the same export
-pathway would let us ship a self-contained AIMNet2 jit asset.
+The TorchScript-export blockers shared by GROMACS and LAMMPS are tracked in [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md). AMBER also benefits from that work -- `torchani-amber` accepts a TorchScript `.pt` via the `model_type` keyword, so the same export pathway would let us ship a self-contained AIMNet2 jit asset.

--- a/docs/external/index.md
+++ b/docs/external/index.md
@@ -2,28 +2,23 @@
 
 AIMNet2 is consumed by several external simulation and analysis packages.
 This section is the entry point for users coming from one of those tools.
-
-## Available today
-
-| Package | Status | Page |
-|---|---|---|
-| ASE | Supported (in-tree calculator) | [ASE](ase.md) |
-| pysisyphus | Supported (in-tree calculator) | [pysisyphus](pysis.md) |
-| OpenMM (`openmmml`) | Supported upstream via `MLPotential('aimnet2')` (Python callback, no TorchScript needed) | [OpenMM](openmm.md) |
-| AMBER (`torchani-amber`) | Supported upstream for `sander` and `pmemd`; requires recompiling AmberTools 25/26 with the integration | [AMBER](amber.md) |
-| SCM AMS (`MLPotential` engine) | Supported upstream from AMS2024.1 via `Model AIMNet2-wB97MD3` / `AIMNet2-B973c` | [SCM AMS](ams.md) |
-| ORCA (`!ExtOpt`) | Supported upstream from ORCA 6.1 via the ORCA-External-Tools `aimnet2` wrapper | [ORCA](orca.md) |
-
-## In progress / blocked
+Each package's per-page banner is the canonical status; the table here
+is a navigation aid only.
 
 | Package | Status | Page |
 |---|---|---|
-| GROMACS NNPot (>=2025.0) | Blocked on TorchScript export | [GROMACS](gromacs.md) |
+| ASE | Supported | [ASE](ase.md) |
+| pysisyphus | Supported | [pysisyphus](pysis.md) |
+| OpenMM (`openmmml`) | Supported upstream | [OpenMM](openmm.md) |
+| AMBER (`torchani-amber`) | Supported upstream | [AMBER](amber.md) |
+| SCM AMS (`MLPotential` engine) | Supported upstream | [SCM AMS](ams.md) |
+| ORCA (`!ExtOpt`) | Supported upstream | [ORCA](orca.md) |
+| GROMACS NNPot | Blocked on TorchScript export | [GROMACS](gromacs.md) |
 | LAMMPS (`pair_style mliap`) | Blocked on TorchScript export | [LAMMPS](lammps.md) |
 
 The TorchScript-export blockers shared by GROMACS and LAMMPS are tracked
 in
 [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
-Note: AMBER also consumes a TorchScript `.pt` (via `model_type = "..."`
-in the `&ani` namelist), so the same export work would let us ship a
-self-contained AIMNet2 jit asset for `torchani-amber` too.
+AMBER also benefits from that work -- `torchani-amber` accepts a
+TorchScript `.pt` via the `model_type` keyword, so the same export
+pathway would let us ship a self-contained AIMNet2 jit asset.

--- a/docs/external/lammps.md
+++ b/docs/external/lammps.md
@@ -27,3 +27,8 @@ scripted module instead.
 
 The shared remediation plan lives at
 [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+
+A future LAMMPS wrapper must include AIMNet2's D3 dispersion to match
+the published wb97m-d3 level of theory. A no-dispersion shortcut would
+silently shift conformer rankings, intermolecular binding, and torsion
+barriers by 1-10 kcal/mol vs the published numbers.

--- a/docs/external/lammps.md
+++ b/docs/external/lammps.md
@@ -2,33 +2,16 @@
 
 **Status: not currently supported.**
 
-LAMMPS exposes TorchScript-based ML potentials via
-[`pair_style mliap`](https://docs.lammps.org/pair_mliap.html) with the
-`mliappy` model (built into LAMMPS; requires the `ML-IAP` and `PYTHON`
-packages at build time). LAMMPS supplies the neighbor list to the
-Python/TorchScript model rather than the model building its own.
+LAMMPS exposes TorchScript-based ML potentials via [`pair_style mliap`](https://docs.lammps.org/pair_mliap.html) with the `mliappy` model (built into LAMMPS; requires the `ML-IAP` and `PYTHON` packages at build time). LAMMPS supplies the neighbor list to the Python/TorchScript model rather than the model building its own.
 
-AIMNet2 cannot currently produce a `.pt` that this route accepts, for
-the same reasons documented in [GROMACS NNPot](gromacs.md):
+AIMNet2 cannot currently produce a `.pt` that this route accepts, for the same reasons documented in [GROMACS NNPot](gromacs.md):
 
 1. The shipped v2 `.pt` files are state-dict archives, not TorchScript.
-2. `torch.jit.script` on the core `AIMNet2` module fails on
-   `tensor.data_ptr()` in `aimnet/nbops.py`.
-3. `torch.jit.script` on the external `DFTD3` module fails on its
-   custom autograd signature.
+2. `torch.jit.script` on the core `AIMNet2` module fails on `tensor.data_ptr()` in `aimnet/nbops.py`.
+3. `torch.jit.script` on the external `DFTD3` module fails on its custom autograd signature.
 
-In addition, LAMMPS expects the scripted model to **accept a
-LAMMPS-supplied neighbor list** (atom indices, and for some pair styles
-edge-index + cell-shift tensors) rather than build its own. The
-all-pairs neighbor list used in the parked GROMACS wrapper would not be
-performant for typical LAMMPS box sizes. A LAMMPS-targeted wrapper
-would need to consume the engine-supplied neighbor list inside the
-scripted module instead.
+In addition, LAMMPS expects the scripted model to **accept a LAMMPS-supplied neighbor list** (atom indices, and for some pair styles edge-index + cell-shift tensors) rather than build its own. The all-pairs neighbor list used in the parked GROMACS wrapper would not be performant for typical LAMMPS box sizes. A LAMMPS-targeted wrapper would need to consume the engine-supplied neighbor list inside the scripted module instead.
 
-The shared remediation plan lives at
-[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+The shared remediation plan lives at [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
 
-A future LAMMPS wrapper must include AIMNet2's D3 dispersion to match
-the published wb97m-d3 level of theory. A no-dispersion shortcut would
-silently shift conformer rankings, intermolecular binding, and torsion
-barriers by 1-10 kcal/mol vs the published numbers.
+A future LAMMPS wrapper must include AIMNet2's D3 dispersion to match the published wb97m-d3 level of theory. A no-dispersion shortcut would silently shift conformer rankings, intermolecular binding, and torsion barriers by 1-10 kcal/mol vs the published numbers.

--- a/docs/external/lammps.md
+++ b/docs/external/lammps.md
@@ -1,0 +1,29 @@
+# LAMMPS
+
+**Status: not currently supported.**
+
+LAMMPS exposes TorchScript-based ML potentials via
+[`pair_style mliap`](https://docs.lammps.org/pair_mliap.html) with the
+`mliappy` model (built into LAMMPS; requires the `ML-IAP` and `PYTHON`
+packages at build time). LAMMPS supplies the neighbor list to the
+Python/TorchScript model rather than the model building its own.
+
+AIMNet2 cannot currently produce a `.pt` that this route accepts, for
+the same reasons documented in [GROMACS NNPot](gromacs.md):
+
+1. The shipped v2 `.pt` files are state-dict archives, not TorchScript.
+2. `torch.jit.script` on the core `AIMNet2` module fails on
+   `tensor.data_ptr()` in `aimnet/nbops.py`.
+3. `torch.jit.script` on the external `DFTD3` module fails on its
+   custom autograd signature.
+
+In addition, LAMMPS expects the scripted model to **accept a
+LAMMPS-supplied neighbor list** (atom indices, and for some pair styles
+edge-index + cell-shift tensors) rather than build its own. The
+all-pairs neighbor list used in the parked GROMACS wrapper would not be
+performant for typical LAMMPS box sizes. A LAMMPS-targeted wrapper
+would need to consume the engine-supplied neighbor list inside the
+scripted module instead.
+
+The shared remediation plan lives at
+[`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).

--- a/docs/external/openmm.md
+++ b/docs/external/openmm.md
@@ -45,10 +45,19 @@ Pass via the `MLPotential` arguments. They are forwarded to the AIMNet2
 calculator through the `args` dict:
 
 ```python
-system = potential.createSystem(topology, charge=-1, multiplicity=2)
+system = potential.createSystem(topology, charge=-1, multiplicity=1)
 ```
 
 Defaults: `charge=0`, `multiplicity=1`.
+
+!!! warning "Closed-shell only"
+    `MLPotential('aimnet2')` is hard-wired upstream to the wb97m-d3
+    closed-shell model (`is_nse=False`). The `multiplicity` argument is
+    silently consumed but does **not** select an open-shell PES --
+    setting `multiplicity=2` for a doublet returns the closed-shell
+    answer. For radicals / open-shell species use the AIMNet2-NSE
+    family directly via the in-tree [`AIMNet2ASE`](ase.md) calculator;
+    NSE is not exposed by `openmmml` today.
 
 ## Periodic systems
 
@@ -77,10 +86,14 @@ the same eager-mode AIMNet2 throughput you get from
 
 ## Caveats
 
-- The model name is hard-coded to `'aimnet2'` upstream. Other AIMNet2
-  variants (b97-3c, NSE, rxn) need a one-line change in
-  `openmmml/models/aimnet2potential.py` to expose them via
-  `MLPotential('...')`.
+- **Model coverage in this engine**: only the wb97m-d3 model is exposed
+  upstream as `MLPotential('aimnet2')`. Other variants (B97-3c, NSE,
+  rxn) require per-family changes upstream, not just a model-name
+  string -- e.g. AIMNet2-rxn has `supports_charged_systems=False`,
+  fixed 4.6 A SR/LR cutoffs, and a learned energy scale that makes
+  cross-family `createMixedSystem` energies meaningless. Exposing
+  another variant in `openmmml` is a per-family contract, not a
+  one-line change.
 - Performance is the eager Python path -- not the eventual TorchScript
   fast path planned in
   [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).

--- a/docs/external/openmm.md
+++ b/docs/external/openmm.md
@@ -2,12 +2,7 @@
 
 **Status: supported.**
 
-[`openmm-ml`](https://github.com/openmm/openmm-ml) ships a built-in
-`AIMNet2PotentialImpl` that wraps `aimnet.calculators.AIMNet2Calculator`
-behind OpenMM's `MLPotential` API. The integration uses
-`openmm.PythonForce` -- a Python callback per step -- so it does **not**
-require a TorchScript export and is unaffected by the
-[TorchScript-export blockers](gromacs.md) that gate GROMACS and LAMMPS.
+[`openmm-ml`](https://github.com/openmm/openmm-ml) ships a built-in `AIMNet2PotentialImpl` that wraps `aimnet.calculators.AIMNet2Calculator` behind OpenMM's `MLPotential` API. The integration uses `openmm.PythonForce` -- a Python callback per step -- so it does **not** require a TorchScript export and is unaffected by the [TorchScript-export blockers](gromacs.md) that gate GROMACS and LAMMPS.
 
 ## Install
 
@@ -15,8 +10,7 @@ require a TorchScript export and is unaffected by the
 pip install aimnet openmm openmmml
 ```
 
-The PyPI distribution name is `openmmml` (no hyphen). Conda-forge ships
-the same project as `openmm-ml`.
+The PyPI distribution name is `openmmml` (no hyphen). Conda-forge ships the same project as `openmm-ml`.
 
 ## Quick start
 
@@ -30,9 +24,7 @@ system = potential.createSystem(topology)
 
 ## QM/MM (mixed system)
 
-`createMixedSystem` lets you replace a subset of atoms with the AIMNet2
-potential while keeping the rest of the system on a classical force
-field:
+`createMixedSystem` lets you replace a subset of atoms with the AIMNet2 potential while keeping the rest of the system on a classical force field:
 
 ```python
 mlAtoms = [...]   # atom indices belonging to the ML region
@@ -41,8 +33,7 @@ system = potential.createMixedSystem(topology, mmSystem, mlAtoms)
 
 ## Charge and multiplicity
 
-Pass via the `MLPotential` arguments. They are forwarded to the AIMNet2
-calculator through the `args` dict:
+Pass via the `MLPotential` arguments. They are forwarded to the AIMNet2 calculator through the `args` dict:
 
 ```python
 system = potential.createSystem(topology, charge=-1, multiplicity=1)
@@ -50,50 +41,27 @@ system = potential.createSystem(topology, charge=-1, multiplicity=1)
 
 Defaults: `charge=0`, `multiplicity=1`.
 
-!!! warning "Closed-shell only"
-    `MLPotential('aimnet2')` is hard-wired upstream to the wb97m-d3
-    closed-shell model (`is_nse=False`). The `multiplicity` argument is
-    silently consumed but does **not** select an open-shell PES --
-    setting `multiplicity=2` for a doublet returns the closed-shell
-    answer. For radicals / open-shell species use the AIMNet2-NSE
-    family directly via the in-tree [`AIMNet2ASE`](ase.md) calculator;
-    NSE is not exposed by `openmmml` today.
+!!! warning "Closed-shell only" `MLPotential('aimnet2')` is hard-wired upstream to the wb97m-d3 closed-shell model (`is_nse=False`). The `multiplicity` argument is silently consumed but does **not** select an open-shell PES -- setting `multiplicity=2` for a doublet returns the closed-shell answer. For radicals / open-shell species use the AIMNet2-NSE family directly via the in-tree [`AIMNet2ASE`](ase.md) calculator; NSE is not exposed by `openmmml` today.
 
 ## Periodic systems
 
-`AIMNet2PotentialImpl` automatically passes the periodic box vectors to
-the calculator when the topology has them set
-(`topology.getPeriodicBoxVectors() is not None`). The `PythonForce` is
-flagged with `setUsesPeriodicBoundaryConditions(True)` in that case.
+`AIMNet2PotentialImpl` automatically passes the periodic box vectors to the calculator when the topology has them set (`topology.getPeriodicBoxVectors() is not None`). The `PythonForce` is flagged with `setUsesPeriodicBoundaryConditions(True)` in that case.
 
 ## Mechanism
 
 Internally:
 
-1. `MLPotential('aimnet2')` constructs `AIMNet2Calculator('aimnet2')` --
-   the published wb97m-d3 model is hard-wired upstream.
+1. `MLPotential('aimnet2')` constructs `AIMNet2Calculator('aimnet2')` -- the published wb97m-d3 model is hard-wired upstream.
 2. Each step OpenMM calls a Python function that:
    - reads positions (nm) from the simulation `State`, converts to A,
-   - calls `model({"coord", "numbers", "charge", "mult", "cell"?},
-     forces=True)`,
+   - calls `model({"coord", "numbers", "charge", "mult", "cell"?}, forces=True)`,
    - converts energy eV -> kJ/mol and forces eV/A -> kJ/mol/nm,
    - returns `(energy, forces)`.
 3. OpenMM consumes those via `PythonForce`.
 
-Because this runs in Python on every MD step, performance is bounded by
-the same eager-mode AIMNet2 throughput you get from
-[`AIMNet2ASE`](ase.md).
+Because this runs in Python on every MD step, performance is bounded by the same eager-mode AIMNet2 throughput you get from [`AIMNet2ASE`](ase.md).
 
 ## Caveats
 
-- **Model coverage in this engine**: only the wb97m-d3 model is exposed
-  upstream as `MLPotential('aimnet2')`. Other variants (B97-3c, NSE,
-  rxn) require per-family changes upstream, not just a model-name
-  string -- e.g. AIMNet2-rxn has `supports_charged_systems=False`,
-  fixed 4.6 A SR/LR cutoffs, and a learned energy scale that makes
-  cross-family `createMixedSystem` energies meaningless. Exposing
-  another variant in `openmmml` is a per-family contract, not a
-  one-line change.
-- Performance is the eager Python path -- not the eventual TorchScript
-  fast path planned in
-  [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).
+- **Model coverage in this engine**: only the wb97m-d3 model is exposed upstream as `MLPotential('aimnet2')`. Other variants (B97-3c, NSE, rxn) require per-family changes upstream, not just a model-name string -- e.g. AIMNet2-rxn has `supports_charged_systems=False`, fixed 4.6 A SR/LR cutoffs, and a learned energy scale that makes cross-family `createMixedSystem` energies meaningless. Exposing another variant in `openmmml` is a per-family contract, not a one-line change.
+- Performance is the eager Python path -- not the eventual TorchScript fast path planned in [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).

--- a/docs/external/openmm.md
+++ b/docs/external/openmm.md
@@ -1,0 +1,86 @@
+# OpenMM (openmm-ml)
+
+**Status: supported.**
+
+[`openmm-ml`](https://github.com/openmm/openmm-ml) ships a built-in
+`AIMNet2PotentialImpl` that wraps `aimnet.calculators.AIMNet2Calculator`
+behind OpenMM's `MLPotential` API. The integration uses
+`openmm.PythonForce` -- a Python callback per step -- so it does **not**
+require a TorchScript export and is unaffected by the
+[TorchScript-export blockers](gromacs.md) that gate GROMACS and LAMMPS.
+
+## Install
+
+```bash
+pip install aimnet openmm openmmml
+```
+
+The PyPI distribution name is `openmmml` (no hyphen). Conda-forge ships
+the same project as `openmm-ml`.
+
+## Quick start
+
+```python
+from openmm.app import Topology
+from openmmml import MLPotential
+
+potential = MLPotential('aimnet2')
+system = potential.createSystem(topology)
+```
+
+## QM/MM (mixed system)
+
+`createMixedSystem` lets you replace a subset of atoms with the AIMNet2
+potential while keeping the rest of the system on a classical force
+field:
+
+```python
+mlAtoms = [...]   # atom indices belonging to the ML region
+system = potential.createMixedSystem(topology, mmSystem, mlAtoms)
+```
+
+## Charge and multiplicity
+
+Pass via the `MLPotential` arguments. They are forwarded to the AIMNet2
+calculator through the `args` dict:
+
+```python
+system = potential.createSystem(topology, charge=-1, multiplicity=2)
+```
+
+Defaults: `charge=0`, `multiplicity=1`.
+
+## Periodic systems
+
+`AIMNet2PotentialImpl` automatically passes the periodic box vectors to
+the calculator when the topology has them set
+(`topology.getPeriodicBoxVectors() is not None`). The `PythonForce` is
+flagged with `setUsesPeriodicBoundaryConditions(True)` in that case.
+
+## Mechanism
+
+Internally:
+
+1. `MLPotential('aimnet2')` constructs `AIMNet2Calculator('aimnet2')` --
+   the published wb97m-d3 model is hard-wired upstream.
+2. Each step OpenMM calls a Python function that:
+   - reads positions (nm) from the simulation `State`, converts to A,
+   - calls `model({"coord", "numbers", "charge", "mult", "cell"?},
+     forces=True)`,
+   - converts energy eV -> kJ/mol and forces eV/A -> kJ/mol/nm,
+   - returns `(energy, forces)`.
+3. OpenMM consumes those via `PythonForce`.
+
+Because this runs in Python on every MD step, performance is bounded by
+the same eager-mode AIMNet2 throughput you get from
+[`AIMNet2ASE`](ase.md).
+
+## Caveats
+
+- The model name is hard-coded to `'aimnet2'` upstream. Other AIMNet2
+  variants (b97-3c, NSE, rxn) need a one-line change in
+  `openmmml/models/aimnet2potential.py` to expose them via
+  `MLPotential('...')`.
+- Performance is the eager Python path -- not the eventual TorchScript
+  fast path planned in
+  [`docs/superpowers/plans/2026-04-26-torchscript-export.md`](../superpowers/plans/2026-04-26-torchscript-export.md).

--- a/docs/external/orca.md
+++ b/docs/external/orca.md
@@ -1,0 +1,80 @@
+# ORCA (`!ExtOpt`)
+
+**Status: supported upstream.**
+
+ORCA 6.1 added a generic external-methods interface (`!ExtOpt`) that lets
+the ORCA optimizer, NEB-TS, and GOAT conformer sampler drive arbitrary
+external energy/gradient providers, including neural-network potentials.
+AIMNet2 is one of the explicitly named supported backends, alongside UMA
+and `g-xTB`. Wrapper scripts live in the upstream
+[ORCA-External-Tools](https://www.faccts.de/docs/orca/6.1/tutorials/workflows/extopt.html)
+project.
+
+## Install the AIMNet2 wrapper
+
+ORCA-External-Tools ships an installer that creates an isolated venv
+with the AIMNet2 dependencies:
+
+```bash
+python install.py -e aimnet2
+```
+
+To control the install location:
+
+```bash
+python install.py --venv-dir <path/to/venv> --script-dir <path/to/bin> -e aimnet2
+```
+
+The installer creates a `bin/` directory containing the
+`oet_client` / `oet_server` scripts. The venv path **must not** be moved
+after installation; the scripts can be moved freely.
+
+## Standalone vs server/client
+
+Two execution modes:
+
+- **Standalone**: each ORCA energy/gradient call spawns a fresh Python
+  process. Simple, but Python + Torch import overhead is paid every
+  call -- noticeable in optimizations and especially in `!GOAT`.
+- **Server/client (recommended)**: `oet_server` keeps the AIMNet2 model
+  resident in memory; ORCA hits it via the lightweight `oet_client`
+  per call. Once started with an AIMNet2 model, the same server can
+  service multiple ORCA jobs.
+
+Start a server in a separate shell:
+
+```bash
+oet_server aimnet2 --nthreads 4
+```
+
+Then in the ORCA input:
+
+```text
+! ExtOpt Opt PAL8
+
+%method
+  ProgExt "/full/path/to/oet_client"
+end
+
+*XYZfile 0 1 mol.xyz
+```
+
+For standalone mode, point `ProgExt` at the AIMNet2 standalone wrapper
+script (also installed by `install.py`) instead of `oet_client`.
+
+## Compatible workflows
+
+ORCA's external-methods interface composes with:
+
+- `!Opt` -- geometry optimization
+- `!NEB-TS` -- nudged-elastic-band transition-state search
+- `!GOAT` -- conformer sampling
+- `!FREQ` / `!NUMFREQ` -- numerical frequencies
+
+## See also
+
+- [ORCA 6.1 ExtOpt tutorial](https://www.faccts.de/docs/orca/6.1/tutorials/workflows/extopt.html)
+- [ORCA-External-Tools repo](https://github.com/grimme-lab/ORCA-External-Tools)
+  (search GitHub for the current canonical fork; the wrapper scripts and
+  installer live there)
+- [OPI (ORCA Python Interface) external-methods notebook](https://www.faccts.de/docs/opi/nightly/docs/contents/notebooks/extopt.html)

--- a/docs/external/orca.md
+++ b/docs/external/orca.md
@@ -62,6 +62,14 @@ end
 For standalone mode, point `ProgExt` at the AIMNet2 standalone wrapper
 script (also installed by `install.py`) instead of `oet_client`.
 
+!!! warning "Closed-shell only"
+    Charge / multiplicity in the `*XYZfile` line are passed through to
+    the wrapper. Charged closed-shell systems work (e.g.
+    `*XYZfile -1 1 mol.xyz`); open-shell multiplicities (`mult > 1`)
+    are not exposed by the upstream `aimnet2` wrapper -- the wb97m-d3
+    model is closed-shell only. Verify with the wrapper's own docs if
+    you need radicals.
+
 ## Compatible workflows
 
 ORCA's external-methods interface composes with:
@@ -71,10 +79,13 @@ ORCA's external-methods interface composes with:
 - `!GOAT` -- conformer sampling
 - `!FREQ` / `!NUMFREQ` -- numerical frequencies
 
+## Model coverage
+
+The upstream ORCA-External-Tools `aimnet2` wrapper exposes the wb97m-d3
+model only. NSE (open-shell) and rxn (reactive) AIMNet2 families are
+not currently wrapped.
+
 ## See also
 
 - [ORCA 6.1 ExtOpt tutorial](https://www.faccts.de/docs/orca/6.1/tutorials/workflows/extopt.html)
-- [ORCA-External-Tools repo](https://github.com/grimme-lab/ORCA-External-Tools)
-  (search GitHub for the current canonical fork; the wrapper scripts and
-  installer live there)
 - [OPI (ORCA Python Interface) external-methods notebook](https://www.faccts.de/docs/opi/nightly/docs/contents/notebooks/extopt.html)

--- a/docs/external/orca.md
+++ b/docs/external/orca.md
@@ -2,18 +2,11 @@
 
 **Status: supported upstream.**
 
-ORCA 6.1 added a generic external-methods interface (`!ExtOpt`) that lets
-the ORCA optimizer, NEB-TS, and GOAT conformer sampler drive arbitrary
-external energy/gradient providers, including neural-network potentials.
-AIMNet2 is one of the explicitly named supported backends, alongside UMA
-and `g-xTB`. Wrapper scripts live in the upstream
-[ORCA-External-Tools](https://www.faccts.de/docs/orca/6.1/tutorials/workflows/extopt.html)
-project.
+ORCA 6.1 added a generic external-methods interface (`!ExtOpt`) that lets the ORCA optimizer, NEB-TS, and GOAT conformer sampler drive arbitrary external energy/gradient providers, including neural-network potentials. AIMNet2 is one of the explicitly named supported backends, alongside UMA and `g-xTB`. Wrapper scripts live in the upstream [ORCA-External-Tools](https://www.faccts.de/docs/orca/6.1/tutorials/workflows/extopt.html) project.
 
 ## Install the AIMNet2 wrapper
 
-ORCA-External-Tools ships an installer that creates an isolated venv
-with the AIMNet2 dependencies:
+ORCA-External-Tools ships an installer that creates an isolated venv with the AIMNet2 dependencies:
 
 ```bash
 python install.py -e aimnet2
@@ -25,21 +18,14 @@ To control the install location:
 python install.py --venv-dir <path/to/venv> --script-dir <path/to/bin> -e aimnet2
 ```
 
-The installer creates a `bin/` directory containing the
-`oet_client` / `oet_server` scripts. The venv path **must not** be moved
-after installation; the scripts can be moved freely.
+The installer creates a `bin/` directory containing the `oet_client` / `oet_server` scripts. The venv path **must not** be moved after installation; the scripts can be moved freely.
 
 ## Standalone vs server/client
 
 Two execution modes:
 
-- **Standalone**: each ORCA energy/gradient call spawns a fresh Python
-  process. Simple, but Python + Torch import overhead is paid every
-  call -- noticeable in optimizations and especially in `!GOAT`.
-- **Server/client (recommended)**: `oet_server` keeps the AIMNet2 model
-  resident in memory; ORCA hits it via the lightweight `oet_client`
-  per call. Once started with an AIMNet2 model, the same server can
-  service multiple ORCA jobs.
+- **Standalone**: each ORCA energy/gradient call spawns a fresh Python process. Simple, but Python + Torch import overhead is paid every call -- noticeable in optimizations and especially in `!GOAT`.
+- **Server/client (recommended)**: `oet_server` keeps the AIMNet2 model resident in memory; ORCA hits it via the lightweight `oet_client` per call. Once started with an AIMNet2 model, the same server can service multiple ORCA jobs.
 
 Start a server in a separate shell:
 
@@ -59,16 +45,9 @@ end
 *XYZfile 0 1 mol.xyz
 ```
 
-For standalone mode, point `ProgExt` at the AIMNet2 standalone wrapper
-script (also installed by `install.py`) instead of `oet_client`.
+For standalone mode, point `ProgExt` at the AIMNet2 standalone wrapper script (also installed by `install.py`) instead of `oet_client`.
 
-!!! warning "Closed-shell only"
-    Charge / multiplicity in the `*XYZfile` line are passed through to
-    the wrapper. Charged closed-shell systems work (e.g.
-    `*XYZfile -1 1 mol.xyz`); open-shell multiplicities (`mult > 1`)
-    are not exposed by the upstream `aimnet2` wrapper -- the wb97m-d3
-    model is closed-shell only. Verify with the wrapper's own docs if
-    you need radicals.
+!!! warning "Closed-shell only" Charge / multiplicity in the `*XYZfile` line are passed through to the wrapper. Charged closed-shell systems work (e.g. `*XYZfile -1 1 mol.xyz`); open-shell multiplicities (`mult > 1`) are not exposed by the upstream `aimnet2` wrapper -- the wb97m-d3 model is closed-shell only. Verify with the wrapper's own docs if you need radicals.
 
 ## Compatible workflows
 
@@ -81,9 +60,7 @@ ORCA's external-methods interface composes with:
 
 ## Model coverage
 
-The upstream ORCA-External-Tools `aimnet2` wrapper exposes the wb97m-d3
-model only. NSE (open-shell) and rxn (reactive) AIMNet2 families are
-not currently wrapped.
+The upstream ORCA-External-Tools `aimnet2` wrapper exposes the wb97m-d3 model only. NSE (open-shell) and rxn (reactive) AIMNet2 families are not currently wrapped.
 
 ## See also
 

--- a/docs/external/pysis.md
+++ b/docs/external/pysis.md
@@ -1,0 +1,47 @@
+# pysisyphus
+
+AIMNet2 ships a pysisyphus `Calculator` implementation (`AIMNet2Pysis`)
+for use inside pysisyphus workflows: optimisations, intrinsic reaction
+coordinate following, transition-state searches, NEB, growing-string, etc.
+
+## Install
+
+```bash
+pip install "aimnet[pysis]"
+```
+
+## Use from Python
+
+```python
+from pysisyphus.helpers import geom_loader
+from aimnet.calculators import AIMNet2Pysis
+
+geom = geom_loader("reactant.xyz")
+geom.set_calculator(AIMNet2Pysis("aimnet2", charge=0, mult=1))
+energy = geom.energy        # Hartree (pysisyphus convention)
+forces = geom.forces        # Hartree/Bohr
+```
+
+## Use from a pysisyphus YAML run
+
+`aimnet2pysis` is a console script that wraps `pysis` and registers the
+calculator under the YAML key `aimnet`. Run your pysisyphus input file
+with `aimnet2pysis input.yaml` instead of `pysis input.yaml`, and select
+the calculator with:
+
+```yaml
+calc:
+  type: aimnet
+  model: aimnet2
+  charge: 0
+  mult: 1
+```
+
+## Units
+
+Pysisyphus uses Hartree / Bohr internally; the wrapper converts AIMNet2's
+native eV / Angstrom output transparently.
+
+## See also
+
+- [Reaction paths and transition states](../advanced/reaction_paths.md)

--- a/docs/external/pysis.md
+++ b/docs/external/pysis.md
@@ -2,9 +2,7 @@
 
 **Status: supported (in-tree calculator).**
 
-AIMNet2 ships a pysisyphus `Calculator` implementation (`AIMNet2Pysis`)
-for use inside pysisyphus workflows: optimisations, intrinsic reaction
-coordinate following, transition-state searches, NEB, growing-string, etc.
+AIMNet2 ships a pysisyphus `Calculator` implementation (`AIMNet2Pysis`) for use inside pysisyphus workflows: optimisations, intrinsic reaction coordinate following, transition-state searches, NEB, growing-string, etc.
 
 ## Install
 
@@ -26,10 +24,7 @@ forces = geom.forces        # Hartree/Bohr
 
 ## Use from a pysisyphus YAML run
 
-`aimnet2pysis` is a console script that wraps `pysis` and registers the
-calculator under the YAML key `aimnet`. Run your pysisyphus input file
-with `aimnet2pysis input.yaml` instead of `pysis input.yaml`, and select
-the calculator with:
+`aimnet2pysis` is a console script that wraps `pysis` and registers the calculator under the YAML key `aimnet`. Run your pysisyphus input file with `aimnet2pysis input.yaml` instead of `pysis input.yaml`, and select the calculator with:
 
 ```yaml
 calc:
@@ -41,15 +36,11 @@ calc:
 
 ## Units
 
-Pysisyphus uses Hartree / Bohr internally; the wrapper converts AIMNet2's
-native eV / Angstrom output transparently.
+Pysisyphus uses Hartree / Bohr internally; the wrapper converts AIMNet2's native eV / Angstrom output transparently.
 
 ## Model coverage
 
-All AIMNet2 model families are accessible by passing the model name to
-the constructor: wb97m-d3, b97-3c, NSE, rxn, Pd. AIMNet2-rxn is
-particularly relevant for reaction-path / TS work in pysisyphus -- see
-the linked guide.
+All AIMNet2 model families are accessible by passing the model name to the constructor: wb97m-d3, b97-3c, NSE, rxn, Pd. AIMNet2-rxn is particularly relevant for reaction-path / TS work in pysisyphus -- see the linked guide.
 
 ## See also
 

--- a/docs/external/pysis.md
+++ b/docs/external/pysis.md
@@ -1,5 +1,7 @@
 # pysisyphus
 
+**Status: supported (in-tree calculator).**
+
 AIMNet2 ships a pysisyphus `Calculator` implementation (`AIMNet2Pysis`)
 for use inside pysisyphus workflows: optimisations, intrinsic reaction
 coordinate following, transition-state searches, NEB, growing-string, etc.
@@ -42,6 +44,14 @@ calc:
 Pysisyphus uses Hartree / Bohr internally; the wrapper converts AIMNet2's
 native eV / Angstrom output transparently.
 
+## Model coverage
+
+All AIMNet2 model families are accessible by passing the model name to
+the constructor: wb97m-d3, b97-3c, NSE, rxn, Pd. AIMNet2-rxn is
+particularly relevant for reaction-path / TS work in pysisyphus -- see
+the linked guide.
+
 ## See also
 
 - [Reaction paths and transition states](../advanced/reaction_paths.md)
+- [Calculator API reference](../calculator.md)

--- a/docs/superpowers/plans/2026-04-26-torchscript-export.md
+++ b/docs/superpowers/plans/2026-04-26-torchscript-export.md
@@ -1,0 +1,99 @@
+# TorchScript export pathway for external MD engines
+
+**Status:** Open / parked. Created 2026-04-26 from issue #19 (GROMACS) follow-up.
+
+## Goal
+
+Make AIMNet2 models exportable as a single self-contained TorchScript `.pt`
+file usable by:
+
+- **GROMACS NNPot** (`nnpot-modelfile`, GROMACS >= 2025.0)
+- **LAMMPS** (`pair_pytorch` plugin)
+- Any other engine that loads via `torch.jit.load`
+
+Note: OpenMM is **not** in this list. `openmm-ml` already ships an
+`AIMNet2PotentialImpl` that wraps `AIMNet2Calculator` behind
+`openmm.PythonForce`, sidestepping TorchScript entirely. A TorchScript
+path would still benefit OpenMM by removing the per-step Python callback
+overhead, but it is not a prerequisite for OpenMM support.
+
+Today: **none of the shipped `aimnet/calculators/assets/*.pt` files are
+loadable as TorchScript.** They are `torch.save` state-dict archives, not
+TorchScript archives.
+
+## Concrete upstream blockers
+
+1. **`aimnet/nbops.py:51`** uses `tensor.data_ptr()` as a cache key for
+   neighbor-list reuse. `torch.jit.script` errors on this:
+   ```
+   'Tensor' object has no attribute or method 'data_ptr'.
+   ```
+   Fix options:
+   - Replace `data_ptr` cache key with the `id(tensor)` Python builtin
+     (forbidden in script too) -- not viable.
+   - Drop the cache from the script path entirely; only use it when running
+     in eager Python. Refactor so the script path recomputes neighbor
+     pieces unconditionally.
+   - Pass cache-bust hints in via the input dict (e.g. an explicit
+     `data["_recompute_nb"]` bool) and do membership checks on a dict key.
+
+2. **`aimnet/modules/lr.py` DFTD3 autograd** -- the `DFTD3` class
+   (`aimnet/modules/lr.py:356`) calls `torch.autograd.grad` at line 596
+   with a signature TorchScript cannot match. Verified runtime error:
+   `Expected a value of type 'List[Tensor]' for argument 'outputs' but
+   instead found type 'Tensor'.`. Fix options:
+   - Wrap in a proper `torch.autograd.Function` with explicit `forward` /
+     `backward` static methods (TorchScript supports these).
+   - Split into a script-only forward path + a Python-only training path,
+     since GROMACS only needs forces via autograd of energy w.r.t.
+     positions.
+   - Note: `aimnet/modules/ops.py` contains a separate `_DFTD3Function`
+     wrapping `nvalchemiops` -- that one is unrelated to the script
+     failure.
+
+3. **Bundled-export wrapper** -- once 1 and 2 are fixed, wrap
+   `(model, external_coulomb, external_dftd3)` together so a single
+   scripted module reproduces full `AIMNet2Calculator.eval()` energies
+   without `nvalchemiops` (which is NVIDIA-only and not jit-able anyway).
+   This means writing a TorchScript-friendly all-pairs / cutoff neighbor
+   list inside the wrapper.
+
+## Already done (parked)
+
+- `aimnet/interfaces/__init__.py` -- new package, no public exports until
+  the wrapper actually works.
+- `aimnet/interfaces/gromacs.py` -- starter wrapper with the GROMACS NNPot
+  forward signature, unit conversions, and an all-pairs neighbor-list
+  construction. Verified to `jit.script` cleanly with a *dummy* inner
+  ScriptModule, save+reload round-trip OK, autograd-derived forces OK.
+  `build_gromacs_nnpot_model("aimnet2")` correctly raises for every shipped
+  model today (model isn't a ScriptModule + has external LR).
+
+## Per-engine status
+
+| Engine | Needs TorchScript? | Status |
+|---|---|---|
+| GROMACS NNPot | yes | Blocked (this plan) |
+| LAMMPS `pair_style mliap` (mliappy) | yes | Blocked (this plan) |
+| OpenMM (openmm-ml) | no -- uses `openmm.PythonForce` with a Python callback | **Already supported upstream** via `MLPotential('aimnet2')`. A TorchScript path would still cut per-step Python overhead. |
+| AMBER `sander` / `pmemd` (`torchani-amber`) | yes (jit-compiled `.pt`), but with a different harness | **Supported upstream** via the [`torchani-amber`](https://github.com/roitberg-group/torchani-amber) integration, which ships pre-built support for AimNet2 (and Nutmeg). Requires recompiling AmberTools 25/26 with the integration; not pip-installable. Models are jit-compiled `.pt` files passed as `model_type` -- the same TorchScript-export work in this plan unblocks shipping a self-contained AIMNet2 jit asset for that path. |
+
+## Suggested ordering
+
+1. Refactor `nbops.py` to remove `data_ptr` from the script path.
+2. Refactor `DFTD3` autograd into `torch.autograd.Function`.
+3. Land the bundled `GromacsNNPotWrapper` and an export CLI
+   (`examples/export_gromacs.py`, removed from this branch).
+4. Land docs/external/gromacs.md as a real "how to use" page (not a
+   blocker page).
+5. LAMMPS pair_pytorch then follows with a thin per-engine wrapper
+   around the same scripted core. OpenMM gets an optional TorchScript
+   fast-path that replaces the existing `PythonForce` callback in
+   `openmm-ml`.
+
+## Out of scope here
+
+- PBC support inside the scripted wrapper (nvalchemiops neighbor lists
+  are NVIDIA-only and not script-able). PBC AIMNet2 stays on the Python
+  ASE path.
+- NSE / open-shell models. Separate model family, separate wrapper later.

--- a/docs/superpowers/plans/2026-04-26-torchscript-export.md
+++ b/docs/superpowers/plans/2026-04-26-torchscript-export.md
@@ -4,109 +4,58 @@
 
 ## Goal
 
-Make AIMNet2 models exportable as a single self-contained TorchScript `.pt`
-file usable by:
+Make AIMNet2 models exportable as a single self-contained TorchScript `.pt` file usable by:
 
 - **GROMACS NNPot** (`nnpot-modelfile`, GROMACS >= 2025.0)
 - **LAMMPS** (`pair_pytorch` plugin)
 - Any other engine that loads via `torch.jit.load`
 
-Note: OpenMM is **not** in this list. `openmm-ml` already ships an
-`AIMNet2PotentialImpl` that wraps `AIMNet2Calculator` behind
-`openmm.PythonForce`, sidestepping TorchScript entirely. A TorchScript
-path would still benefit OpenMM by removing the per-step Python callback
-overhead, but it is not a prerequisite for OpenMM support.
+Note: OpenMM is **not** in this list. `openmm-ml` already ships an `AIMNet2PotentialImpl` that wraps `AIMNet2Calculator` behind `openmm.PythonForce`, sidestepping TorchScript entirely. A TorchScript path would still benefit OpenMM by removing the per-step Python callback overhead, but it is not a prerequisite for OpenMM support.
 
-Today: **none of the shipped `aimnet/calculators/assets/*.pt` files are
-loadable as TorchScript.** They are `torch.save` state-dict archives, not
-TorchScript archives.
+Today: **none of the shipped `aimnet/calculators/assets/*.pt` files are loadable as TorchScript.** They are `torch.save` state-dict archives, not TorchScript archives.
 
 ## Concrete upstream blockers
 
-(File:line references current as of commit 9b89166; symbol references
-are intended to survive line drift.)
+(File:line references current as of commit 9b89166; symbol references are intended to survive line drift.)
 
-1. **The neighbor-cache `data_ptr()` call in `aimnet/nbops.py`** uses
-   `tensor.data_ptr()` as a cache key for neighbor-list reuse.
-   `torch.jit.script` errors on this with:
+1. **The neighbor-cache `data_ptr()` call in `aimnet/nbops.py`** uses `tensor.data_ptr()` as a cache key for neighbor-list reuse. `torch.jit.script` errors on this with:
+
    ```
    'Tensor' object has no attribute or method 'data_ptr'.
    ```
+
    Fix options:
-   - Replace `data_ptr` cache key with the `id(tensor)` Python builtin
-     (forbidden in script too) -- not viable.
-   - Drop the cache from the script path entirely; only use it when running
-     in eager Python. Refactor so the script path recomputes neighbor
-     pieces unconditionally.
-   - Pass cache-bust hints in via the input dict (e.g. an explicit
-     `data["_recompute_nb"]` bool) and do membership checks on a dict key.
+   - Replace `data_ptr` cache key with the `id(tensor)` Python builtin (forbidden in script too) -- not viable.
+   - Drop the cache from the script path entirely; only use it when running in eager Python. Refactor so the script path recomputes neighbor pieces unconditionally.
+   - Pass cache-bust hints in via the input dict (e.g. an explicit `data["_recompute_nb"]` bool) and do membership checks on a dict key.
 
-2. **The `DFTD3` external module's autograd in `aimnet/modules/lr.py`**
-   calls `torch.autograd.grad` with a signature TorchScript cannot match.
-   Verified runtime error:
-   `Expected a value of type 'List[Tensor]' for argument 'outputs' but
-   instead found type 'Tensor'.`. Fix options:
-   - Wrap in a proper `torch.autograd.Function` with explicit `forward` /
-     `backward` static methods (TorchScript supports these).
-   - Split into a script-only forward path + a Python-only training path,
-     since GROMACS only needs forces via autograd of energy w.r.t.
-     positions.
-   - Note: `aimnet/modules/ops.py` contains a separate `_DFTD3Function`
-     wrapping `nvalchemiops` -- that one is unrelated to the script
-     failure.
+2. **The `DFTD3` external module's autograd in `aimnet/modules/lr.py`** calls `torch.autograd.grad` with a signature TorchScript cannot match. Verified runtime error: `Expected a value of type 'List[Tensor]' for argument 'outputs' but instead found type 'Tensor'.`. Fix options:
+   - Wrap in a proper `torch.autograd.Function` with explicit `forward` / `backward` static methods (TorchScript supports these).
+   - Split into a script-only forward path + a Python-only training path, since GROMACS only needs forces via autograd of energy w.r.t. positions.
+   - Note: `aimnet/modules/ops.py` contains a separate `_DFTD3Function` wrapping `nvalchemiops` -- that one is unrelated to the script failure.
 
-3. **Bundled-export wrapper** -- once 1 and 2 are fixed, wrap
-   `(model, external_coulomb, external_dftd3)` together so a single
-   scripted module reproduces full `AIMNet2Calculator.eval()` energies
-   without `nvalchemiops` (which is NVIDIA-only and not jit-able anyway).
-   This means writing a TorchScript-friendly all-pairs / cutoff neighbor
-   list inside the wrapper.
+3. **Bundled-export wrapper** -- once 1 and 2 are fixed, wrap `(model, external_coulomb, external_dftd3)` together so a single scripted module reproduces full `AIMNet2Calculator.eval()` energies without `nvalchemiops` (which is NVIDIA-only and not jit-able anyway). This means writing a TorchScript-friendly all-pairs / cutoff neighbor list inside the wrapper.
 
 ## Already done (parked)
 
 - `aimnet/interfaces/__init__.py` -- new namespace; no public exports.
-- `aimnet/interfaces/gromacs.py` -- starter `AIMNet2Gromacs` class with the
-  GROMACS NNPot forward signature, unit conversions, and all-pairs
-  neighbor-list construction. Verified to `jit.script` cleanly with a
-  *dummy* inner ScriptModule, save+reload round-trip OK, autograd-derived
-  forces OK. `build_gromacs_nnpot_model()` is a stub that raises
-  `NotImplementedError` unconditionally; the class definition is preserved
-  as a starting point.
+- `aimnet/interfaces/gromacs.py` -- starter `AIMNet2Gromacs` class with the GROMACS NNPot forward signature, unit conversions, and all-pairs neighbor-list construction. Verified to `jit.script` cleanly with a _dummy_ inner ScriptModule, save+reload round-trip OK, autograd-derived forces OK. `build_gromacs_nnpot_model()` is a stub that raises `NotImplementedError` unconditionally; the class definition is preserved as a starting point.
 
 ## Per-engine status
 
-See [`docs/external/`](../../external/index.md) for the canonical
-per-engine status. Summary in this plan: GROMACS NNPot and LAMMPS
-`pair_style mliap` are blocked here. OpenMM is supported today via
-`openmm-ml` (Python callback, no TorchScript). AMBER is supported today
-via `torchani-amber` (compiled-in C++/Fortran, accepts a jit `.pt` via
-`model_type`). Resolving this plan also enables shipping a
-self-contained jit AIMNet2 for AMBER and an optional TorchScript
-fast-path for OpenMM.
+See [`docs/external/`](../../external/index.md) for the canonical per-engine status. Summary in this plan: GROMACS NNPot and LAMMPS `pair_style mliap` are blocked here. OpenMM is supported today via `openmm-ml` (Python callback, no TorchScript). AMBER is supported today via `torchani-amber` (compiled-in C++/Fortran, accepts a jit `.pt` via `model_type`). Resolving this plan also enables shipping a self-contained jit AIMNet2 for AMBER and an optional TorchScript fast-path for OpenMM.
 
 ## Suggested ordering
 
 1. Refactor `nbops.py` to remove `data_ptr` from the script path.
 2. Refactor `DFTD3` autograd into `torch.autograd.Function`.
-3. Promote `aimnet/interfaces/gromacs.py` from parked to functional
-   (drop the `NotImplementedError` stub, add tests, ship a CLI driver
-   under `examples/`).
+3. Promote `aimnet/interfaces/gromacs.py` from parked to functional (drop the `NotImplementedError` stub, add tests, ship a CLI driver under `examples/`).
 4. Rewrite `docs/external/gromacs.md` as a real "how to use" page.
-5. Surface a documented "external input contract" on the calculator
-   side (e.g. `AIMNet2Calculator.build_input_dict(coord, numbers, charge)`)
-   so future export wrappers depend on a documented surface rather than
-   reaching into private helpers like `_add_padding_row`.
-6. LAMMPS `pair_style mliap` then follows with a thin per-engine wrapper.
-   OpenMM gets an optional TorchScript fast-path that replaces the
-   existing `PythonForce` callback in `openmm-ml`.
-7. Once a second TorchScript export wrapper exists, factor out a shared
-   base (unit conversions + neighbor-list builder + padding-row
-   construction) under `aimnet/interfaces/_torchscript_base.py` rather
-   than duplicating across wrappers.
+5. Surface a documented "external input contract" on the calculator side (e.g. `AIMNet2Calculator.build_input_dict(coord, numbers, charge)`) so future export wrappers depend on a documented surface rather than reaching into private helpers like `_add_padding_row`.
+6. LAMMPS `pair_style mliap` then follows with a thin per-engine wrapper. OpenMM gets an optional TorchScript fast-path that replaces the existing `PythonForce` callback in `openmm-ml`.
+7. Once a second TorchScript export wrapper exists, factor out a shared base (unit conversions + neighbor-list builder + padding-row construction) under `aimnet/interfaces/_torchscript_base.py` rather than duplicating across wrappers.
 
 ## Out of scope here
 
-- PBC support inside the scripted wrapper (nvalchemiops neighbor lists
-  are NVIDIA-only and not script-able). PBC AIMNet2 stays on the Python
-  ASE path.
+- PBC support inside the scripted wrapper (nvalchemiops neighbor lists are NVIDIA-only and not script-able). PBC AIMNet2 stays on the Python ASE path.
 - NSE / open-shell models. Separate model family, separate wrapper later.

--- a/docs/superpowers/plans/2026-04-26-torchscript-export.md
+++ b/docs/superpowers/plans/2026-04-26-torchscript-export.md
@@ -23,8 +23,12 @@ TorchScript archives.
 
 ## Concrete upstream blockers
 
-1. **`aimnet/nbops.py:51`** uses `tensor.data_ptr()` as a cache key for
-   neighbor-list reuse. `torch.jit.script` errors on this:
+(File:line references current as of commit 9b89166; symbol references
+are intended to survive line drift.)
+
+1. **The neighbor-cache `data_ptr()` call in `aimnet/nbops.py`** uses
+   `tensor.data_ptr()` as a cache key for neighbor-list reuse.
+   `torch.jit.script` errors on this with:
    ```
    'Tensor' object has no attribute or method 'data_ptr'.
    ```
@@ -37,9 +41,9 @@ TorchScript archives.
    - Pass cache-bust hints in via the input dict (e.g. an explicit
      `data["_recompute_nb"]` bool) and do membership checks on a dict key.
 
-2. **`aimnet/modules/lr.py` DFTD3 autograd** -- the `DFTD3` class
-   (`aimnet/modules/lr.py:356`) calls `torch.autograd.grad` at line 596
-   with a signature TorchScript cannot match. Verified runtime error:
+2. **The `DFTD3` external module's autograd in `aimnet/modules/lr.py`**
+   calls `torch.autograd.grad` with a signature TorchScript cannot match.
+   Verified runtime error:
    `Expected a value of type 'List[Tensor]' for argument 'outputs' but
    instead found type 'Tensor'.`. Fix options:
    - Wrap in a proper `torch.autograd.Function` with explicit `forward` /
@@ -60,36 +64,45 @@ TorchScript archives.
 
 ## Already done (parked)
 
-- `aimnet/interfaces/__init__.py` -- new package, no public exports until
-  the wrapper actually works.
-- `aimnet/interfaces/gromacs.py` -- starter wrapper with the GROMACS NNPot
-  forward signature, unit conversions, and an all-pairs neighbor-list
-  construction. Verified to `jit.script` cleanly with a *dummy* inner
-  ScriptModule, save+reload round-trip OK, autograd-derived forces OK.
-  `build_gromacs_nnpot_model("aimnet2")` correctly raises for every shipped
-  model today (model isn't a ScriptModule + has external LR).
+- `aimnet/interfaces/__init__.py` -- new namespace; no public exports.
+- `aimnet/interfaces/gromacs.py` -- starter `AIMNet2Gromacs` class with the
+  GROMACS NNPot forward signature, unit conversions, and all-pairs
+  neighbor-list construction. Verified to `jit.script` cleanly with a
+  *dummy* inner ScriptModule, save+reload round-trip OK, autograd-derived
+  forces OK. `build_gromacs_nnpot_model()` is a stub that raises
+  `NotImplementedError` unconditionally; the class definition is preserved
+  as a starting point.
 
 ## Per-engine status
 
-| Engine | Needs TorchScript? | Status |
-|---|---|---|
-| GROMACS NNPot | yes | Blocked (this plan) |
-| LAMMPS `pair_style mliap` (mliappy) | yes | Blocked (this plan) |
-| OpenMM (openmm-ml) | no -- uses `openmm.PythonForce` with a Python callback | **Already supported upstream** via `MLPotential('aimnet2')`. A TorchScript path would still cut per-step Python overhead. |
-| AMBER `sander` / `pmemd` (`torchani-amber`) | yes (jit-compiled `.pt`), but with a different harness | **Supported upstream** via the [`torchani-amber`](https://github.com/roitberg-group/torchani-amber) integration, which ships pre-built support for AimNet2 (and Nutmeg). Requires recompiling AmberTools 25/26 with the integration; not pip-installable. Models are jit-compiled `.pt` files passed as `model_type` -- the same TorchScript-export work in this plan unblocks shipping a self-contained AIMNet2 jit asset for that path. |
+See [`docs/external/`](../../external/index.md) for the canonical
+per-engine status. Summary in this plan: GROMACS NNPot and LAMMPS
+`pair_style mliap` are blocked here. OpenMM is supported today via
+`openmm-ml` (Python callback, no TorchScript). AMBER is supported today
+via `torchani-amber` (compiled-in C++/Fortran, accepts a jit `.pt` via
+`model_type`). Resolving this plan also enables shipping a
+self-contained jit AIMNet2 for AMBER and an optional TorchScript
+fast-path for OpenMM.
 
 ## Suggested ordering
 
 1. Refactor `nbops.py` to remove `data_ptr` from the script path.
 2. Refactor `DFTD3` autograd into `torch.autograd.Function`.
-3. Land the bundled `GromacsNNPotWrapper` and an export CLI
-   (`examples/export_gromacs.py`, removed from this branch).
-4. Land docs/external/gromacs.md as a real "how to use" page (not a
-   blocker page).
-5. LAMMPS pair_pytorch then follows with a thin per-engine wrapper
-   around the same scripted core. OpenMM gets an optional TorchScript
-   fast-path that replaces the existing `PythonForce` callback in
-   `openmm-ml`.
+3. Promote `aimnet/interfaces/gromacs.py` from parked to functional
+   (drop the `NotImplementedError` stub, add tests, ship a CLI driver
+   under `examples/`).
+4. Rewrite `docs/external/gromacs.md` as a real "how to use" page.
+5. Surface a documented "external input contract" on the calculator
+   side (e.g. `AIMNet2Calculator.build_input_dict(coord, numbers, charge)`)
+   so future export wrappers depend on a documented surface rather than
+   reaching into private helpers like `_add_padding_row`.
+6. LAMMPS `pair_style mliap` then follows with a thin per-engine wrapper.
+   OpenMM gets an optional TorchScript fast-path that replaces the
+   existing `PythonForce` callback in `openmm-ml`.
+7. Once a second TorchScript export wrapper exists, factor out a shared
+   base (unit conversions + neighbor-list builder + padding-row
+   construction) under `aimnet/interfaces/_torchscript_base.py` rather
+   than duplicating across wrappers.
 
 ## Out of scope here
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,16 @@ nav:
           - Non-Covalent Interactions: advanced/intermolecular_interactions.md
           - Pd Catalysis: advanced/transition_metal_catalysis.md
           - Charged Systems: advanced/charged_systems.md
+    - External Packages:
+          - Overview: external/index.md
+          - ASE: external/ase.md
+          - pysisyphus: external/pysis.md
+          - OpenMM (openmm-ml): external/openmm.md
+          - AMBER (torchani-amber): external/amber.md
+          - SCM AMS (MLPotential): external/ams.md
+          - ORCA (ExtOpt): external/orca.md
+          - GROMACS (NNPot): external/gromacs.md
+          - LAMMPS (mliap): external/lammps.md
     - Reference:
           - Calculator API: calculator.md
           - Long-Range Methods: long_range.md


### PR DESCRIPTION
## Summary

- Adds a new **External Packages** documentation section under `docs/external/` grouping every external package that consumes AIMNet2, with audited per-integration status (ASE, pysisyphus, OpenMM, AMBER, SCM AMS, ORCA, GROMACS, LAMMPS).
- Adds `aimnet/interfaces/` as a new package for external-engine wrappers; ships a parked GROMACS NNPot wrapper (`aimnet/interfaces/gromacs.py`) with a clear WIP banner.
- Adds `docs/superpowers/plans/2026-04-26-torchscript-export.md` tracking the concrete TorchScript-export blockers (`aimnet/nbops.py:51` `data_ptr()` and `aimnet/modules/lr.py:596` DFTD3 autograd) that gate GROMACS, LAMMPS, and an optional TorchScript fast-path for OpenMM and AMBER.

Status snapshot in the new docs:

| Engine | Status |
|---|---|
| ASE, pysisyphus | Supported (in-tree calculators) |
| OpenMM (`openmmml`) | Supported upstream via `MLPotential('aimnet2')` (Python callback) |
| AMBER (`torchani-amber`) | Supported upstream for `sander`/`pmemd` (recompiled AmberTools 25/26) |
| SCM AMS (`MLPotential` engine) | Supported upstream from AMS2024.1 (`Model AIMNet2-wB97MD3`/`-B973c`) |
| ORCA (`!ExtOpt`) | Supported upstream from ORCA 6.1 (ORCA-External-Tools `aimnet2` wrapper) |
| GROMACS NNPot, LAMMPS `pair_style mliap` | Blocked on TorchScript export |

## Verification

- Strict `mkdocs build --strict` passes after every change in this branch.
- Wrapper code path: `GromacsNNPotWrapper` was sanity-checked against a dummy inner ScriptModule (`torch.jit.script`, `torch.jit.save`, `torch.jit.load`, autograd-derived forces all OK).
- All claims about external packages were independently verified by parallel review agents (in-repo + upstream/web) before commit; corrections from the audit are folded in (e.g. GROMACS NNPot was introduced in **2025.0**, not 2026; PyPI distribution name is `openmmml`; pysisyphus YAML key is `aimnet`, not `aimnet2pysis`; AMBER goes through `torchani-amber`'s `&extpot`/`&qmmm` paths, not an in-process Python callback).

## Test plan

- [ ] `mkdocs build --strict` succeeds locally.
- [ ] mkdocs nav renders the new External Packages section between Advanced Use Cases and Reference.
- [ ] Each `docs/external/*.md` page renders and all internal cross-links resolve.
- [ ] `aimnet/interfaces/gromacs.py` import succeeds; `build_gromacs_nnpot_model("aimnet2")` raises with the expected "did not load as a TorchScript ScriptModule" / "external long-range modules" message rather than producing a broken `.pt`.