### PR TITLE
Speed up CI: cache model loads and Warp kernels, trim matrix

### DIFF
--- a/.github/actions/setup-uv-env/action.yml
+++ b/.github/actions/setup-uv-env/action.yml
@@ -28,6 +28,14 @@ runs:
           with:
               enable-cache: true
 
+        - name: Cache Warp kernels
+          uses: actions/cache@v5
+          with:
+              path: ~/.cache/warp
+              key: warp-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+              restore-keys: |
+                  warp-${{ runner.os }}-
+
         - name: Install dependencies
           env:
               INPUT_GROUPS: ${{ inputs.groups }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                python-version: ["3.11", "3.12", "3.13"]
+                python-version: ["3.11", "3.13"]
             fail-fast: false
         defaults:
             run:
@@ -51,7 +51,7 @@ jobs:
                   groups: dev
 
             - name: Run tests
-              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim" --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" -n auto --cov --cov-config=pyproject.toml --cov-report=xml
 
             - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
               uses: codecov/codecov-action@v6
@@ -81,7 +81,7 @@ jobs:
                   extras: ase
 
             - name: Run ASE tests
-              run: uv run pytest tests -m "ase and not sella" --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "ase and not sella and not slow" -n auto --cov --cov-config=pyproject.toml --cov-report=xml
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v6
@@ -112,7 +112,7 @@ jobs:
             - name: Run train-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m train --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m train -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No train-marked tests collected; treating as success."
                     exit 0
@@ -149,7 +149,7 @@ jobs:
             - name: Run pysis-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m pysis --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m pysis -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No pysis-marked tests collected; treating as success."
                     exit 0
@@ -186,7 +186,7 @@ jobs:
             - name: Run sella-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m sella --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m sella -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No sella-marked tests collected; treating as success."
                     exit 0
@@ -223,7 +223,7 @@ jobs:
             - name: Run hf-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m hf --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m hf -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No hf-marked tests collected; treating as success."
                     exit 0
@@ -260,7 +260,7 @@ jobs:
             - name: Run torch_sim-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m torch_sim --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m torch_sim -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No torch_sim-marked tests collected; treating as success."
                     exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
                   groups: dev
 
             - name: Run tests
-              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" -n auto --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" --cov --cov-config=pyproject.toml --cov-report=xml
 
             - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
               uses: codecov/codecov-action@v6
@@ -81,7 +81,7 @@ jobs:
                   extras: ase
 
             - name: Run ASE tests
-              run: uv run pytest tests -m "ase and not sella and not slow" -n auto --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "ase and not sella and not slow" --cov --cov-config=pyproject.toml --cov-report=xml
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v6
@@ -112,7 +112,7 @@ jobs:
             - name: Run train-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m train -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m train --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No train-marked tests collected; treating as success."
                     exit 0
@@ -149,7 +149,7 @@ jobs:
             - name: Run pysis-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m pysis -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m pysis --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No pysis-marked tests collected; treating as success."
                     exit 0
@@ -186,7 +186,7 @@ jobs:
             - name: Run sella-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m sella -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m sella --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No sella-marked tests collected; treating as success."
                     exit 0
@@ -223,7 +223,7 @@ jobs:
             - name: Run hf-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m hf -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m hf --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No hf-marked tests collected; treating as success."
                     exit 0
@@ -260,7 +260,7 @@ jobs:
             - name: Run torch_sim-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m torch_sim -n auto --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m torch_sim --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No torch_sim-marked tests collected; treating as success."
                     exit 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for AIMNet2 tests."""
 
 import contextlib
+import functools
 import os
 import shutil
 import sys
@@ -689,3 +690,128 @@ def nacl_crystal(device) -> dict[str, Tensor]:
 def simple_periodic_system(device) -> dict[str, Tensor]:
     """Simple periodic system fixture for Ewald tests."""
     return setup_simple_periodic_system(device)
+
+
+# =============================================================================
+# Cached model loading to speed up the test suite
+# =============================================================================
+#
+# Constructing an ``AIMNet2Calculator`` / ``AIMNet2ASE`` re-runs
+# ``load_model(get_model_path(name))`` every time, which deserializes the model
+# and triggers TorchScript / Warp kernel JIT on first forward. That dominates
+# CI wall time (the ASE suite constructs a calculator per test). We memoize
+# ``load_model`` for the duration of the test session so repeated calculator
+# constructions reuse the already-loaded ``nn.Module``.
+#
+# This is safe because:
+#   * the cached object is the loaded model only; every test still builds its
+#     own calculator wrapper, so per-instance mutable state (coulomb method,
+#     external_dftd3, _saved_for_grad, ...) stays independent;
+#   * no test reloads weights (no ``load_state_dict``), flips the module into
+#     training mode, or mutates model parameters/buffers in place;
+#   * the training suite (test_train.py) does not use ``load_model`` or the
+#     calculators, so it is unaffected.
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cache_load_model():
+    """Memoize the expensive part of ``load_model`` for the whole test session.
+
+    The dominant cost of ``load_model`` is the on-disk deserialize plus the
+    first-forward TorchScript / Warp kernel JIT. We memoize that work once per
+    ``(path, device)`` and hand each caller a fresh ``copy.deepcopy`` of the
+    cached module.
+
+    Returning a *copy* (rather than the shared instance) is required for
+    correctness: tests construct calculators in both eval (``train=False``,
+    which sets ``requires_grad=False`` on every parameter) and train
+    (``train=True``) modes, and train-mode tests run ``loss.backward()`` and
+    inspect ``param.grad``. If the module were shared, an earlier eval-mode
+    calculator would leave ``requires_grad=False`` / stale ``.grad`` on the
+    parameters and a later train-mode test in the same file would observe no
+    gradients. A deepcopy gives every calculator an independent module while
+    still skipping the disk read and kernel JIT.
+
+    Each xdist worker is a separate process with its own session, so each
+    worker pays the load cost at most once per model. ``AIMNet2Calculator``
+    does a module-level ``from aimnet.models.base import load_model``, so we
+    patch both the source module and the calculator's bound reference.
+    """
+    import copy as _copy
+
+    import aimnet.calculators.calculator as _calc
+    import aimnet.models.base as _base
+
+    _real_load_model = _base.load_model
+    _store: dict = {}
+
+    @functools.wraps(_real_load_model)
+    def _cached_load_model(path, device="cpu"):
+        key = (path, str(device))
+        if key not in _store:
+            _store[key] = _real_load_model(path, device)
+        model, metadata = _store[key]
+        # Hand back an independent module so per-calculator mutation
+        # (requires_grad toggling, accumulated .grad) never leaks across tests.
+        return _copy.deepcopy(model), metadata
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_base, "load_model", _cached_load_model, raising=False)
+        if hasattr(_calc, "load_model"):
+            mp.setattr(_calc, "load_model", _cached_load_model, raising=False)
+        yield _cached_load_model
+
+
+@pytest.fixture(scope="session")
+def model_cache():
+    """Session-scoped loader returning fresh ``(nn.Module, metadata)`` pairs.
+
+    Usage::
+
+        module, metadata = model_cache.load("aimnet2", device="cpu")
+
+    The expensive load is memoized once per ``(name, device)``; each ``load``
+    call returns an independent ``copy.deepcopy`` of the cached module, so
+    callers may freely mutate parameters/buffers without leaking across tests.
+    """
+    import copy
+
+    from aimnet.calculators.model_registry import get_model_path
+    from aimnet.models.base import load_model as _load_model
+
+    cache: dict = {}
+
+    class _ModelCache:
+        @staticmethod
+        def load(name: str = "aimnet2", device: str = "cpu"):
+            key = (name, str(device))
+            if key not in cache:
+                cache[key] = _load_model(get_model_path(name), device)
+            model, metadata = cache[key]
+            return copy.deepcopy(model), metadata
+
+    return _ModelCache()
+
+
+@pytest.fixture
+def make_calc(model_cache):
+    """Factory building a fresh ``AIMNet2Calculator`` around a cached module."""
+    from aimnet.calculators import AIMNet2Calculator
+
+    def _make(name: str = "aimnet2", device: str = "cpu", **kwargs):
+        module, _ = model_cache.load(name, device=device)
+        return AIMNet2Calculator(module, **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def make_ase_calc(model_cache):
+    """Factory building a fresh ``AIMNet2ASE`` around a cached module."""
+    from aimnet.calculators import AIMNet2ASE
+
+    def _make(name: str = "aimnet2", device: str = "cpu", **kwargs):
+        module, _ = model_cache.load(name, device=device)
+        return AIMNet2ASE(module, **kwargs)
+
+    return _make

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -177,6 +177,7 @@ class TestPBC:
 class TestOptimization:
     """Tests for geometry optimization."""
 
+    @pytest.mark.slow
     def test_energy_decreases_on_optimization(self):
         """Test that energy decreases during optimization."""
         pytest.importorskip("ase", reason="ASE not installed")

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -10,7 +10,7 @@ from conftest import CAFFEINE_FILE, load_mol
 from aimnet.calculators import AIMNet2Calculator
 
 # These are calculator integration tests: most construct and run a model.
-pytestmark = [pytest.mark.ase, pytest.mark.slow]
+pytestmark = [pytest.mark.ase]
 
 
 def test_from_zoo():


### PR DESCRIPTION
## Summary

Cuts CI wall time, dominated by the `tests-ase` job (was ~9 min). Stacked on top of #78 — base branch is `lr-coulomb-and-batched-hessian`, so this diff is CI/test-infra only.

Root cause: every ASE test cold-loaded the model (~22 s of TorchScript/Warp-kernel JIT + weight load), ~36 times, serially, with the Warp kernel cache not cached in CI. The science per test is <2 s.

## Changes

- **Cache loaded models across the test session** (`tests/conftest.py`): an autouse session fixture memoizes `load_model` per `(path, device)` and hands each test an independent `deepcopy` of the module — so existing `AIMNet2Calculator("aimnet2")` / `AIMNet2ASE("aimnet2")` calls reuse the expensive load with zero test-body rewrites. `model_cache` / `make_calc` / `make_ase_calc` factory fixtures are also provided. The deepcopy is required: a shared instance leaked `requires_grad=False` state across eval/train tests.
- **Cache `~/.cache/warp` in CI** (`.github/actions/setup-uv-env/action.yml`): keyed on `uv.lock`; all jobs benefit.
- **Trim the core matrix** (`.github/workflows/main.yml`): `tests-core` `["3.11","3.12","3.13"]` → `["3.11","3.13"]`.
- **Mark the one genuinely-slow test** `test_energy_decreases_on_optimization` (BFGS opt) `slow` and skip it on PR CI; **remove the now-obsolete module-level `slow` mark from `test_calculator.py`** (it existed only because of the per-test model-load cost this PR eliminates) so all 106 calculator correctness tests keep running on PR.

Note: `pytest -n auto` was evaluated and intentionally **not** included — it regressed on contended runners (each worker re-pays the per-process model load); the cache + matrix trim deliver the bulk of the win without it.

## Measured

- `tests-ase` selection (`ase and not sella and not slow`): **9 min → ~98 s** (213 passed, 2 skipped), serial.
- Coverage preserved: collection is 213 tests (was 214; only the single BFGS opt test is now skipped).
- `test_calculator` reuses cache: 106 passed in ~36 s.

## Test Plan

- [x] `test_pbc + test_lr + test_hvp`: 132 passed.
- [x] `test_calculator`: 106 passed.
- [x] `tests-ase` selection: 213 passed, 2 skipped.
- [x] YAML valid; `ruff check` clean.
