### PR TITLE
refactor(registry): adopt aimnet2-<family>_<member> naming convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,7 +159,7 @@ cython_debug/
 
 # Claude Code
 .claude/
-CLAUDE.md
+# CLAUDE.md is checked in as a project rule reference for contributors using Claude Code
 
 # Other AI assistants
 AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# Project rules for Claude Code
+
+These rules cover invariants and conventions that are not obvious from reading the code. The general code style is established by the codebase itself; only project-wide rules and back-compat anchors live here.
+
+## Model registry naming convention
+
+The registry at `aimnet/calculators/model_registry.yaml` uses a strict shape for every entry under `models:`:
+
+```
+aimnet2-<family>_<ensemble-member>
+```
+
+- A dash separates `aimnet2` from the family tag, and is the only separator allowed inside the family tag.
+- The trailing `_<int>` is reserved for the ensemble member index.
+- Family tags must NOT contain `_` and must NOT end in `_<int>`, so `key.rsplit("_", 1)` always yields `(family, member)` unambiguously.
+- The convention applies to entries under `models:` only. Entries under `aliases:` are not parsed.
+
+When adding a new model family:
+
+1. Add the canonical key under `models:` following the convention above. The `file:` field can keep any historical filename — file fields are not constrained by the convention.
+2. Add a canonical short alias `aimnet2-<family>` → `aimnet2-<family>_0` under the `# canonical short aliases` block in `aliases:`.
+3. If you also publish any legacy form (snake-form, no-separator), add it under `# legacy short aliases` and `# legacy member-level aliases`. **Once a name has been released, never remove it.**
+4. Update `tests/test_model_registry.py::test_canonical_keys_for_all_families` to include the new family.
+5. Update `docs/models/guide.md` (Quick-Pick table, Loading Models examples, Aliases Reference table, per-family download table) and `README.md` (Available Models table).
+6. If the family ships a per-model doc page, write it under `docs/models/` and add a "Legacy names" admonition listing any prior published aliases.
+
+## Single-hop alias rule (load-bearing invariant)
+
+`aimnet/calculators/model_registry.py:get_registry_model_path` does **exactly one** alias hop, then a `models:` lookup:
+
+```python
+if model_name in aliases:
+    model_name = aliases[model_name]      # ONE hop only
+if model_name not in models:
+    raise ValueError(...)
+cfg = models[model_name]
+```
+
+So every alias value MUST be a key in `models:`, never another alias. `tests/test_model_registry.py::test_no_alias_to_alias_chains` enforces this — do not bypass it.
+
+## Backwards-compat horizon
+
+The legacy alias section in `model_registry.yaml` covers every name released in **v0.1.0 onward**. Anything published since v0.1.0 must continue to resolve. Names that existed only in pre-v0.1.0 commits (e.g., `aimnet2_qr`, `wb97m_cpcms_v2_*`) are intentionally not preserved.
+
+When in doubt about whether a name is "released," check `git log -- aimnet/calculators/model_registry.yaml` and the v0.1.0 tag (`23e33f2`) onward.
+
+## Tests that should run before any registry change
+
+```
+pytest tests/test_model_registry.py
+pytest tests/test_hf_hub.py
+```
+
+Both must pass. The full suite (`pytest`) requires GPU/network for some tests and is not always practical locally.
+
+## Network-marked tests
+
+Calculator tests that download `.pt` files from GCS are marked `@pytest.mark.network` and skipped by default. They do exercise the registry, so they implicitly cover legacy aliases (`aimnet2nse`, `aimnet2rxn`, etc.) — when changing the registry, do not break the strings these tests reference.

--- a/README.md
+++ b/README.md
@@ -78,12 +78,13 @@ source .venv/bin/activate
 | Model | Elements | Description |
 | --- | --- | --- |
 | `aimnet2` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | wB97M-D3 (default) |
-| `aimnet2_2025` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | B97-3c + improved intermolecular (recommended) |
-| `aimnet2_b973c` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | B97-3c (superseded by aimnet2_2025) |
-| `aimnet2nse` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | Open-shell / radical chemistry |
-| `aimnet2pd` | H, B, C, N, O, F, Si, P, S, Cl, Se, Br, Pd, I | Pd systems with CPCM solvation (THF) |
+| `aimnet2-2025` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | B97-3c + improved intermolecular (recommended) |
+| `aimnet2-b973c` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | B97-3c (superseded by aimnet2-2025) |
+| `aimnet2-nse` | H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I | Open-shell / radical chemistry |
+| `aimnet2-pd` | H, B, C, N, O, F, Si, P, S, Cl, Se, Br, Pd, I | Pd systems with CPCM solvation (THF) |
+| `aimnet2-rxn` | H, C, N, O | Reactive chemistry (TS, NEB, IRC) |
 
-Each model has 4 ensemble members (0-3). Models are auto-downloaded on first use.
+Each model has 4 ensemble members (0-3). Models are auto-downloaded on first use. Previously published aliases (`aimnet2_2025`, `aimnet2nse`, `aimnet2pd`, etc.) continue to resolve.
 
 ## Quick Start
 

--- a/aimnet/calculators/model_registry.yaml
+++ b/aimnet/calculators/model_registry.yaml
@@ -1,7 +1,10 @@
 # map model name to file/url
-# Convention: aimnet2-<model-family-tag>_<ensemble-member>
-#   - dash separates "aimnet2" from the model-family tag (which may contain its own dashes)
-#   - the trailing _<int> is reserved for the ensemble member index
+# Convention for `models:` keys:  aimnet2-<family>_<ensemble-member>
+#   - dash separates "aimnet2" from the family tag and is the only separator inside the family tag
+#   - trailing `_<int>` is reserved for the ensemble member index
+#   - family tags must NOT contain `_` and must NOT end in `_<int>` (so `key.rsplit("_", 1)`
+#     unambiguously yields (family, member))
+#   - convention applies to entries under `models:` only; entries under `aliases:` are not parsed
 # File names on the GCS bucket are unchanged; the key→file mapping below absorbs
 # the historical naming so consumers never need to track the bucket layout.
 models:
@@ -88,14 +91,16 @@ aliases:
     aimnet2-nse: aimnet2-nse_0
     aimnet2-pd: aimnet2-pd_0
     aimnet2-rxn: aimnet2-rxn_0
-    # legacy short aliases (kept for backwards compat with published configs and downstream tools)
+    # legacy short aliases (kept for backwards compat with published configs and downstream tools).
+    # Back-compat horizon: every alias/key released in v0.1.0 onward must continue to resolve.
     aimnet2_wb97m: aimnet2-wb97m-d3_0
     aimnet2_b973c: aimnet2-b973c-d3_0
     aimnet2_2025: aimnet2-b973c-2025-d3_0
     aimnet2nse: aimnet2-nse_0
     aimnet2pd: aimnet2-pd_0
     aimnet2rxn: aimnet2-rxn_0
-    # legacy member-level aliases (full ensemble of every published key form)
+    # legacy member-level aliases — every previously published member key whose canonical
+    # form is now different (Pd member keys are unchanged, so they need no aliases).
     aimnet2_wb97m_d3_0: aimnet2-wb97m-d3_0
     aimnet2_wb97m_d3_1: aimnet2-wb97m-d3_1
     aimnet2_wb97m_d3_2: aimnet2-wb97m-d3_2

--- a/aimnet/calculators/model_registry.yaml
+++ b/aimnet/calculators/model_registry.yaml
@@ -1,51 +1,56 @@
-# map file name to url
+# map model name to file/url
+# Convention: aimnet2-<model-family-tag>_<ensemble-member>
+#   - dash separates "aimnet2" from the model-family tag (which may contain its own dashes)
+#   - the trailing _<int> is reserved for the ensemble member index
+# File names on the GCS bucket are unchanged; the key→file mapping below absorbs
+# the historical naming so consumers never need to track the bucket layout.
 models:
-    aimnet2_wb97m_d3_0:
+    aimnet2-wb97m-d3_0:
         file: aimnet2_wb97m_d3_0.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_0.pt
-    aimnet2_wb97m_d3_1:
+    aimnet2-wb97m-d3_1:
         file: aimnet2_wb97m_d3_1.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_1.pt
-    aimnet2_wb97m_d3_2:
+    aimnet2-wb97m-d3_2:
         file: aimnet2_wb97m_d3_2.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_2.pt
-    aimnet2_wb97m_d3_3:
+    aimnet2-wb97m-d3_3:
         file: aimnet2_wb97m_d3_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_3.pt
-    aimnet2_b973c_d3_0:
+    aimnet2-b973c-d3_0:
         file: aimnet2_b973c_d3_0.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_0.pt
-    aimnet2_b973c_d3_1:
+    aimnet2-b973c-d3_1:
         file: aimnet2_b973c_d3_1.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_1.pt
-    aimnet2_b973c_d3_2:
+    aimnet2-b973c-d3_2:
         file: aimnet2_b973c_d3_2.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_2.pt
-    aimnet2_b973c_d3_3:
+    aimnet2-b973c-d3_3:
         file: aimnet2_b973c_d3_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_3.pt
-    aimnet2_b973c_2025_d3_0:
+    aimnet2-b973c-2025-d3_0:
         file: aimnet2_2025_b973c_d3_0.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_0.pt
-    aimnet2_b973c_2025_d3_1:
+    aimnet2-b973c-2025-d3_1:
         file: aimnet2_2025_b973c_d3_1.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_1.pt
-    aimnet2_b973c_2025_d3_2:
+    aimnet2-b973c-2025-d3_2:
         file: aimnet2_2025_b973c_d3_2.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_2.pt
-    aimnet2_b973c_2025_d3_3:
+    aimnet2-b973c-2025-d3_3:
         file: aimnet2_2025_b973c_d3_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_3.pt
-    aimnet2nse_0:
+    aimnet2-nse_0:
         file: aimnet2nse_wb97m_0.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_0.pt
-    aimnet2nse_1:
+    aimnet2-nse_1:
         file: aimnet2nse_wb97m_1.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_1.pt
-    aimnet2nse_2:
+    aimnet2-nse_2:
         file: aimnet2nse_wb97m_2.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_2.pt
-    aimnet2nse_3:
+    aimnet2-nse_3:
         file: aimnet2nse_wb97m_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_3.pt
     aimnet2-pd_0:
@@ -60,25 +65,54 @@ models:
     aimnet2-pd_3:
         file: aimnet2-pd_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2Pd/aimnet2-pd_3.pt
-    aimnet2_rxn_0:
+    aimnet2-rxn_0:
         file: aimnet2_rxn_0.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt
-    aimnet2_rxn_1:
+    aimnet2-rxn_1:
         file: aimnet2_rxn_1.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt
-    aimnet2_rxn_2:
+    aimnet2-rxn_2:
         file: aimnet2_rxn_2.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt
-    aimnet2_rxn_3:
+    aimnet2-rxn_3:
         file: aimnet2_rxn_3.pt
         url: https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt
 
-# map model alias to file name
+# map model alias to model name
 aliases:
-    aimnet2: aimnet2_wb97m_d3_0
-    aimnet2_wb97m: aimnet2_wb97m_d3_0
-    aimnet2_b973c: aimnet2_b973c_d3_0
-    aimnet2nse: aimnet2nse_0
+    # canonical short aliases (recommended)
+    aimnet2: aimnet2-wb97m-d3_0
+    aimnet2-wb97m: aimnet2-wb97m-d3_0
+    aimnet2-b973c: aimnet2-b973c-d3_0
+    aimnet2-2025: aimnet2-b973c-2025-d3_0
+    aimnet2-nse: aimnet2-nse_0
+    aimnet2-pd: aimnet2-pd_0
+    aimnet2-rxn: aimnet2-rxn_0
+    # legacy short aliases (kept for backwards compat with published configs and downstream tools)
+    aimnet2_wb97m: aimnet2-wb97m-d3_0
+    aimnet2_b973c: aimnet2-b973c-d3_0
+    aimnet2_2025: aimnet2-b973c-2025-d3_0
+    aimnet2nse: aimnet2-nse_0
     aimnet2pd: aimnet2-pd_0
-    aimnet2_2025: aimnet2_b973c_2025_d3_0
-    aimnet2rxn: aimnet2_rxn_0
+    aimnet2rxn: aimnet2-rxn_0
+    # legacy member-level aliases (full ensemble of every published key form)
+    aimnet2_wb97m_d3_0: aimnet2-wb97m-d3_0
+    aimnet2_wb97m_d3_1: aimnet2-wb97m-d3_1
+    aimnet2_wb97m_d3_2: aimnet2-wb97m-d3_2
+    aimnet2_wb97m_d3_3: aimnet2-wb97m-d3_3
+    aimnet2_b973c_d3_0: aimnet2-b973c-d3_0
+    aimnet2_b973c_d3_1: aimnet2-b973c-d3_1
+    aimnet2_b973c_d3_2: aimnet2-b973c-d3_2
+    aimnet2_b973c_d3_3: aimnet2-b973c-d3_3
+    aimnet2_b973c_2025_d3_0: aimnet2-b973c-2025-d3_0
+    aimnet2_b973c_2025_d3_1: aimnet2-b973c-2025-d3_1
+    aimnet2_b973c_2025_d3_2: aimnet2-b973c-2025-d3_2
+    aimnet2_b973c_2025_d3_3: aimnet2-b973c-2025-d3_3
+    aimnet2nse_0: aimnet2-nse_0
+    aimnet2nse_1: aimnet2-nse_1
+    aimnet2nse_2: aimnet2-nse_2
+    aimnet2nse_3: aimnet2-nse_3
+    aimnet2_rxn_0: aimnet2-rxn_0
+    aimnet2_rxn_1: aimnet2-rxn_1
+    aimnet2_rxn_2: aimnet2-rxn_2
+    aimnet2_rxn_3: aimnet2-rxn_3

--- a/docs/advanced/charged_systems.md
+++ b/docs/advanced/charged_systems.md
@@ -15,7 +15,7 @@
 
 ## Relevant Models
 
-Charge handling is universal across all AIMNet2 models. The examples in this guide work with any model variant (`aimnet2`, `aimnet2_2025`, `aimnet2nse`, `aimnet2pd`, `aimnet2_b973c`). Choose the model based on your chemistry, not your charge state.
+Charge handling is universal across all AIMNet2 models. The examples in this guide work with any model variant (`aimnet2`, `aimnet2-2025`, `aimnet2-nse`, `aimnet2-pd`, `aimnet2-b973c`). Choose the model based on your chemistry, not your charge state.
 
 ## Setting the Charge
 

--- a/docs/advanced/conformer_search.md
+++ b/docs/advanced/conformer_search.md
@@ -3,7 +3,7 @@
 ## What You Will Learn
 
 - Building a conformer search pipeline with RDKit and AIMNet2
-- Choosing between `aimnet2` (accuracy) and `aimnet2_2025` (B97-3c speed) for screening
+- Choosing between `aimnet2` (accuracy) and `aimnet2-2025` (B97-3c speed) for screening
 - Batch geometry optimization of conformer ensembles
 - Boltzmann-weighted population analysis
 - Computing dihedral angles for Ramachandran-style analysis
@@ -29,12 +29,12 @@ This combines the strengths of each method: RDKit provides broad sampling of con
 
 | Model | Functional | Relative Speed | Best For |
 | --- | --- | --- | --- |
-| `aimnet2_2025` | B97-3c (improved) | Faster | Initial screening, large libraries, many conformers |
+| `aimnet2-2025` | B97-3c (improved) | Faster | Initial screening, large libraries, many conformers |
 | `aimnet2` | wB97M-D3 | Baseline | Final ranking, publication-quality results |
 
 !!! tip "Two-stage workflow"
 
-    For large molecules with many conformers, use `aimnet2_2025` to screen and discard high-energy conformers (e.g., > 5 kcal/mol above minimum), then re-optimize the survivors with `aimnet2` for final ranking.
+    For large molecules with many conformers, use `aimnet2-2025` to screen and discard high-energy conformers (e.g., > 5 kcal/mol above minimum), then re-optimize the survivors with `aimnet2` for final ranking.
 
 ## Step 1: Generate Conformers with RDKit
 
@@ -355,7 +355,7 @@ print(f"Unique conformers: {len(unique_conformers)} (from {len(all_results)})")
 
 ## What's Next
 
-- [Model Selection Guide](../models/guide.md) -- choosing `aimnet2` vs `aimnet2_2025` for your workflow
+- [Model Selection Guide](../models/guide.md) -- choosing `aimnet2` vs `aimnet2-2025` for your workflow
 - [Batch Processing tutorial](../tutorials/batch_processing.md) -- efficient processing of molecular datasets
 - [Performance Tuning tutorial](../tutorials/performance.md) -- `compile_model=True` and GPU optimization
 - [Reaction Paths and Transition States](reaction_paths.md) -- finding transition states between conformers

--- a/docs/advanced/intermolecular_interactions.md
+++ b/docs/advanced/intermolecular_interactions.md
@@ -5,7 +5,7 @@
 - How to compute interaction energies for molecular complexes
 - Scanning potential energy surfaces for non-covalent dimers
 - Why BSSE is different for ML potentials versus quantum chemistry
-- Comparing `aimnet2` and `aimnet2_2025` for intermolecular accuracy
+- Comparing `aimnet2` and `aimnet2-2025` for intermolecular accuracy
 - Configuring long-range electrostatics for non-covalent systems
 
 ## Prerequisites
@@ -16,7 +16,7 @@
 
 ## Spotlight Model: AIMNet2-2025
 
-The `aimnet2_2025` model was specifically trained with improved sampling of intermolecular configurations, making it the best choice for non-covalent interaction studies. It shares the same element coverage as the standard models (H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I) but provides significantly better accuracy for hydrogen bonding, pi-stacking, and dispersion-dominated complexes.
+The `aimnet2-2025` model was specifically trained with improved sampling of intermolecular configurations, making it the best choice for non-covalent interaction studies. It shares the same element coverage as the standard models (H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I) but provides significantly better accuracy for hydrogen bonding, pi-stacking, and dispersion-dominated complexes.
 
 See the [Model Selection Guide](../models/guide.md) for choosing between models.
 
@@ -34,7 +34,7 @@ Each monomer is computed at its geometry within the complex (no re-optimization)
 import torch
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2_2025")
+calc = AIMNet2Calculator("aimnet2-2025")
 
 def interaction_energy(coords_ab, numbers_ab, charge_ab,
                        coords_a, numbers_a, charge_a,
@@ -58,7 +58,7 @@ import torch
 import numpy as np
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2_2025")
+calc = AIMNet2Calculator("aimnet2-2025")
 
 # Water monomer A (acceptor): O at origin, H atoms in xz-plane
 water_a_coords = torch.tensor([
@@ -125,7 +125,7 @@ print(f"Interaction energy = {energies_kcal[min_idx]:.2f} kcal/mol")
 
 ## Comparing Models on the Water Dimer
 
-The `aimnet2_2025` model shows improved accuracy over the original `aimnet2` for intermolecular interactions. You can compare them directly:
+The `aimnet2-2025` model shows improved accuracy over the original `aimnet2` for intermolecular interactions. You can compare them directly:
 
 ```python
 import torch
@@ -133,7 +133,7 @@ import numpy as np
 from aimnet.calculators import AIMNet2Calculator
 
 calc_orig = AIMNet2Calculator("aimnet2")
-calc_2025 = AIMNet2Calculator("aimnet2_2025")
+calc_2025 = AIMNet2Calculator("aimnet2-2025")
 
 # Use the same water dimer geometry at near-equilibrium distance
 # Acceptor at origin, donor at 2.9 A along x with one H pointing toward acceptor O
@@ -154,7 +154,7 @@ charge = torch.tensor(0.0)
 
 ev_to_kcal = 23.0609
 
-for name, calc in [("aimnet2", calc_orig), ("aimnet2_2025", calc_2025)]:
+for name, calc in [("aimnet2", calc_orig), ("aimnet2-2025", calc_2025)]:
     e_dimer = calc({"coord": dimer, "numbers": numbers_dimer,
                      "charge": charge})["energy"].item()
     e_a = calc({"coord": water_a, "numbers": numbers_mono,
@@ -174,7 +174,7 @@ import torch
 import numpy as np
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2_2025")
+calc = AIMNet2Calculator("aimnet2-2025")
 
 # Benzene monomer (planar, in xy-plane centered at origin)
 benzene_c = torch.tensor([
@@ -231,7 +231,7 @@ print(f"Benzene dimer (PD) interaction energy: {e_int:.2f} kcal/mol")
 
     ML potentials like AIMNet2 have **no basis set** and therefore **no BSSE** in the traditional sense. The interaction energy computed as `E(AB) - E(A) - E(B)` does not suffer from basis set incompleteness.
 
-    However, a subtlety remains: the DFT reference data used for training **was** computed with a finite basis set (def2-TZVPP for `aimnet2`/`aimnet2nse`; def2-mTZVP for `aimnet2_2025`/`aimnet2_b973c`). If the training data was not counterpoise-corrected, the model may have learned an implicit BSSE from the reference energies. For AIMNet2 models, these basis sets minimize this effect, but it is not entirely absent.
+    However, a subtlety remains: the DFT reference data used for training **was** computed with a finite basis set (def2-TZVPP for `aimnet2`/`aimnet2-nse`; def2-mTZVP for `aimnet2-2025`/`aimnet2-b973c`). If the training data was not counterpoise-corrected, the model may have learned an implicit BSSE from the reference energies. For AIMNet2 models, these basis sets minimize this effect, but it is not entirely absent.
 
     **In practice:** Do not apply counterpoise corrections to AIMNet2 results. The supramolecular approach (`E(AB) - E(A) - E(B)`) is the correct way to compute interaction energies with ML potentials.
 
@@ -244,7 +244,7 @@ For larger aggregates or periodic systems with non-covalent contacts:
 ```python
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2_2025")
+calc = AIMNet2Calculator("aimnet2-2025")
 
 # For non-periodic clusters: simple method is fine (default)
 # For periodic systems: use DSF or Ewald
@@ -270,11 +270,11 @@ AIMNet2 models handle several classes of non-covalent interactions:
 
 | Interaction Type | Example | Typical Strength | Model Recommendation |
 | --- | --- | --- | --- |
-| Hydrogen bonding | Water dimer, DNA base pairs | 3-20 kcal/mol | `aimnet2_2025` |
-| pi-pi stacking | Benzene dimer, nucleobases | 1-5 kcal/mol | `aimnet2_2025` |
-| CH-pi | Methane-benzene | 0.5-2 kcal/mol | `aimnet2_2025` |
-| Halogen bonding | R-X...Y (X = Cl, Br, I) | 2-10 kcal/mol | `aimnet2_2025` |
-| Dispersion (vdW) | Alkane dimers | 0.5-3 kcal/mol | `aimnet2_2025` |
+| Hydrogen bonding | Water dimer, DNA base pairs | 3-20 kcal/mol | `aimnet2-2025` |
+| pi-pi stacking | Benzene dimer, nucleobases | 1-5 kcal/mol | `aimnet2-2025` |
+| CH-pi | Methane-benzene | 0.5-2 kcal/mol | `aimnet2-2025` |
+| Halogen bonding | R-X...Y (X = Cl, Br, I) | 2-10 kcal/mol | `aimnet2-2025` |
+| Dispersion (vdW) | Alkane dimers | 0.5-3 kcal/mol | `aimnet2-2025` |
 
 !!! note "Accuracy Expectations"
 

--- a/docs/advanced/open_shell.md
+++ b/docs/advanced/open_shell.md
@@ -17,11 +17,11 @@
 
 ## Why Closed-Shell Models Fail for Radicals
 
-Standard AIMNet2 models (`aimnet2`, `aimnet2_b973c`, `aimnet2_2025`) use a single charge channel internally (`num_charge_channels=1`). This means the model predicts one set of atomic partial charges and implicitly assumes all electrons are paired. When applied to a radical -- a species with one or more unpaired electrons -- the model has no mechanism to represent the spin density distribution and produces unreliable energies and forces.
+Standard AIMNet2 models (`aimnet2`, `aimnet2-b973c`, `aimnet2-2025`) use a single charge channel internally (`num_charge_channels=1`). This means the model predicts one set of atomic partial charges and implicitly assumes all electrons are paired. When applied to a radical -- a species with one or more unpaired electrons -- the model has no mechanism to represent the spin density distribution and produces unreliable energies and forces.
 
 !!! warning "Do not use closed-shell models for open-shell systems"
 
-    Applying `aimnet2` to a doublet radical or triplet state will silently produce results that look reasonable but have large systematic errors. Always use `aimnet2nse` when unpaired electrons are present.
+    Applying `aimnet2` to a doublet radical or triplet state will silently produce results that look reasonable but have large systematic errors. Always use `aimnet2-nse` when unpaired electrons are present.
 
 Common symptoms of using the wrong model:
 
@@ -63,7 +63,7 @@ The `mult` parameter specifies the spin multiplicity (2S+1):
 import torch
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2nse")
+calc = AIMNet2Calculator("aimnet2-nse")
 
 result = calc({
     "coord": coords,
@@ -79,7 +79,7 @@ result = calc({
 from aimnet.calculators import AIMNet2ASE
 
 # Doublet radical
-calc = AIMNet2ASE("aimnet2nse", charge=0, mult=2)
+calc = AIMNet2ASE("aimnet2-nse", charge=0, mult=2)
 
 # Change multiplicity later
 calc.set_mult(3)  # Switch to triplet
@@ -87,7 +87,7 @@ calc.set_mult(3)  # Switch to triplet
 
 !!! note "Default multiplicity"
 
-    If `mult` is not provided, the calculator defaults to `mult=1` (singlet). For closed-shell molecules with `aimnet2nse`, this is correct and the model reduces to standard behavior. You do not need to switch models for closed-shell species.
+    If `mult` is not provided, the calculator defaults to `mult=1` (singlet). For closed-shell molecules with `aimnet2-nse`, this is correct and the model reduces to standard behavior. You do not need to switch models for closed-shell species.
 
 ## Worked Example: C-H Bond Dissociation Energy
 
@@ -105,7 +105,7 @@ from ase import Atoms
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2nse", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 
 # --- Step 1: Optimize toluene (closed-shell singlet) ---
 toluene = Atoms(
@@ -184,7 +184,7 @@ from ase import Atoms
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2nse", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 
 
 def compute_bde(parent_atoms, radical_atoms, h_energy):
@@ -215,7 +215,7 @@ E_H = H_atom.get_potential_energy()
 # Results should show: methyl > ethyl > isopropyl > tert-butyl
 ```
 
-## Side-by-Side: aimnet2 vs aimnet2nse
+## Side-by-Side: aimnet2 vs aimnet2-nse
 
 This comparison demonstrates the systematic error of using a closed-shell model for radical species.
 
@@ -247,20 +247,20 @@ E_closed = ch3_closed.get_potential_energy()
 print(f"aimnet2 (closed-shell): {E_closed:.4f} eV")
 
 # --- Open-shell model (CORRECT) ---
-calc_nse = AIMNet2Calculator("aimnet2nse", compile_model=True)
+calc_nse = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 ch3_nse = ch3.copy()
 ch3_nse.calc = AIMNet2ASE(calc_nse, charge=0, mult=2)
 opt = BFGS(ch3_nse, logfile=None)
 opt.run(fmax=0.01)
 E_nse = ch3_nse.get_potential_energy()
-print(f"aimnet2nse (open-shell): {E_nse:.4f} eV")
+print(f"aimnet2-nse (open-shell): {E_nse:.4f} eV")
 
 print(f"Energy difference: {abs(E_closed - E_nse) * 23.0609:.1f} kcal/mol")
 ```
 
-!!! tip "When in doubt, use aimnet2nse"
+!!! tip "When in doubt, use aimnet2-nse"
 
-    The NSE model handles closed-shell species correctly (mult=1 reduces to standard behavior). If your workflow involves a mix of closed-shell and open-shell species -- for example, computing BDEs -- use `aimnet2nse` throughout for consistent energetics.
+    The NSE model handles closed-shell species correctly (mult=1 reduces to standard behavior). If your workflow involves a mix of closed-shell and open-shell species -- for example, computing BDEs -- use `aimnet2-nse` throughout for consistent energetics.
 
 ## When to Fall Back to Multi-Reference Methods
 

--- a/docs/advanced/reaction_paths.md
+++ b/docs/advanced/reaction_paths.md
@@ -21,7 +21,7 @@ Finding transition states with DFT typically requires hundreds to thousands of g
 
 !!! tip "Model selection for reaction paths"
 
-    Use `aimnet2nse` for reactions involving bond breaking or forming, especially homolytic processes (radical mechanisms, H-atom abstractions). For heterolytic processes (SN2, proton transfers), the standard `aimnet2` model may also work, but `aimnet2nse` is the safer default because it handles both closed-shell and open-shell regions of the potential energy surface.
+    Use `aimnet2-nse` for reactions involving bond breaking or forming, especially homolytic processes (radical mechanisms, H-atom abstractions). For heterolytic processes (SN2, proton transfers), the standard `aimnet2` model may also work, but `aimnet2-nse` is the safer default because it handles both closed-shell and open-shell regions of the potential energy surface.
 
 ## PySisyphus Integration
 
@@ -42,10 +42,10 @@ AIMNet2 integrates with PySisyphus through the `AIMNet2Pysis` calculator class. 
 from aimnet.calculators import AIMNet2Pysis, AIMNet2Calculator
 
 # From model name (creates AIMNet2Calculator internally)
-calc = AIMNet2Pysis("aimnet2nse", charge=-1, mult=1)
+calc = AIMNet2Pysis("aimnet2-nse", charge=-1, mult=1)
 
 # From existing calculator (reuse across workflows)
-base = AIMNet2Calculator("aimnet2nse", compile_model=True)
+base = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 calc = AIMNet2Pysis(base, charge=-1, mult=1)
 ```
 
@@ -75,7 +75,7 @@ from ase import Atoms
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2nse", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 
 # Reactant complex: Cl- approaching CH3Cl from the back side
 reactant = Atoms(
@@ -131,7 +131,7 @@ geom:
 
 calc:
   type: aimnet
-  model: aimnet2nse
+  model: aimnet2-nse
   charge: -1
   mult: 1
 
@@ -184,7 +184,7 @@ import torch
 import numpy as np
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2nse", compile_model=True)
+calc = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 
 # TS geometry (from NEB climbing image)
 # Replace with actual TS coordinates from your NEB result
@@ -286,7 +286,7 @@ geom:
 
 calc:
   type: aimnet
-  model: aimnet2nse
+  model: aimnet2-nse
   charge: -1
   mult: 1
 
@@ -312,7 +312,7 @@ geom:
 
 calc:
   type: aimnet
-  model: aimnet2nse
+  model: aimnet2-nse
   charge: -1
   mult: 1
 
@@ -393,7 +393,7 @@ from ase.io import write
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2nse", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-nse", compile_model=True)
 
 # 1. Optimize reactant complex
 reactant = Atoms(
@@ -455,7 +455,7 @@ geom:
 
 calc:
   type: aimnet
-  model: aimnet2nse
+  model: aimnet2-nse
   charge: -1
   mult: 1
 
@@ -479,7 +479,7 @@ print("Run with: python -c 'from aimnet.calculators.aimnet2pysis import run_pysi
 
 !!! note "SN2 reactions and model choice"
 
-    The SN2 reaction involves heterolytic bond breaking (the leaving group departs with both bonding electrons). For heterolytic processes like this, the standard `aimnet2` model may perform adequately. However, `aimnet2nse` is recommended as the default for all reaction path calculations because it handles mixed closed-shell/open-shell regions correctly and introduces no penalty for closed-shell species (`mult=1` reduces to standard behavior).
+    The SN2 reaction involves heterolytic bond breaking (the leaving group departs with both bonding electrons). For heterolytic processes like this, the standard `aimnet2` model may perform adequately. However, `aimnet2-nse` is recommended as the default for all reaction path calculations because it handles mixed closed-shell/open-shell regions correctly and introduces no penalty for closed-shell species (`mult=1` reduces to standard behavior).
 
 ## Practical Tips
 

--- a/docs/advanced/transition_metal_catalysis.md
+++ b/docs/advanced/transition_metal_catalysis.md
@@ -2,7 +2,7 @@
 
 ## What You'll Learn
 
-- How to use the `aimnet2pd` model for palladium organometallic chemistry
+- How to use the `aimnet2-pd` model for palladium organometallic chemistry
 - Computing relative stabilities of Pd coordination geometries
 - Modeling a step of a Suzuki cross-coupling catalytic cycle
 - Understanding the limitations of transition metal ML potentials
@@ -15,17 +15,17 @@
 
 ## Spotlight Model: AIMNet2-Pd
 
-The `aimnet2pd` model extends AIMNet2 to palladium-containing organometallic systems. It is trained on B97-3c/CPCM reference data with **THF implicit solvation**, so predicted energetics include continuum solvent effects relevant to homogeneous catalysis. This enables rapid exploration of catalytic reaction profiles at near-DFT accuracy with solvent stabilization built in.
+The `aimnet2-pd` model extends AIMNet2 to palladium-containing organometallic systems. It is trained on B97-3c/CPCM reference data with **THF implicit solvation**, so predicted energetics include continuum solvent effects relevant to homogeneous catalysis. This enables rapid exploration of catalytic reaction profiles at near-DFT accuracy with solvent stabilization built in.
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, Se, Br, Pd, I (14 elements)
 
 !!! warning "No Arsenic"
 
-    The Pd model replaces As with Pd in the element set. You **cannot** use AsPh3 ligands or any arsenic-containing species with `aimnet2pd`. Common phosphine ligands (PPh3, PMe3, etc.) are fully supported.
+    The Pd model replaces As with Pd in the element set. You **cannot** use AsPh3 ligands or any arsenic-containing species with `aimnet2-pd`. Common phosphine ligands (PPh3, PMe3, etc.) are fully supported.
 
 !!! warning "Palladium Only"
 
-    `aimnet2pd` supports Pd as the only transition metal. It does **not** cover Ni, Cu, Fe, Ru, Rh, Ir, or any other transition metals. For reactions catalyzed by other metals, DFT remains necessary.
+    `aimnet2-pd` supports Pd as the only transition metal. It does **not** cover Ni, Cu, Fe, Ru, Rh, Ir, or any other transition metals. For reactions catalyzed by other metals, DFT remains necessary.
 
 ## Loading the Pd Model
 
@@ -33,11 +33,11 @@ The `aimnet2pd` model extends AIMNet2 to palladium-containing organometallic sys
 from aimnet.calculators import AIMNet2Calculator, AIMNet2ASE
 
 # Direct calculator
-calc = AIMNet2Calculator("aimnet2pd")
+calc = AIMNet2Calculator("aimnet2-pd")
 
 # ASE interface
 from ase import Atoms
-base_calc = AIMNet2Calculator("aimnet2pd", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-pd", compile_model=True)
 ase_calc = AIMNet2ASE(base_calc, charge=0)
 ```
 
@@ -49,7 +49,7 @@ Pd(II) complexes typically adopt square planar geometry, while Pd(0) prefers lin
 import torch
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2pd")
+calc = AIMNet2Calculator("aimnet2-pd")
 
 # PdCl4(2-): ideal square planar
 # Pd at origin, 4 Cl in xy-plane
@@ -82,7 +82,7 @@ print(f"Max force: {result_sq['forces'].abs().max().item():.4f} eV/A")
     from ase.optimize import BFGS
     from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-    base_calc = AIMNet2Calculator("aimnet2pd", compile_model=True)
+    base_calc = AIMNet2Calculator("aimnet2-pd", compile_model=True)
     atoms = Atoms("PdCl4", positions=sq_planar.numpy())
     atoms.calc = AIMNet2ASE(base_calc, charge=-2)
 
@@ -112,7 +112,7 @@ from ase import Atoms
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2pd", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-pd", compile_model=True)
 
 # Pd(PH3)2: linear Pd(0) complex
 # Pd at origin, two PH3 along x-axis
@@ -235,7 +235,7 @@ print(f"Oxidative addition energy: {e_rxn_kcal:.1f} kcal/mol")
 
 !!! tip "CPCM solvation is built in"
 
-    Unlike other AIMNet2 models, `aimnet2pd` is trained on B97-3c/CPCM reference data with **THF as the implicit solvent**. All predicted energetics include continuum solvent stabilization effects appropriate for homogeneous catalysis in THF or similar non-polar aprotic solvents.
+    Unlike other AIMNet2 models, `aimnet2-pd` is trained on B97-3c/CPCM reference data with **THF as the implicit solvent**. All predicted energetics include continuum solvent stabilization effects appropriate for homogeneous catalysis in THF or similar non-polar aprotic solvents.
 
     For reactions in very different solvent environments (e.g., water, DMSO, DMF), the THF solvation model may not capture the correct solvent effects. In those cases, additional solvation corrections or explicit solvent modeling may be needed.
 
@@ -269,7 +269,7 @@ print(f"Oxidative addition energy: {e_rxn_kcal:.1f} kcal/mol")
 
 !!! warning "No AsPh3 or Arsenic Ligands"
 
-    Arsenic is **not** in the `aimnet2pd` element set. Triphenylarsine (AsPh3) and other As-containing ligands cannot be used. Use the standard `aimnet2` model for As-containing systems (but without Pd).
+    Arsenic is **not** in the `aimnet2-pd` element set. Triphenylarsine (AsPh3) and other As-containing ligands cannot be used. Use the standard `aimnet2` model for As-containing systems (but without Pd).
 
 ## Tips for Catalytic Cycle Modeling
 

--- a/docs/models/aimnet2.md
+++ b/docs/models/aimnet2.md
@@ -6,9 +6,13 @@ AIMNet2 is the **default general-purpose model** for organic and main-group mole
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (14 elements)
 
-**Registry alias:** `aimnet2` (loads ensemble member `aimnet2_wb97m_d3_0`)
+**Registry alias:** `aimnet2` (loads ensemble member `aimnet2-wb97m-d3_0`)
 
-**Ensemble members:** `aimnet2_wb97m_d3_0` through `aimnet2_wb97m_d3_3` (4 models)
+**Ensemble members:** `aimnet2-wb97m-d3_0` through `aimnet2-wb97m-d3_3` (4 models)
+
+!!! note "Legacy names"
+
+    The previously published short alias `aimnet2_wb97m` and the member-level keys `aimnet2_wb97m_d3_0` … `aimnet2_wb97m_d3_3` still resolve and remain supported.
 
 If you are unsure which model to use, start here. AIMNet2 provides the best balance of accuracy and element coverage for most molecular chemistry applications.
 
@@ -135,10 +139,10 @@ See [Long-Range Methods](../long_range.md) for details on DSF vs Ewald.
 
 ### Ensemble Averaging
 
-Four independently trained ensemble members are available (`aimnet2_wb97m_d3_0` through `aimnet2_wb97m_d3_3`). Use ensemble averaging for production calculations to improve accuracy and estimate prediction uncertainty:
+Four independently trained ensemble members are available (`aimnet2-wb97m-d3_0` through `aimnet2-wb97m-d3_3`). Use ensemble averaging for production calculations to improve accuracy and estimate prediction uncertainty:
 
 ```python
-models = [AIMNet2Calculator(f"aimnet2_wb97m_d3_{i}") for i in range(4)]
+models = [AIMNet2Calculator(f"aimnet2-wb97m-d3_{i}") for i in range(4)]
 results = [m(data, forces=True) for m in models]
 
 energies = torch.stack([r["energy"] for r in results])

--- a/docs/models/aimnet2_2025.md
+++ b/docs/models/aimnet2_2025.md
@@ -6,13 +6,17 @@
 
 ## Overview
 
-AIMNet2-2025 is the **current-generation B97-3c model**, combining the cost-effective B97-3c reference level with improved training for non-covalent chemistry. It supersedes the original AIMNet2-B97-3c (`aimnet2_b973c`) and is recommended for all applications: high-throughput screening, conformer ranking, binding energy calculations, and any workflow where B97-3c-level accuracy is appropriate.
+AIMNet2-2025 is the **current-generation B97-3c model**, combining the cost-effective B97-3c reference level with improved training for non-covalent chemistry. It supersedes the original AIMNet2-B97-3c (`aimnet2-b973c`) and is recommended for all applications: high-throughput screening, conformer ranking, binding energy calculations, and any workflow where B97-3c-level accuracy is appropriate.
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (14 elements)
 
-**Registry alias:** `aimnet2_2025` (loads ensemble member `aimnet2_b973c_2025_d3_0`)
+**Registry alias:** `aimnet2-2025` (loads ensemble member `aimnet2-b973c-2025-d3_0`)
 
-**Ensemble members:** `aimnet2_b973c_2025_d3_0` through `aimnet2_b973c_2025_d3_3` (4 models)
+**Ensemble members:** `aimnet2-b973c-2025-d3_0` through `aimnet2-b973c-2025-d3_3` (4 models)
+
+!!! note "Legacy names"
+
+    The previously published short alias `aimnet2_2025` and the member-level keys `aimnet2_b973c_2025_d3_0` … `aimnet2_b973c_2025_d3_3` still resolve and remain supported.
 
 ## Strengths and Limitations
 
@@ -40,7 +44,7 @@ AIMNet2-2025 is the **current-generation B97-3c model**, combining the cost-effe
 
 ## Typical Use Cases
 
-- **General-purpose B97-3c calculations** -- recommended replacement for `aimnet2_b973c` in all workflows
+- **General-purpose B97-3c calculations** -- recommended replacement for `aimnet2-b973c` in all workflows
 - **High-throughput conformer screening** -- rapid ranking of large conformer sets with B97-3c accuracy
 - **Binding energy calculations** -- compute interaction energies for molecular dimers and complexes using the supramolecular approach (complex minus monomers)
 - **Hydrogen-bonded systems** -- study water clusters, nucleobase pairs, protein-ligand hydrogen bonds
@@ -55,7 +59,7 @@ Computing the binding energy of a water dimer:
 import torch
 from aimnet.calculators import AIMNet2Calculator
 
-calc = AIMNet2Calculator("aimnet2_2025", compile_model=True)
+calc = AIMNet2Calculator("aimnet2-2025", compile_model=True)
 
 # Water dimer coordinates (Angstrom)
 dimer_coords = torch.tensor([
@@ -109,7 +113,7 @@ print(f"Binding energy: {binding_energy * 23.0609:.2f} kcal/mol")
 from ase.build import molecule
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2_2025", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-2025", compile_model=True)
 atoms = molecule("H2O")
 atoms.calc = AIMNet2ASE(base_calc, charge=0)
 
@@ -140,7 +144,7 @@ calc.set_lrcoulomb_method("dsf", cutoff=15.0)
 For binding energy calculations, ensemble averaging across all four members is recommended to assess reliability:
 
 ```python
-models = [AIMNet2Calculator(f"aimnet2_b973c_2025_d3_{i}") for i in range(4)]
+models = [AIMNet2Calculator(f"aimnet2-b973c-2025-d3_{i}") for i in range(4)]
 
 binding_energies = []
 for m in models:

--- a/docs/models/aimnet2_b973c.md
+++ b/docs/models/aimnet2_b973c.md
@@ -2,7 +2,7 @@
 
 !!! warning "Superseded by AIMNet2-2025"
 
-    This model has been superseded by [AIMNet2-2025](aimnet2_2025.md), which provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. **Use `aimnet2_2025` for all new work.** The original `aimnet2_b973c` is retained only for reproducing previously published results.
+    This model has been superseded by [AIMNet2-2025](aimnet2_2025.md), which provides improved intermolecular interaction accuracy with no regression for intramolecular chemistry. **Use `aimnet2-2025` for all new work.** The original `aimnet2-b973c` is retained only for reproducing previously published results.
 
 ## Overview
 
@@ -10,9 +10,13 @@ AIMNet2-B97-3c is the **original B97-3c screening model** trained against B97-3c
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (14 elements)
 
-**Registry alias:** `aimnet2_b973c` (loads ensemble member `aimnet2_b973c_d3_0`)
+**Registry alias:** `aimnet2-b973c` (loads ensemble member `aimnet2-b973c-d3_0`)
 
-**Ensemble members:** `aimnet2_b973c_d3_0` through `aimnet2_b973c_d3_3` (4 models)
+**Ensemble members:** `aimnet2-b973c-d3_0` through `aimnet2-b973c-d3_3` (4 models)
+
+!!! note "Legacy names"
+
+    The previously published short alias `aimnet2_b973c` and the member-level keys `aimnet2_b973c_d3_0` … `aimnet2_b973c_d3_3` still resolve and remain supported.
 
 ## Strengths and Limitations
 
@@ -39,12 +43,12 @@ AIMNet2-B97-3c is the **original B97-3c screening model** trained against B97-3c
 
 ## Typical Use Cases
 
-- **Reproducing published results** -- use when replicating calculations from papers that used `aimnet2_b973c`
+- **Reproducing published results** -- use when replicating calculations from papers that used `aimnet2-b973c`
 - **Cross-validation** -- compare B97-3c and wB97M-D3 predictions to gauge sensitivity to the reference method
 
 !!! tip "For new projects, use AIMNet2-2025"
 
-    For high-throughput screening, conformer ranking, and any new B97-3c-level work, switch to [`aimnet2_2025`](aimnet2_2025.md) which provides strictly better accuracy for the same computational cost.
+    For high-throughput screening, conformer ranking, and any new B97-3c-level work, switch to [`aimnet2-2025`](aimnet2_2025.md) which provides strictly better accuracy for the same computational cost.
 
 ## Quick Example
 
@@ -55,7 +59,7 @@ import torch
 from aimnet.calculators import AIMNet2Calculator
 
 # Use B97-3c model for fast screening
-calc = AIMNet2Calculator("aimnet2_b973c", compile_model=True)
+calc = AIMNet2Calculator("aimnet2-b973c", compile_model=True)
 
 # Load multiple conformers (example: 3 conformers of butane, 14 atoms each)
 # In practice, read from a multi-frame XYZ file
@@ -84,7 +88,7 @@ from ase.io import read
 from ase.optimize import BFGS
 from aimnet.calculators import AIMNet2ASE, AIMNet2Calculator
 
-base_calc = AIMNet2Calculator("aimnet2_b973c", compile_model=True)
+base_calc = AIMNet2Calculator("aimnet2-b973c", compile_model=True)
 atoms = read("molecule.xyz")
 atoms.calc = AIMNet2ASE(base_calc, charge=0)
 
@@ -114,7 +118,7 @@ calc.set_lrcoulomb_method("dsf", cutoff=15.0)
 Four ensemble members are available for uncertainty estimation:
 
 ```python
-models = [AIMNet2Calculator(f"aimnet2_b973c_d3_{i}") for i in range(4)]
+models = [AIMNet2Calculator(f"aimnet2-b973c-d3_{i}") for i in range(4)]
 results = [m(data) for m in models]
 
 energies = torch.stack([r["energy"] for r in results])

--- a/docs/models/aimnet2_rxn.md
+++ b/docs/models/aimnet2_rxn.md
@@ -8,11 +8,15 @@ A neural network interatomic potential specialized for **closed-shell organic re
 from aimnet.calculators import AIMNet2Calculator
 
 # From the GCS-backed registry (alias):
-calc = AIMNet2Calculator("aimnet2rxn", ensemble_member=0)
+calc = AIMNet2Calculator("aimnet2-rxn", ensemble_member=0)
 
 # From Hugging Face Hub:
 calc = AIMNet2Calculator("isayevlab/aimnet2-rxn", ensemble_member=0)
 ```
+
+!!! note "Legacy alias"
+
+    The previously published short alias `aimnet2rxn` and member-level keys `aimnet2_rxn_0` … `aimnet2_rxn_3` still resolve and remain supported.
 
 Both paths produce equivalent calculators. The HF path requires `pip install "aimnet[hf]"`.
 

--- a/docs/models/aimnet2nse.md
+++ b/docs/models/aimnet2nse.md
@@ -6,9 +6,13 @@ AIMNet2-NSE (Neutral Spin Equilibrated) is the model for **open-shell molecular 
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I (14 elements)
 
-**Registry alias:** `aimnet2nse` (loads ensemble member `aimnet2nse_0`)
+**Registry alias:** `aimnet2-nse` (loads ensemble member `aimnet2-nse_0`)
 
-**Ensemble members:** `aimnet2nse_0` through `aimnet2nse_3` (4 models)
+**Ensemble members:** `aimnet2-nse_0` through `aimnet2-nse_3` (4 models)
+
+!!! note "Legacy names"
+
+    The previously published `aimnet2nse` alias and `aimnet2nse_0` … `aimnet2nse_3` member keys still resolve and remain supported.
 
 **DFT reference:** wB97M-D3/def2-TZVPP (same functional as the default AIMNet2)
 

--- a/docs/models/aimnet2pd.md
+++ b/docs/models/aimnet2pd.md
@@ -6,9 +6,13 @@ AIMNet2-Pd extends AIMNet2 to **palladium-catalyzed organometallic chemistry**. 
 
 **Supported elements:** H, B, C, N, O, F, Si, P, S, Cl, Se, Br, Pd, I (14 elements)
 
-**Registry alias:** `aimnet2pd` (loads ensemble member `aimnet2-pd_0`)
+**Registry alias:** `aimnet2-pd` (loads ensemble member `aimnet2-pd_0`)
 
 **Ensemble members:** `aimnet2-pd_0` through `aimnet2-pd_3` (4 models)
+
+!!! note "Legacy alias"
+
+    The previously published short alias `aimnet2pd` still resolves to `aimnet2-pd_0` and remains supported. The member-level keys `aimnet2-pd_0` … `aimnet2-pd_3` are unchanged.
 
 **DFT reference:** B97-3c with CPCM implicit solvation (THF solvent)
 
@@ -163,7 +167,7 @@ print(f"Energy: {energies.mean().item():.6f} +/- {energies.std().item():.6f} eV"
 
 !!! note "Ensemble member naming"
 
-    The Pd model ensemble members use a hyphen: `aimnet2-pd_0` through `aimnet2-pd_3` (note the hyphen between "aimnet2" and "pd").
+    The Pd model ensemble members follow the registry convention `aimnet2-<family>_<index>`: `aimnet2-pd_0` through `aimnet2-pd_3` (dash separates "aimnet2" from the family tag, underscore precedes the ensemble index).
 
 ### Performance
 

--- a/docs/models/architecture.md
+++ b/docs/models/architecture.md
@@ -135,7 +135,7 @@ This ensures exact charge conservation at every pass without constraining the ne
 
 ### Open-Shell Extension (num_charge_channels=2)
 
-For the NSE model (`aimnet2nse`), charges have two channels: alpha-spin and beta-spin. The model sets `num_charge_channels=2`.
+For the NSE model (`aimnet2-nse`), charges have two channels: alpha-spin and beta-spin. The model sets `num_charge_channels=2`.
 
 **Preprocessing:** The total charge `Q` and multiplicity `M` are converted to two-channel targets:
 

--- a/docs/models/guide.md
+++ b/docs/models/guide.md
@@ -160,56 +160,70 @@ print(f"Energy: {mean_energy.item():.6f} +/- {energy_variance.sqrt().item():.6f}
 
 The following table shows all available model names and their aliases:
 
+Registry keys follow the convention `aimnet2-<family>_<index>`: a dash separates `aimnet2` from the model-family tag, and the trailing `_<int>` is the ensemble member index. The previously published forms (`aimnet2nse_*`, `aimnet2_wb97m_d3_*`, etc.) remain supported as aliases.
+
 | Alias | Resolves To | Ensemble Members |
 | --- | --- | --- |
-| `aimnet2` | `aimnet2_wb97m_d3_0` | `aimnet2_wb97m_d3_{0,1,2,3}` |
-| `aimnet2_wb97m` | `aimnet2_wb97m_d3_0` | (same as above) |
-| `aimnet2_b973c` | `aimnet2_b973c_d3_0` | `aimnet2_b973c_d3_{0,1,2,3}` |
-| `aimnet2_2025` | `aimnet2_b973c_2025_d3_0` | `aimnet2_b973c_2025_d3_{0,1,2,3}` |
-| `aimnet2nse` | `aimnet2nse_0` | `aimnet2nse_{0,1,2,3}` |
-| `aimnet2pd` | `aimnet2-pd_0` | `aimnet2-pd_{0,1,2,3}` |
+| `aimnet2` | `aimnet2-wb97m-d3_0` | `aimnet2-wb97m-d3_{0,1,2,3}` |
+| `aimnet2-wb97m` | `aimnet2-wb97m-d3_0` | (same as above) |
+| `aimnet2-b973c` | `aimnet2-b973c-d3_0` | `aimnet2-b973c-d3_{0,1,2,3}` |
+| `aimnet2-2025` | `aimnet2-b973c-2025-d3_0` | `aimnet2-b973c-2025-d3_{0,1,2,3}` |
+| `aimnet2-nse` | `aimnet2-nse_0` | `aimnet2-nse_{0,1,2,3}` |
+| `aimnet2-pd` | `aimnet2-pd_0` | `aimnet2-pd_{0,1,2,3}` |
+| `aimnet2-rxn` | `aimnet2-rxn_0` | `aimnet2-rxn_{0,1,2,3}` |
+
+Legacy aliases that still resolve (kept for backwards compat):
+
+| Legacy alias | Resolves to |
+| --- | --- |
+| `aimnet2_wb97m`, `aimnet2_wb97m_d3_{0..3}` | `aimnet2-wb97m-d3_*` |
+| `aimnet2_b973c`, `aimnet2_b973c_d3_{0..3}` | `aimnet2-b973c-d3_*` |
+| `aimnet2_2025`, `aimnet2_b973c_2025_d3_{0..3}` | `aimnet2-b973c-2025-d3_*` |
+| `aimnet2nse`, `aimnet2nse_{0..3}` | `aimnet2-nse_*` |
+| `aimnet2pd` | `aimnet2-pd_0` |
+| `aimnet2rxn`, `aimnet2_rxn_{0..3}` | `aimnet2-rxn_*` |
 
 ## Direct Model Downloads
 
 All model files are downloaded automatically the first time you call `AIMNet2Calculator("alias")`. To download manually or inspect files, use the links below. All files are in PyTorch v2 `.pt` format.
 
-### AIMNet2 (wB97M-D3) — alias `aimnet2` / `aimnet2_wb97m`
+### AIMNet2 (wB97M-D3) — alias `aimnet2` / `aimnet2-wb97m`
 
 | Registry name | File | Download |
 | --- | --- | --- |
-| `aimnet2_wb97m_d3_0` | aimnet2_wb97m_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_0.pt) |
-| `aimnet2_wb97m_d3_1` | aimnet2_wb97m_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_1.pt) |
-| `aimnet2_wb97m_d3_2` | aimnet2_wb97m_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_2.pt) |
-| `aimnet2_wb97m_d3_3` | aimnet2_wb97m_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_3.pt) |
+| `aimnet2-wb97m-d3_0` | aimnet2_wb97m_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_0.pt) |
+| `aimnet2-wb97m-d3_1` | aimnet2_wb97m_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_1.pt) |
+| `aimnet2-wb97m-d3_2` | aimnet2_wb97m_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_2.pt) |
+| `aimnet2-wb97m-d3_3` | aimnet2_wb97m_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_wb97m_d3_3.pt) |
 
-### AIMNet2-B97-3c — alias `aimnet2_b973c`
-
-| Registry name | File | Download |
-| --- | --- | --- |
-| `aimnet2_b973c_d3_0` | aimnet2_b973c_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_0.pt) |
-| `aimnet2_b973c_d3_1` | aimnet2_b973c_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_1.pt) |
-| `aimnet2_b973c_d3_2` | aimnet2_b973c_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_2.pt) |
-| `aimnet2_b973c_d3_3` | aimnet2_b973c_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_3.pt) |
-
-### AIMNet2-2025 — alias `aimnet2_2025`
+### AIMNet2-B97-3c — alias `aimnet2-b973c`
 
 | Registry name | File | Download |
 | --- | --- | --- |
-| `aimnet2_b973c_2025_d3_0` | aimnet2_2025_b973c_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_0.pt) |
-| `aimnet2_b973c_2025_d3_1` | aimnet2_2025_b973c_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_1.pt) |
-| `aimnet2_b973c_2025_d3_2` | aimnet2_2025_b973c_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_2.pt) |
-| `aimnet2_b973c_2025_d3_3` | aimnet2_2025_b973c_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_3.pt) |
+| `aimnet2-b973c-d3_0` | aimnet2_b973c_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_0.pt) |
+| `aimnet2-b973c-d3_1` | aimnet2_b973c_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_1.pt) |
+| `aimnet2-b973c-d3_2` | aimnet2_b973c_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_2.pt) |
+| `aimnet2-b973c-d3_3` | aimnet2_b973c_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_b973c_d3_3.pt) |
 
-### AIMNet2-NSE — alias `aimnet2nse`
+### AIMNet2-2025 — alias `aimnet2-2025`
 
 | Registry name | File | Download |
 | --- | --- | --- |
-| `aimnet2nse_0` | aimnet2nse_wb97m_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_0.pt) |
-| `aimnet2nse_1` | aimnet2nse_wb97m_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_1.pt) |
-| `aimnet2nse_2` | aimnet2nse_wb97m_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_2.pt) |
-| `aimnet2nse_3` | aimnet2nse_wb97m_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_3.pt) |
+| `aimnet2-b973c-2025-d3_0` | aimnet2_2025_b973c_d3_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_0.pt) |
+| `aimnet2-b973c-2025-d3_1` | aimnet2_2025_b973c_d3_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_1.pt) |
+| `aimnet2-b973c-2025-d3_2` | aimnet2_2025_b973c_d3_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_2.pt) |
+| `aimnet2-b973c-2025-d3_3` | aimnet2_2025_b973c_d3_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2/aimnet2_2025_b973c_d3_3.pt) |
 
-### AIMNet2-Pd — alias `aimnet2pd`
+### AIMNet2-NSE — alias `aimnet2-nse`
+
+| Registry name | File | Download |
+| --- | --- | --- |
+| `aimnet2-nse_0` | aimnet2nse_wb97m_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_0.pt) |
+| `aimnet2-nse_1` | aimnet2nse_wb97m_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_1.pt) |
+| `aimnet2-nse_2` | aimnet2nse_wb97m_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_2.pt) |
+| `aimnet2-nse_3` | aimnet2nse_wb97m_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2NSE/aimnet2nse_wb97m_3.pt) |
+
+### AIMNet2-Pd — alias `aimnet2-pd`
 
 | Registry name | File | Download |
 | --- | --- | --- |
@@ -217,6 +231,15 @@ All model files are downloaded automatically the first time you call `AIMNet2Cal
 | `aimnet2-pd_1` | aimnet2-pd_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2Pd/aimnet2-pd_1.pt) |
 | `aimnet2-pd_2` | aimnet2-pd_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2Pd/aimnet2-pd_2.pt) |
 | `aimnet2-pd_3` | aimnet2-pd_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2Pd/aimnet2-pd_3.pt) |
+
+### AIMNet2-rxn — alias `aimnet2-rxn`
+
+| Registry name | File | Download |
+| --- | --- | --- |
+| `aimnet2-rxn_0` | aimnet2_rxn_0.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_0.pt) |
+| `aimnet2-rxn_1` | aimnet2_rxn_1.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_1.pt) |
+| `aimnet2-rxn_2` | aimnet2_rxn_2.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_2.pt) |
+| `aimnet2-rxn_3` | aimnet2_rxn_3.pt | [download](https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn/aimnet2_rxn_3.pt) |
 
 ## What's Next
 

--- a/docs/models/guide.md
+++ b/docs/models/guide.md
@@ -178,14 +178,14 @@ Registry keys follow the convention `aimnet2-<family>_<index>`: a dash separates
 
 Legacy aliases that still resolve (kept for backwards compat):
 
-| Legacy alias | Resolves to |
-| --- | --- |
-| `aimnet2_wb97m`, `aimnet2_wb97m_d3_{0..3}` | `aimnet2-wb97m-d3_*` |
-| `aimnet2_b973c`, `aimnet2_b973c_d3_{0..3}` | `aimnet2-b973c-d3_*` |
+| Legacy alias                                   | Resolves to               |
+| ---------------------------------------------- | ------------------------- |
+| `aimnet2_wb97m`, `aimnet2_wb97m_d3_{0..3}`     | `aimnet2-wb97m-d3_*`      |
+| `aimnet2_b973c`, `aimnet2_b973c_d3_{0..3}`     | `aimnet2-b973c-d3_*`      |
 | `aimnet2_2025`, `aimnet2_b973c_2025_d3_{0..3}` | `aimnet2-b973c-2025-d3_*` |
-| `aimnet2nse`, `aimnet2nse_{0..3}` | `aimnet2-nse_*` |
-| `aimnet2pd` | `aimnet2-pd_0` |
-| `aimnet2rxn`, `aimnet2_rxn_{0..3}` | `aimnet2-rxn_*` |
+| `aimnet2nse`, `aimnet2nse_{0..3}`              | `aimnet2-nse_*`           |
+| `aimnet2pd`                                    | `aimnet2-pd_0`            |
+| `aimnet2rxn`, `aimnet2_rxn_{0..3}`             | `aimnet2-rxn_*`           |
 
 ## Direct Model Downloads
 

--- a/docs/models/guide.md
+++ b/docs/models/guide.md
@@ -42,10 +42,11 @@ The Pd model replaces As with Pd:
 | Model | Alias | Functional | Best For | Key Strength |
 | --- | --- | --- | --- | --- |
 | AIMNet2 | `aimnet2` | wB97M-D3 | General organic chemistry | Reliable default, broad coverage |
-| **AIMNet2-2025** | **`aimnet2_2025`** | **B97-3c (improved)** | **General-purpose B97-3c** | **Recommended B97-3c model; supersedes B97-3c** |
-| AIMNet2-B97-3c | `aimnet2_b973c` | B97-3c | Legacy B97-3c screening | Superseded by AIMNet2-2025 |
-| AIMNet2-NSE | `aimnet2nse` | wB97M-D3 | Open-shell systems | Radicals, triplet states, bond dissociation |
-| AIMNet2-Pd | `aimnet2pd` | B97-3c/CPCM (THF) | Pd catalysis | Pd organometallics with implicit THF solvation |
+| **AIMNet2-2025** | **`aimnet2-2025`** | **B97-3c (improved)** | **General-purpose B97-3c** | **Recommended B97-3c model; supersedes B97-3c** |
+| AIMNet2-B97-3c | `aimnet2-b973c` | B97-3c | Legacy B97-3c screening | Superseded by AIMNet2-2025 |
+| AIMNet2-NSE | `aimnet2-nse` | wB97M-D3 | Open-shell systems | Radicals, triplet states, bond dissociation |
+| AIMNet2-Pd | `aimnet2-pd` | B97-3c/CPCM (THF) | Pd catalysis | Pd organometallics with implicit THF solvation |
+| AIMNet2-rxn | `aimnet2-rxn` | wB97M-D3 | Reactive chemistry | Bond breaking/forming, transition states |
 
 ## Decision Flowchart
 
@@ -57,28 +58,28 @@ Check the [element table](#supported-elements) above. If your system contains el
 
 ### Step 2: Does your system contain palladium?
 
-If yes, use **`aimnet2pd`**. This is the only model that supports Pd. Note that it does **not** support As (which the other models do).
+If yes, use **`aimnet2-pd`**. This is the only model that supports Pd. Note that it does **not** support As (which the other models do).
 
 ### Step 3: Is your system open-shell?
 
-Radicals, triplet states, or any system with unpaired electrons should use **`aimnet2nse`**. The NSE (Neutral Spin Equilibrated) scheme handles spin polarization through two charge channels instead of one.
+Radicals, triplet states, or any system with unpaired electrons should use **`aimnet2-nse`**. The NSE (Neutral Spin Equilibrated) scheme handles spin polarization through two charge channels instead of one.
 
 !!! note "When to use NSE"
 
-    Use `aimnet2nse` whenever you need to set `mult > 1`, or when bonds are breaking or forming (e.g., transition states, bond dissociation curves). Even for closed-shell transition states, NSE often gives more reliable energies because the NN can represent partial bond breaking.
+    Use `aimnet2-nse` whenever you need to set `mult > 1`, or when bonds are breaking or forming (e.g., transition states, bond dissociation curves). Even for closed-shell transition states, NSE often gives more reliable energies because the NN can represent partial bond breaking.
 
 ### Step 4: Do you want a B97-3c-level model?
 
-If you prefer a B97-3c reference level (faster DFT, suitable for screening and large-scale studies), use **`aimnet2_2025`**. This is the recommended B97-3c model — it supersedes the original `aimnet2_b973c` with improved intermolecular interaction accuracy while retaining the same intramolecular performance.
+If you prefer a B97-3c reference level (faster DFT, suitable for screening and large-scale studies), use **`aimnet2-2025`**. This is the recommended B97-3c model — it supersedes the original `aimnet2-b973c` with improved intermolecular interaction accuracy while retaining the same intramolecular performance.
 
 !!! note "AIMNet2-2025 supersedes AIMNet2-B97-3c"
 
-    For all new work requiring a B97-3c-level model, use `aimnet2_2025`. The original `aimnet2_b973c` is retained for reproducibility of published results but is no longer the recommended choice. AIMNet2-2025 provides strictly better accuracy for non-covalent interactions with no regression for covalent chemistry.
+    For all new work requiring a B97-3c-level model, use `aimnet2-2025`. The original `aimnet2-b973c` is retained for reproducibility of published results but is no longer the recommended choice. AIMNet2-2025 provides strictly better accuracy for non-covalent interactions with no regression for covalent chemistry.
 
 ### Step 5: General-purpose?
 
 - **General-purpose** calculations: use **`aimnet2`** (the default). Trained on wB97M-D3, a well-validated range-separated hybrid functional.
-- **Legacy B97-3c**: `aimnet2_b973c` is available for reproducing previous results but new projects should use `aimnet2_2025` instead.
+- **Legacy B97-3c**: `aimnet2-b973c` is available for reproducing previous results but new projects should use `aimnet2-2025` instead.
 
 ## Loading Models
 
@@ -91,23 +92,26 @@ from aimnet.calculators import AIMNet2Calculator
 calc = AIMNet2Calculator("aimnet2")
 
 # B97-3c model
-calc = AIMNet2Calculator("aimnet2_b973c")
+calc = AIMNet2Calculator("aimnet2-b973c")
 
 # 2025 improved model
-calc = AIMNet2Calculator("aimnet2_2025")
+calc = AIMNet2Calculator("aimnet2-2025")
 
 # NSE open-shell model
-calc = AIMNet2Calculator("aimnet2nse")
+calc = AIMNet2Calculator("aimnet2-nse")
 
 # Palladium model
-calc = AIMNet2Calculator("aimnet2pd")
+calc = AIMNet2Calculator("aimnet2-pd")
+
+# Reactive chemistry model
+calc = AIMNet2Calculator("aimnet2-rxn")
 ```
 
 Each alias loads ensemble member `_0` by default. To load a specific member, use the full model name:
 
 ```python
 # Load member 2 of the wB97M-D3 ensemble
-calc = AIMNet2Calculator("aimnet2_wb97m_d3_2")
+calc = AIMNet2Calculator("aimnet2-wb97m-d3_2")
 ```
 
 ## Ensemble Models and Uncertainty Estimation
@@ -129,7 +133,7 @@ import torch
 from aimnet.calculators import AIMNet2Calculator
 
 # Load all 4 ensemble members
-calcs = [AIMNet2Calculator(f"aimnet2_wb97m_d3_{i}") for i in range(4)]
+calcs = [AIMNet2Calculator(f"aimnet2-wb97m-d3_{i}") for i in range(4)]
 
 # Run inference with each member
 data = {

--- a/docs/train.md
+++ b/docs/train.md
@@ -213,7 +213,9 @@ For maintainers migrating the model registry from legacy `.jpt` to new `.pt` for
 4. **Update model_registry.yaml:**
    ```yaml
    models:
-     aimnet2_wb97m_d3_0:
+     aimnet2-wb97m-d3_0:
        file: aimnet2_wb97m_d3_0.pt
        url: https://storage.googleapis.com/aimnetcentral/AIMNet2/aimnet2_wb97m_d3_0.pt
    ```
+
+   Registry keys follow the convention `aimnet2-<family>_<member>` (dash separates `aimnet2` from the family tag, trailing `_<int>` is the ensemble member index). The `file:` field keeps the original filename so cached `.pt` downloads remain valid.

--- a/docs/train.md
+++ b/docs/train.md
@@ -211,6 +211,7 @@ For maintainers migrating the model registry from legacy `.jpt` to new `.pt` for
    ```
 
 4. **Update model_registry.yaml:**
+
    ```yaml
    models:
      aimnet2-wb97m-d3_0:

--- a/docs/tutorials/geometry_optimization.md
+++ b/docs/tutorials/geometry_optimization.md
@@ -130,7 +130,7 @@ You should see the energy decrease monotonically (or nearly so) and the maximum 
        of `BFGS` for the first phase.
     2. **Charge**: An incorrect net charge leads to wrong forces. Verify with
        `calc.charge`.
-    3. **Multiplicity**: For open-shell systems, use `AIMNet2ASE("aimnet2nse")`
+    3. **Multiplicity**: For open-shell systems, use `AIMNet2ASE("aimnet2-nse")`
        and set `mult` appropriately.
 
 ## Step 4: Verify the Minimum with Frequency Analysis

--- a/docs/tutorials/hugging_face.md
+++ b/docs/tutorials/hugging_face.md
@@ -27,9 +27,10 @@ The first call downloads the model weights to the HF cache directory (`~/.cache/
 | HF Repo | Equivalent Alias | DFT Functional | Best For |
 | --- | --- | --- | --- |
 | `isayevlab/aimnet2-wb97m-d3` | `aimnet2` | wB97M-D3 | General organic chemistry |
-| `isayevlab/aimnet2-2025` | `aimnet2_2025` | B97-3c | Recommended for intermolecular interactions |
-| `isayevlab/aimnet2-nse` | `aimnet2nse` | wB97M-D3 | Open-shell systems / radicals |
-| `isayevlab/aimnet2-pd` | `aimnet2pd` | B97-3c/CPCM | Palladium chemistry |
+| `isayevlab/aimnet2-2025` | `aimnet2-2025` | B97-3c | Recommended for intermolecular interactions |
+| `isayevlab/aimnet2-nse` | `aimnet2-nse` | wB97M-D3 | Open-shell systems / radicals |
+| `isayevlab/aimnet2-pd` | `aimnet2-pd` | B97-3c/CPCM | Palladium chemistry |
+| `isayevlab/aimnet2-rxn` | `aimnet2-rxn` | wB97M-V | Reactive chemistry / TS / IRC |
 
 Each repo contains four ensemble members (`ensemble_0.safetensors` – `ensemble_3.safetensors`). Member 0 is loaded by default.
 

--- a/docs/tutorials/single_point.md
+++ b/docs/tutorials/single_point.md
@@ -175,7 +175,7 @@ print(f"Hessian shape: {hessian.shape}")  # (21, 3, 21, 3) for aspirin
 AIMNet2 provides several models trained on different DFT functionals. Each is suitable for different chemistry. You can compare them on the same molecule to understand how model choice affects predictions:
 
 ```python
-model_names = ["aimnet2", "aimnet2_b973c", "aimnet2_2025"]
+model_names = ["aimnet2", "aimnet2-b973c", "aimnet2-2025"]
 
 input_data = {
     "coord": aspirin_coords,
@@ -203,12 +203,13 @@ The available model aliases are:
 | Alias           | DFT Functional    | Best for                     |
 | --------------- | ----------------- | ---------------------------- |
 | `aimnet2`       | wB97M-D3          | General organic chemistry    |
-| `aimnet2_2025`  | B97-3c (improved) | Recommended B97-3c model     |
-| `aimnet2_b973c` | B97-3c            | Legacy (superseded by 2025)  |
-| `aimnet2nse`    | wB97M-D3          | Open-shell / radical systems |
-| `aimnet2pd`     | wB97M-D3          | Palladium-containing systems |
+| `aimnet2-2025`  | B97-3c (improved) | Recommended B97-3c model     |
+| `aimnet2-b973c` | B97-3c            | Legacy (superseded by 2025)  |
+| `aimnet2-nse`   | wB97M-D3          | Open-shell / radical systems |
+| `aimnet2-pd`    | B97-3c/CPCM (THF) | Palladium-containing systems |
+| `aimnet2-rxn`   | wB97M-V           | Reactive chemistry / TS / IRC |
 
-Each alias points to ensemble member `_0` by default. For uncertainty estimation, you can load all four ensemble members (e.g., `aimnet2_wb97m_d3_0` through `aimnet2_wb97m_d3_3`) and compare their predictions.
+Each alias points to ensemble member `_0` by default. For uncertainty estimation, you can load all four ensemble members (e.g., `aimnet2-wb97m-d3_0` through `aimnet2-wb97m-d3_3`) and compare their predictions. Previously published aliases (`aimnet2_2025`, `aimnet2nse`, etc.) continue to resolve.
 
 ## Step 5: Using `compile_model` for Repeated Calculations
 

--- a/docs/tutorials/single_point.md
+++ b/docs/tutorials/single_point.md
@@ -200,13 +200,13 @@ for name in model_names:
 
 The available model aliases are:
 
-| Alias           | DFT Functional    | Best for                     |
-| --------------- | ----------------- | ---------------------------- |
-| `aimnet2`       | wB97M-D3          | General organic chemistry    |
-| `aimnet2-2025`  | B97-3c (improved) | Recommended B97-3c model     |
-| `aimnet2-b973c` | B97-3c            | Legacy (superseded by 2025)  |
-| `aimnet2-nse`   | wB97M-D3          | Open-shell / radical systems |
-| `aimnet2-pd`    | B97-3c/CPCM (THF) | Palladium-containing systems |
+| Alias           | DFT Functional    | Best for                      |
+| --------------- | ----------------- | ----------------------------- |
+| `aimnet2`       | wB97M-D3          | General organic chemistry     |
+| `aimnet2-2025`  | B97-3c (improved) | Recommended B97-3c model      |
+| `aimnet2-b973c` | B97-3c            | Legacy (superseded by 2025)   |
+| `aimnet2-nse`   | wB97M-D3          | Open-shell / radical systems  |
+| `aimnet2-pd`    | B97-3c/CPCM (THF) | Palladium-containing systems  |
 | `aimnet2-rxn`   | wB97M-V           | Reactive chemistry / TS / IRC |
 
 Each alias points to ensemble member `_0` by default. For uncertainty estimation, you can load all four ensemble members (e.g., `aimnet2-wb97m-d3_0` through `aimnet2-wb97m-d3_3`) and compare their predictions. Previously published aliases (`aimnet2_2025`, `aimnet2nse`, etc.) continue to resolve.

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -20,21 +20,102 @@ def test_load_model_registry_uses_default_when_no_param():
     assert "aimnet2" in result.get("aliases", {})
 
 
-def test_aimnet2rxn_registry_entries_and_alias():
-    """All four aimnet2-rxn members must be registered with the canonical GCS URL,
-    and the `aimnet2rxn` alias must resolve to member 0."""
-    from aimnet.calculators.model_registry import load_model_registry
+def test_default_aimnet2_alias_resolves_to_wb97m_d3():
+    """The bare `aimnet2` alias must resolve to the canonical wb97m-d3 member 0."""
+    registry = load_model_registry()
+    assert registry["aliases"]["aimnet2"] == "aimnet2-wb97m-d3_0"
+    assert "aimnet2-wb97m-d3_0" in registry["models"]
 
+
+def test_canonical_aimnet2rxn_registry_entries():
+    """All four aimnet2-rxn members must be registered under the canonical
+    dash-form key with the original GCS URL/file."""
     registry = load_model_registry()
     models = registry["models"]
 
     base_url = "https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn"
     for i in range(4):
-        name = f"aimnet2_rxn_{i}"
-        assert name in models, f"missing registry entry: {name}"
-        entry = models[name]
-        assert entry["file"] == f"{name}.pt"
-        assert entry["url"] == f"{base_url}/{name}.pt"
+        canonical = f"aimnet2-rxn_{i}"
+        assert canonical in models, f"missing registry entry: {canonical}"
+        entry = models[canonical]
+        assert entry["file"] == f"aimnet2_rxn_{i}.pt"
+        assert entry["url"] == f"{base_url}/aimnet2_rxn_{i}.pt"
 
+
+def test_short_alias_forms_match():
+    """Each model family's short alias forms (dash-canonical plus any legacy
+    forms that have shipped publicly) must all resolve to the same canonical
+    member-0 model key."""
+    registry = load_model_registry()
     aliases = registry["aliases"]
-    assert aliases.get("aimnet2rxn") == "aimnet2_rxn_0"
+
+    # (canonical_alias, [legacy_aliases], expected_target)
+    expectations = [
+        ("aimnet2-nse", ["aimnet2nse"], "aimnet2-nse_0"),
+        ("aimnet2-pd", ["aimnet2pd"], "aimnet2-pd_0"),
+        ("aimnet2-rxn", ["aimnet2rxn"], "aimnet2-rxn_0"),
+        ("aimnet2-wb97m", ["aimnet2_wb97m"], "aimnet2-wb97m-d3_0"),
+        ("aimnet2-b973c", ["aimnet2_b973c"], "aimnet2-b973c-d3_0"),
+        ("aimnet2-2025", ["aimnet2_2025"], "aimnet2-b973c-2025-d3_0"),
+    ]
+    for canonical_alias, legacy_aliases, expected_target in expectations:
+        assert aliases.get(canonical_alias) == expected_target, (
+            f"{canonical_alias} should resolve to {expected_target}"
+        )
+        for legacy in legacy_aliases:
+            assert aliases.get(legacy) == expected_target, (
+                f"legacy alias {legacy} should resolve to {expected_target}"
+            )
+
+
+def test_canonical_keys_for_all_families():
+    """Every model family must have its four ensemble members registered under
+    the canonical dash-form key, mapped to the original (unchanged) GCS files."""
+    registry = load_model_registry()
+    models = registry["models"]
+
+    expected = {
+        # canonical_key_template, file_template, gcs_subdir
+        ("aimnet2-wb97m-d3_{i}", "aimnet2_wb97m_d3_{i}.pt", "AIMNet2"),
+        ("aimnet2-b973c-d3_{i}", "aimnet2_b973c_d3_{i}.pt", "AIMNet2"),
+        ("aimnet2-b973c-2025-d3_{i}", "aimnet2_2025_b973c_d3_{i}.pt", "AIMNet2"),
+        ("aimnet2-nse_{i}", "aimnet2nse_wb97m_{i}.pt", "AIMNet2NSE"),
+        ("aimnet2-pd_{i}", "aimnet2-pd_{i}.pt", "AIMNet2Pd"),
+        ("aimnet2-rxn_{i}", "aimnet2_rxn_{i}.pt", "AIMNet2rxn"),
+    }
+    base = "https://storage.googleapis.com/aimnetcentral/aimnet2v2"
+    for key_tmpl, file_tmpl, subdir in expected:
+        for i in range(4):
+            key = key_tmpl.format(i=i)
+            file = file_tmpl.format(i=i)
+            assert key in models, f"missing model key: {key}"
+            entry = models[key]
+            assert entry["file"] == file, f"{key}: file mismatch"
+            assert entry["url"] == f"{base}/{subdir}/{file}", f"{key}: url mismatch"
+
+
+def test_legacy_member_aliases_resolve_via_loader():
+    """End-to-end: every legacy member-level key (under any historical naming
+    convention) must resolve through one alias indirection to a real model entry,
+    matching the resolution logic in get_registry_model_path."""
+    registry = load_model_registry()
+    models = registry["models"]
+    aliases = registry["aliases"]
+
+    legacy_keys = [
+        # underscore-form legacy keys (the previous shape of every default model)
+        "aimnet2_wb97m_d3_0", "aimnet2_wb97m_d3_1",
+        "aimnet2_wb97m_d3_2", "aimnet2_wb97m_d3_3",
+        "aimnet2_b973c_d3_0", "aimnet2_b973c_d3_1",
+        "aimnet2_b973c_d3_2", "aimnet2_b973c_d3_3",
+        "aimnet2_b973c_2025_d3_0", "aimnet2_b973c_2025_d3_1",
+        "aimnet2_b973c_2025_d3_2", "aimnet2_b973c_2025_d3_3",
+        "aimnet2_rxn_0", "aimnet2_rxn_1", "aimnet2_rxn_2", "aimnet2_rxn_3",
+        # no-separator-form legacy keys
+        "aimnet2nse_0", "aimnet2nse_1", "aimnet2nse_2", "aimnet2nse_3",
+    ]
+    for legacy in legacy_keys:
+        resolved = aliases.get(legacy, legacy)
+        assert resolved in models, (
+            f"{legacy} resolves to {resolved} which is not a model entry"
+        )

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -44,13 +44,9 @@ def test_short_alias_forms_match():
         ("aimnet2-2025", ["aimnet2_2025"], "aimnet2-b973c-2025-d3_0"),
     ]
     for canonical_alias, legacy_aliases, expected_target in expectations:
-        assert aliases.get(canonical_alias) == expected_target, (
-            f"{canonical_alias} should resolve to {expected_target}"
-        )
+        assert aliases.get(canonical_alias) == expected_target, f"{canonical_alias} should resolve to {expected_target}"
         for legacy in legacy_aliases:
-            assert aliases.get(legacy) == expected_target, (
-                f"legacy alias {legacy} should resolve to {expected_target}"
-            )
+            assert aliases.get(legacy) == expected_target, f"legacy alias {legacy} should resolve to {expected_target}"
 
 
 def test_canonical_keys_for_all_families():
@@ -88,30 +84,41 @@ def test_legacy_member_aliases_resolve_via_loader(monkeypatch):
     # stub the download step so the loader collapses to pure lookup; return
     # the expected on-disk path get_registry_model_path would normally hand back
     monkeypatch.setattr(
-        mr, "_maybe_download_asset",
+        mr,
+        "_maybe_download_asset",
         lambda file, url: f"/assets/{file}",
     )
 
     registry = mr.load_model_registry()
     legacy_keys = [
         # underscore-form legacy keys (the previous shape of every default model)
-        "aimnet2_wb97m_d3_0", "aimnet2_wb97m_d3_1",
-        "aimnet2_wb97m_d3_2", "aimnet2_wb97m_d3_3",
-        "aimnet2_b973c_d3_0", "aimnet2_b973c_d3_1",
-        "aimnet2_b973c_d3_2", "aimnet2_b973c_d3_3",
-        "aimnet2_b973c_2025_d3_0", "aimnet2_b973c_2025_d3_1",
-        "aimnet2_b973c_2025_d3_2", "aimnet2_b973c_2025_d3_3",
-        "aimnet2_rxn_0", "aimnet2_rxn_1", "aimnet2_rxn_2", "aimnet2_rxn_3",
+        "aimnet2_wb97m_d3_0",
+        "aimnet2_wb97m_d3_1",
+        "aimnet2_wb97m_d3_2",
+        "aimnet2_wb97m_d3_3",
+        "aimnet2_b973c_d3_0",
+        "aimnet2_b973c_d3_1",
+        "aimnet2_b973c_d3_2",
+        "aimnet2_b973c_d3_3",
+        "aimnet2_b973c_2025_d3_0",
+        "aimnet2_b973c_2025_d3_1",
+        "aimnet2_b973c_2025_d3_2",
+        "aimnet2_b973c_2025_d3_3",
+        "aimnet2_rxn_0",
+        "aimnet2_rxn_1",
+        "aimnet2_rxn_2",
+        "aimnet2_rxn_3",
         # no-separator-form legacy keys
-        "aimnet2nse_0", "aimnet2nse_1", "aimnet2nse_2", "aimnet2nse_3",
+        "aimnet2nse_0",
+        "aimnet2nse_1",
+        "aimnet2nse_2",
+        "aimnet2nse_3",
     ]
     for legacy in legacy_keys:
         path = mr.get_registry_model_path(legacy)
         canonical = registry["aliases"][legacy]
         expected_file = registry["models"][canonical]["file"]
-        assert path == f"/assets/{expected_file}", (
-            f"{legacy} resolved to {path}, expected /assets/{expected_file}"
-        )
+        assert path == f"/assets/{expected_file}", f"{legacy} resolved to {path}, expected /assets/{expected_file}"
 
 
 def test_no_alias_to_alias_chains():
@@ -124,6 +131,4 @@ def test_no_alias_to_alias_chains():
 
     for src, dst in aliases.items():
         assert dst in models, f"alias {src!r} -> {dst!r} is not a model entry"
-        assert dst not in aliases, (
-            f"alias {src!r} -> {dst!r} is itself an alias (would require >1 hop)"
-        )
+        assert dst not in aliases, f"alias {src!r} -> {dst!r} is itself an alias (would require >1 hop)"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -27,21 +27,6 @@ def test_default_aimnet2_alias_resolves_to_wb97m_d3():
     assert "aimnet2-wb97m-d3_0" in registry["models"]
 
 
-def test_canonical_aimnet2rxn_registry_entries():
-    """All four aimnet2-rxn members must be registered under the canonical
-    dash-form key with the original GCS URL/file."""
-    registry = load_model_registry()
-    models = registry["models"]
-
-    base_url = "https://storage.googleapis.com/aimnetcentral/aimnet2v2/AIMNet2rxn"
-    for i in range(4):
-        canonical = f"aimnet2-rxn_{i}"
-        assert canonical in models, f"missing registry entry: {canonical}"
-        entry = models[canonical]
-        assert entry["file"] == f"aimnet2_rxn_{i}.pt"
-        assert entry["url"] == f"{base_url}/aimnet2_rxn_{i}.pt"
-
-
 def test_short_alias_forms_match():
     """Each model family's short alias forms (dash-canonical plus any legacy
     forms that have shipped publicly) must all resolve to the same canonical
@@ -74,15 +59,15 @@ def test_canonical_keys_for_all_families():
     registry = load_model_registry()
     models = registry["models"]
 
-    expected = {
-        # canonical_key_template, file_template, gcs_subdir
+    expected = [
+        # (canonical_key_template, file_template, gcs_subdir)
         ("aimnet2-wb97m-d3_{i}", "aimnet2_wb97m_d3_{i}.pt", "AIMNet2"),
         ("aimnet2-b973c-d3_{i}", "aimnet2_b973c_d3_{i}.pt", "AIMNet2"),
         ("aimnet2-b973c-2025-d3_{i}", "aimnet2_2025_b973c_d3_{i}.pt", "AIMNet2"),
         ("aimnet2-nse_{i}", "aimnet2nse_wb97m_{i}.pt", "AIMNet2NSE"),
         ("aimnet2-pd_{i}", "aimnet2-pd_{i}.pt", "AIMNet2Pd"),
         ("aimnet2-rxn_{i}", "aimnet2_rxn_{i}.pt", "AIMNet2rxn"),
-    }
+    ]
     base = "https://storage.googleapis.com/aimnetcentral/aimnet2v2"
     for key_tmpl, file_tmpl, subdir in expected:
         for i in range(4):
@@ -94,14 +79,20 @@ def test_canonical_keys_for_all_families():
             assert entry["url"] == f"{base}/{subdir}/{file}", f"{key}: url mismatch"
 
 
-def test_legacy_member_aliases_resolve_via_loader():
-    """End-to-end: every legacy member-level key (under any historical naming
-    convention) must resolve through one alias indirection to a real model entry,
-    matching the resolution logic in get_registry_model_path."""
-    registry = load_model_registry()
-    models = registry["models"]
-    aliases = registry["aliases"]
+def test_legacy_member_aliases_resolve_via_loader(monkeypatch):
+    """End-to-end: every legacy member-level key must resolve through
+    get_registry_model_path's alias indirection to the canonical model's file.
+    The download step is stubbed so the test exercises the lookup logic only."""
+    from aimnet.calculators import model_registry as mr
 
+    # stub the download step so the loader collapses to pure lookup; return
+    # the expected on-disk path get_registry_model_path would normally hand back
+    monkeypatch.setattr(
+        mr, "_maybe_download_asset",
+        lambda file, url: f"/assets/{file}",
+    )
+
+    registry = mr.load_model_registry()
     legacy_keys = [
         # underscore-form legacy keys (the previous shape of every default model)
         "aimnet2_wb97m_d3_0", "aimnet2_wb97m_d3_1",
@@ -115,7 +106,24 @@ def test_legacy_member_aliases_resolve_via_loader():
         "aimnet2nse_0", "aimnet2nse_1", "aimnet2nse_2", "aimnet2nse_3",
     ]
     for legacy in legacy_keys:
-        resolved = aliases.get(legacy, legacy)
-        assert resolved in models, (
-            f"{legacy} resolves to {resolved} which is not a model entry"
+        path = mr.get_registry_model_path(legacy)
+        canonical = registry["aliases"][legacy]
+        expected_file = registry["models"][canonical]["file"]
+        assert path == f"/assets/{expected_file}", (
+            f"{legacy} resolved to {path}, expected /assets/{expected_file}"
+        )
+
+
+def test_no_alias_to_alias_chains():
+    """Single-hop invariant: every alias value must be a real model key, never
+    another alias. This makes the get_registry_model_path one-hop lookup
+    mechanically enforced rather than maintained by hand."""
+    registry = load_model_registry()
+    models = registry["models"]
+    aliases = registry["aliases"]
+
+    for src, dst in aliases.items():
+        assert dst in models, f"alias {src!r} -> {dst!r} is not a model entry"
+        assert dst not in aliases, (
+            f"alias {src!r} -> {dst!r} is itself an alias (would require >1 hop)"
         )


### PR DESCRIPTION
## Summary

- Apply uniform `aimnet2-<family>_<member>` convention to every model key in the registry: dash separates `aimnet2` from the family tag, the trailing `_<int>` is reserved for the ensemble index.
- File fields keep the original GCS filenames, so nothing on the bucket needs renaming.
- Every previously published alias (short forms `aimnet2_wb97m`, `aimnet2nse`, `aimnet2pd`, `aimnet2rxn`, ... and member-level keys `aimnet2_wb97m_d3_0..3`, `aimnet2nse_0..3`, `aimnet2-pd_0..3`, `aimnet2_rxn_0..3`, ...) continues to resolve via the `aliases:` section.

## Test plan

- [x] `pytest tests/test_model_registry.py` -- 7 tests covering canonical keys, short-alias forms, default `aimnet2` alias, and legacy member-level alias resolution
- [x] `pytest tests/test_hf_hub.py` -- 7 tests, all pass (registry indirection)
- [x] Smoke test: every alias in `aliases:` resolves to a real model entry (33 aliases over 24 models)
- [x] `test_aimnet2rxn_alias_calculator_e2e` (network-marked, skipped by default) still uses the legacy `aimnet2rxn` alias which is preserved