### PR TITLE
[codex] Speed up CI test lanes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
     pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     quality:
         runs-on: ubuntu-latest
@@ -51,7 +55,7 @@ jobs:
                   groups: dev
 
             - name: Run tests
-              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1
 
             - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
               uses: codecov/codecov-action@v6
@@ -110,7 +114,8 @@ jobs:
                   TORCHDYNAMO_DISABLE: "1"
               run: |
                   uv run --no-sync pytest tests \
-                      -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow"
+                      -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" \
+                      --durations=25 --durations-min=0.1
 
     tests-ase:
         runs-on: ubuntu-latest
@@ -134,12 +139,41 @@ jobs:
                   extras: ase
 
             - name: Run ASE tests
-              run: uv run pytest tests -m "ase and not sella and not slow" --cov --cov-config=pyproject.toml --cov-report=xml
+              run: uv run pytest tests -m "ase and not gpu and not sella and not slow" --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v6
               with:
                   flags: ase
+
+    tests-pbc:
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        strategy:
+            matrix:
+                python-version: ["3.11"]
+            fail-fast: false
+        defaults:
+            run:
+                shell: bash
+        steps:
+            - name: Check out
+              uses: actions/checkout@v6
+
+            - name: Set up the environment
+              uses: ./.github/actions/setup-uv-env
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  groups: dev
+                  extras: ase
+
+            - name: Run PBC tests
+              run: uv run pytest tests/test_pbc.py -m "ase and gpu and not sella and not slow" --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1
+
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v6
+              with:
+                  flags: pbc
 
     tests-train:
         runs-on: ubuntu-latest
@@ -165,7 +199,7 @@ jobs:
             - name: Run train-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m train --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m train --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1 || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No train-marked tests collected; treating as success."
                     exit 0
@@ -202,7 +236,7 @@ jobs:
             - name: Run pysis-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m pysis --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m pysis --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1 || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No pysis-marked tests collected; treating as success."
                     exit 0
@@ -239,7 +273,7 @@ jobs:
             - name: Run sella-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m sella --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m sella --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1 || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No sella-marked tests collected; treating as success."
                     exit 0
@@ -276,7 +310,7 @@ jobs:
             - name: Run hf-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m hf --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m hf --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1 || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No hf-marked tests collected; treating as success."
                     exit 0
@@ -313,7 +347,7 @@ jobs:
             - name: Run torch_sim-marked tests (allow empty)
               run: |
                   set -e
-                  uv run pytest tests -m torch_sim --cov --cov-config=pyproject.toml --cov-report=xml || rc=$?
+                  uv run pytest tests -m torch_sim --cov --cov-config=pyproject.toml --cov-report=xml --durations=25 --durations-min=0.1 || rc=$?
                   if [ "${rc:-0}" -eq 5 ]; then
                     echo "No torch_sim-marked tests collected; treating as success."
                     exit 0
@@ -350,6 +384,7 @@ jobs:
                 tests-core,
                 tests-torch,
                 tests-ase,
+                tests-pbc,
                 tests-train,
                 tests-pysis,
                 tests-sella,

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,31 @@
+name: Slow Tests
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "17 7 * * *"
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    tests-slow-pbc:
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        defaults:
+            run:
+                shell: bash
+        steps:
+            - name: Check out
+              uses: actions/checkout@v6
+
+            - name: Set up the environment
+              uses: ./.github/actions/setup-uv-env
+              with:
+                  python-version: "3.11"
+                  groups: dev
+                  extras: ase
+
+            - name: Run slow PBC tests
+              run: uv run pytest tests/test_pbc.py -m "slow" --durations=25 --durations-min=0.1

--- a/tests/test_pbc.py
+++ b/tests/test_pbc.py
@@ -1143,6 +1143,7 @@ class TestNvAlchemiCoulombBackend:
         assert torch.isfinite(res["hessian"]).all()
         assert res["hessian"].abs().sum() > 0
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("method", ["ewald", "pme"])
     def test_fd_hessian_matches_energy_fd(self, pbc_crystal_small, device, method):
         """The FD-of-forces full-periodic block equals the central-FD-of-energy Hessian.


### PR DESCRIPTION
## Summary

- Add workflow-level concurrency so superseded runs are canceled.
- Split the previous `tests-ase` lane into fast CPU ASE coverage and a separate PBC lane.
- Mark the exhaustive PBC finite-difference Hessian proof as `slow` and add a scheduled/manual `Slow Tests` workflow for it.
- Add pytest duration reporting across CI test lanes so future slowdowns are visible in logs.

## Why

The latest `main` CI run was green, but wall time was dominated by `tests-ase (3.11)`. Local timing showed the expensive work was concentrated in `tests/test_pbc.py`, especially the PME finite-difference Hessian proof, while the non-GPU ASE subset was already fast.

This keeps PR feedback fast without deleting the expensive numerical regression: normal PR CI runs PBC smoke/integration coverage, and the full slow proof remains available nightly and through `workflow_dispatch`.

## Local validation

- `uv run pytest tests/test_pbc.py -m "ase and gpu and not sella and not slow" --durations=25 --durations-min=0.1 -q` -> 54 passed, 2 deselected in 42.82s
- `uv run pytest tests/test_pbc.py -m "slow" --durations=25 --durations-min=0.1 -q` -> 2 passed, 54 deselected in 120.78s
- `uv run pytest tests/test_ase.py tests/test_calculator.py tests/test_model.py -m "ase and not gpu and not sella and not slow" --durations=25 --durations-min=0.1 -q` -> 143 passed, 1 skipped, 26 deselected in 13.34s
- `uv run ruff check tests/test_pbc.py` -> passed
- `git diff --check` -> no whitespace errors; only Windows CRLF normalization warnings

## Follow-up after merge

Branch protection should be updated after this lands: replace stale `tests-core (3.12)` with `tests-core (3.13)`, and consider requiring the new `tests-pbc (3.11)` context.