### PR TITLE
fix: address code review findings across calculator, ops, and packaging

### DIFF
--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -455,6 +455,10 @@ class AIMNet2Calculator:
         self.cache_static = bool(cache_static)
         self._static_nbmat_cache: dict[tuple[Any, ...], tuple[Any, Any, dict[str, Tensor]]] = {}
         self._static_dftd3_cache: dict[tuple[Any, ...], tuple[Any, Any, dict[str, Any]]] = {}
+        # Identity of the last species-validated `numbers` tensor, so repeated
+        # evals on the same buffer (MD/optimization loops) skip the per-step
+        # D2H tolist() + set-diff in _validate_species_and_charge.
+        self._species_validation_cache: tuple[tuple[Any, ...], Any, Any] | None = None
 
         # Create adaptive neighbor list instances
         self._nblist = AdaptiveNeighborList(cutoff=self.cutoff)
@@ -492,6 +496,15 @@ class AIMNet2Calculator:
         elif self._has_embedded_coulomb():
             # Legacy models have embedded Coulomb with "simple" method
             self._coulomb_method = "simple"
+        # Bookkeeping for the per-evaluation simple->dsf PBC auto-switch:
+        # prepare_input stores the pre-switch Coulomb state here and eval()
+        # restores it in its finally block.
+        self._pbc_coulomb_restore: dict[str, Any] | None = None
+        # Memoized DSF-side state from the auto-switch (incl. warmed-up adaptive
+        # neighbor lists) so repeated periodic evals don't rebuild it every step.
+        self._auto_dsf_state: dict[str, Any] | None = None
+        # One-shot flag for the ignored-multiplicity warning (eval fires inside MD loops).
+        self._mult_ignored_checked = False
 
         # Set training mode (default False for inference)
         self._train = train
@@ -546,6 +559,41 @@ class AIMNet2Calculator:
                 f"(e.g. rxn uses a learned shifted-electronic scale, while wb97m-d3 "
                 f"and b973c-d3 use different DFT targets). Do not mix or compare "
                 f"energies across families.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    def _maybe_warn_mult_ignored(self, data: dict[str, Any]) -> None:
+        """Warn once per instance if ``mult`` != 1 is passed to a closed-shell model.
+
+        ``num_charge_channels=1`` models (e.g. the default aimnet2/wb97m-d3)
+        never read ``mult``, while the ASE/pysisyphus/torch-sim wrappers pass it
+        unconditionally — without this warning a user requesting an open-shell
+        state would silently get the closed-shell result. NSE models
+        (num_charge_channels=2) consume ``mult`` and skip the check.
+
+        Use Python's standard warnings filters if this warning needs to be silenced.
+        """
+        if self._mult_ignored_checked or self.is_nse:
+            return
+        mult = data.get("mult")
+        if mult is None:
+            return
+        if isinstance(mult, Tensor) and mult.device.type != "cpu":
+            # Inspecting a GPU tensor forces a D2H sync; do it at most once per
+            # calculator instance (mult is invariant within MD/optimization loops).
+            self._mult_ignored_checked = True
+            mult_t = mult.detach()
+        else:
+            mult_t = torch.as_tensor(mult)
+        if bool((mult_t != 1).any()):
+            self._mult_ignored_checked = True
+            warnings.warn(
+                f"Input mult={mult_t.flatten().tolist()} is ignored: this model is "
+                f"closed-shell (num_charge_channels=1) and does not use spin "
+                f"multiplicity, so the result corresponds to the closed-shell state. "
+                f"For radicals/open-shell systems use an NSE model, e.g. "
+                f"`isayevlab/aimnet2-nse`.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -828,6 +876,8 @@ class AIMNet2Calculator:
             self.cutoff_lr = self._dftd3_cutoff if self.external_dftd3 is not None else None
 
         self._coulomb_method = method
+        # Method/cutoff changed; the memoized auto-switch DSF state is stale.
+        self._auto_dsf_state = None
         self._update_lr_nblists()
         self._clear_static_nbmat_cache()
 
@@ -849,6 +899,8 @@ class AIMNet2Calculator:
             self._coulomb_cutoff = cutoff
         self._dftd3_cutoff = cutoff
         self.cutoff_lr = cutoff
+        # Cutoffs changed; the memoized auto-switch DSF state is stale.
+        self._auto_dsf_state = None
         self._update_lr_nblists()
         self._clear_static_nbmat_cache()
 
@@ -880,6 +932,8 @@ class AIMNet2Calculator:
         self._dftd3_cutoff = cutoff
         if self.external_dftd3 is not None:
             self.external_dftd3.set_smoothing(cutoff, smoothing_fraction)
+        # Cutoffs changed; the memoized auto-switch DSF state is stale.
+        self._auto_dsf_state = None
         self._update_lr_nblists()
         self._clear_static_nbmat_cache()
 
@@ -892,6 +946,10 @@ class AIMNet2Calculator:
         that did not declare ``implemented_species`` (older ``.pt``, raw
         ``nn.Module``). Shared by :meth:`eval` and
         :meth:`hessian_vector_product` so both enforce the same contract.
+
+        The species part costs a D2H tolist() per call, so it is skipped when
+        the same ``numbers`` tensor was already validated (identity + ``_version``
+        cache); the charge part inspects per-call values and always runs.
         """
         if "numbers" not in data:
             # Guarded so prepare_input still owns the missing-key error path with
@@ -899,18 +957,24 @@ class AIMNet2Calculator:
             return
         impl = (self.metadata or {}).get("implemented_species") or []
         if impl:
-            # data["numbers"] may be a raw list, ndarray, or tensor — normalize first.
-            seen = {int(z) for z in torch.as_tensor(data["numbers"]).flatten().tolist() if int(z) > 0}
-            unsupported = sorted(seen - set(impl))
-            if unsupported:
-                raise ValueError(
-                    f"Atomic numbers {unsupported} are not in this model's "
-                    f"implemented_species {sorted(impl)}. This model was trained on "
-                    f"a restricted element set; passing other elements yields undefined "
-                    f"output. For broader element coverage on equilibrium structures use "
-                    f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
-                    f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
-                )
+            numbers = data["numbers"]
+            cache_key = self._numbers_validation_key(numbers)
+            cached = self._species_validation_cache
+            cache_hit = (
+                cache_key is not None
+                and cached is not None
+                and cached[0] == cache_key
+                and cached[1]() is numbers
+                and cached[2] is impl
+            )
+            if not cache_hit:
+                self._validate_numbers(numbers, impl)
+                if cache_key is not None:
+                    # The weakref guards a recycled id()/data_ptr() at the same
+                    # address; _version in the key guards in-place mutation of a
+                    # kept-alive buffer. impl is compared by identity to catch
+                    # metadata swaps between calls.
+                    self._species_validation_cache = (cache_key, weakref.ref(numbers), impl)
         meta = self.metadata or {}
         if meta.get("supports_charged_systems") is False:
             # torch.as_tensor handles scalars, lists, ndarrays, 0-d and N-d tensors
@@ -926,6 +990,47 @@ class AIMNet2Calculator:
                     f"Pass validate_species=False to bypass."
                 )
 
+    def _validate_numbers(self, numbers: Any, impl: Any) -> None:
+        """Raise for atomic numbers outside ``implemented_species`` (costs a D2H sync)."""
+        # numbers may be a raw list, ndarray, or tensor — normalize first.
+        seen = {int(z) for z in torch.as_tensor(numbers).flatten().tolist() if int(z) > 0}
+        unsupported = sorted(seen - set(impl))
+        if unsupported:
+            raise ValueError(
+                f"Atomic numbers {unsupported} are not in this model's "
+                f"implemented_species {sorted(impl)}. This model was trained on "
+                f"a restricted element set; passing other elements yields undefined "
+                f"output. For broader element coverage on equilibrium structures use "
+                f"`isayevlab/aimnet2-wb97m-d3`; for radicals/open-shell systems use "
+                f"`isayevlab/aimnet2-nse`. Pass validate_species=False to bypass."
+            )
+
+    @staticmethod
+    def _numbers_validation_key(value: Any) -> tuple[Any, ...] | None:
+        """Identity key for skipping repeated species validation of one tensor.
+
+        Unlike :meth:`_tensor_identity_key` (CUDA-only, static nbmat cache),
+        this accepts any dense tensor — CPU inputs also pay the per-step
+        tolist() + set-diff otherwise. ``_version`` in the key guards in-place
+        mutation of a reused buffer.
+        """
+        if not isinstance(value, Tensor) or value.is_sparse:
+            return None
+        try:
+            version = int(value._version)
+        except RuntimeError:
+            return None
+        return (
+            id(value),
+            str(value.device),
+            str(value.dtype),
+            tuple(int(dim) for dim in value.shape),
+            tuple(int(stride) for stride in value.stride()),
+            int(value.data_ptr()),
+            int(value.storage_offset()),
+            version,
+        )
+
     def eval(
         self, data: dict[str, Any], forces=False, stress=False, hessian=False, *, validate_species: bool = True
     ) -> dict[str, Any]:
@@ -940,6 +1045,8 @@ class AIMNet2Calculator:
         # Species validation — opt-out via validate_species=False.
         if validate_species:
             self._validate_species_and_charge(data)
+        # Warn once if the caller requests an open-shell `mult` this model ignores.
+        self._maybe_warn_mult_ignored(data)
         # Hessian + torch.compile is known to hang on the double-backward
         # path through GELU activations. Fail fast instead.
         if hessian and getattr(self, "_was_compiled", False):
@@ -957,24 +1064,42 @@ class AIMNet2Calculator:
                     subsystems, forces=forces, stress=stress, validate_species=validate_species, stack=stack
                 )
 
-        data = self.prepare_input(data, hessian=hessian)
+        # The simple->dsf PBC auto-switch in prepare_input is scoped to this
+        # evaluation: any pending restore is consumed in the finally block, so
+        # an exception mid-eval cannot leave the calculator on the switched method.
+        self._pbc_coulomb_restore = None
+        try:
+            data = self.prepare_input(data, hessian=hessian)
 
-        if hessian and "mol_idx" in data and data["mol_idx"][-1] > 0:
-            raise NotImplementedError(
-                "In-call Hessian for hand-flattened multi-molecule input is not supported; "
-                "pass a 3D batch or a mol_idx dict to get per-structure Hessians."
-            )
-        data = self.set_grad_tensors(data, forces=forces, stress=stress, hessian=hessian)
-        if isinstance(self.model, torch.jit.ScriptModule):
-            with torch.jit.optimized_execution(False):  # type: ignore
+            if hessian and "mol_idx" in data and data["mol_idx"][-1] > 0:
+                raise NotImplementedError(
+                    "In-call Hessian for hand-flattened multi-molecule input is not supported; "
+                    "pass a 3D batch or a mol_idx dict to get per-structure Hessians."
+                )
+            data = self.set_grad_tensors(data, forces=forces, stress=stress, hessian=hessian)
+            if isinstance(self.model, torch.jit.ScriptModule):
+                with torch.jit.optimized_execution(False):  # type: ignore
+                    data = self.model(data)
+            else:
                 data = self.model(data)
-        else:
-            data = self.model(data)
-        # Run external modules if present
-        data, coulomb_terms = self._run_external_modules(data, forces=forces or hessian, stress=stress, hessian=hessian)
-        data = self.get_derivatives(data, forces=forces, stress=stress, hessian=hessian, coulomb_terms=coulomb_terms)
-        data = self.process_output(data)
-        return data
+            # Run external modules if present
+            data, coulomb_terms = self._run_external_modules(
+                data, forces=forces or hessian, stress=stress, hessian=hessian
+            )
+            data = self.get_derivatives(
+                data, forces=forces, stress=stress, hessian=hessian, coulomb_terms=coulomb_terms
+            )
+            data = self.process_output(data)
+            return data
+        finally:
+            restore = self._pbc_coulomb_restore
+            if restore is not None:
+                self._pbc_coulomb_restore = None
+                # Keep the DSF-side state (incl. warmed-up adaptive neighbor
+                # lists) for the next periodic call before flipping back to the
+                # pre-switch method.
+                self._auto_dsf_state = self._snapshot_coulomb_state()
+                self._restore_coulomb_state(restore)
 
     def _run_external_modules(
         self,
@@ -1057,8 +1182,24 @@ class AIMNet2Calculator:
         data = self.to_input_tensors(data)
         data = self.mol_flatten(data, hessian=hessian)
         if data.get("cell") is not None and self._coulomb_method == "simple":
-            warnings.warn("Switching to DSF Coulomb for PBC", stacklevel=1)
-            self.set_lrcoulomb_method("dsf")
+            warnings.warn(
+                "Switching to DSF Coulomb for PBC for this evaluation; "
+                "call set_lrcoulomb_method() to select a periodic method persistently.",
+                stacklevel=1,
+            )
+            # Scope the auto-switch to the current evaluation: eval() restores
+            # this snapshot in its finally block, so one periodic call does not
+            # permanently flip a gas-phase calculator off its trained "simple"
+            # full Coulomb. Explicit set_lrcoulomb_method() calls stay persistent.
+            prev_coulomb_state = self._snapshot_coulomb_state()
+            if self._auto_dsf_state is not None:
+                # Reuse the DSF-side state (incl. warmed-up adaptive neighbor
+                # lists) from the previous auto-switch instead of rebuilding it
+                # on every periodic step.
+                self._restore_coulomb_state(self._auto_dsf_state)
+            else:
+                self.set_lrcoulomb_method("dsf")
+            self._pbc_coulomb_restore = prev_coulomb_state
         if self._coulomb_method in ("ewald", "pme") and data.get("cell") is None:
             raise ValueError(
                 f"Coulomb method '{self._coulomb_method}' requires a periodic 'cell' "
@@ -1385,6 +1526,55 @@ class AIMNet2Calculator:
             subs.append(sub)
         return subs
 
+    def _snapshot_coulomb_state(self) -> dict[str, Any]:
+        """Snapshot the Coulomb-method state mutated by :meth:`set_lrcoulomb_method`.
+
+        Used to scope the automatic simple->dsf PBC switch to a single
+        evaluation. Neighbor-list objects are captured by reference (not
+        copied), so swapping states back and forth preserves their adaptive
+        ``max_neighbors`` warm-up on both sides.
+        """
+        attrs = (
+            "_coulomb_method",
+            "_coulomb_cutoff",
+            "cutoff_lr",
+            "_nblist_lr",
+            "_nblist_dftd3",
+            "_nblist_coulomb",
+        )
+        state: dict[str, Any] = {name: getattr(self, name, _SENTINEL) for name in attrs}
+        if self.external_coulomb is not None:
+            state["_external_coulomb_attrs"] = {
+                name: getattr(self.external_coulomb, name, _SENTINEL)
+                for name in ("method", "dsf_alpha", "dsf_rc", "ewald_accuracy")
+            }
+        else:
+            state["_external_coulomb_attrs"] = _SENTINEL
+        return state
+
+    def _restore_coulomb_state(self, state: dict[str, Any]) -> None:
+        """Apply state captured by :meth:`_snapshot_coulomb_state`.
+
+        Non-destructive on ``state`` — the memoized DSF-side snapshot is
+        re-applied on every periodic call.
+        """
+        external_attrs = state.get("_external_coulomb_attrs", _SENTINEL)
+        for name, val in state.items():
+            if name == "_external_coulomb_attrs":
+                continue
+            if val is _SENTINEL:
+                if hasattr(self, name):
+                    delattr(self, name)
+            else:
+                setattr(self, name, val)
+        if external_attrs is not _SENTINEL and self.external_coulomb is not None:
+            for name, val in external_attrs.items():
+                if val is _SENTINEL:
+                    if hasattr(self.external_coulomb, name):
+                        delattr(self.external_coulomb, name)
+                else:
+                    setattr(self.external_coulomb, name, val)
+
     def _snapshot_eval_state(self) -> dict[str, Any]:
         """Snapshot mutable calculator state touched by nested eval-style calls."""
         shallow_attrs = (
@@ -1446,10 +1636,10 @@ class AIMNet2Calculator:
         Multi-molecule (``mol_idx``) inputs always use ``stack=False`` because the
         molecules are independent and generally ragged.
         """
-        # Recursive eval(...) mutates instance scratch state and can persistently
-        # flip Coulomb method/cutoff/list-builder state via prepare_input's
-        # simple->dsf PBC auto-switch. Snapshot and restore so a batched call
-        # leaves the calculator unmodified.
+        # Recursive eval(...) mutates instance scratch state (_batch, cache
+        # keys, _saved_for_grad, ...). Each inner eval scopes the simple->dsf
+        # PBC auto-switch itself; snapshot and restore the rest so a batched
+        # call leaves the calculator unmodified.
         eval_state = self._snapshot_eval_state()
         try:
             results = [
@@ -1977,6 +2167,8 @@ class AIMNet2Calculator:
         # systems would yield undefined output silently.
         if validate_species:
             self._validate_species_and_charge(data)
+        # Warn once if the caller requests an open-shell `mult` this model ignores.
+        self._maybe_warn_mult_ignored(data)
         coord_in = torch.as_tensor(data["coord"])
         if coord_in.ndim == 3 and coord_in.shape[0] > 1:
             raise NotImplementedError("hessian_vector_product supports a single structure only (got 3D batch).")
@@ -1999,6 +2191,9 @@ class AIMNet2Calculator:
             result = self._hessian_vector_product_impl(data, vectors, eps=eps, create_graph=create_graph)
         finally:
             self._restore_eval_state(eval_state)
+            # _restore_eval_state already undid any PBC auto-switch from
+            # prepare_input; drop the (now-redundant) pending restore marker.
+            self._pbc_coulomb_restore = None
         return result
 
     def _hessian_vector_product_impl(

--- a/aimnet/interfaces/__init__.py
+++ b/aimnet/interfaces/__init__.py
@@ -1,1 +1,0 @@
-"""Optional integration modules for external MD/QM packages."""

--- a/aimnet/kernels/conv_sv_2d_sp_wp.py
+++ b/aimnet/kernels/conv_sv_2d_sp_wp.py
@@ -57,6 +57,7 @@ def _conv_sv_2d_sp_kernel(
     for _m in range(M):
         _idx = idx[_b, _m]
         if _idx >= padding_value:
+            # packed-padding contract: sentinels are contiguous at the row end (see conv_sv_2d_sp docstring)
             break
         a_val = a[_idx, _a, _g]
         g_val = g[_b, _m, _g]
@@ -81,6 +82,7 @@ def _conv_sv_2d_sp_backward_a_kernel(
     for _m in range(M):
         _idx = idx[_b, _m]
         if _idx >= padding_value:
+            # packed-padding contract: sentinels are contiguous at the row end (see conv_sv_2d_sp docstring)
             break
         g_val = g[_b, _m, _g]
         val = wp.dot(grad_out, g_val)
@@ -160,6 +162,7 @@ def _conv_sv_2d_sp_double_backward_g_contrib_kernel(
     for _m in range(M):
         _idx = idx[_b, _m]
         if _idx >= padding_value:
+            # packed-padding contract: sentinels are contiguous at the row end (see conv_sv_2d_sp docstring)
             break
         a_val = a[_idx, _a, _g]
         grad2_g_val = grad2_g[_b, _m, _g]
@@ -185,6 +188,7 @@ def _conv_sv_2d_sp_double_backward_a_contrib_kernel(
     for _m in range(M):
         _idx = idx[_b, _m]
         if _idx >= padding_value:
+            # packed-padding contract: sentinels are contiguous at the row end (see conv_sv_2d_sp docstring)
             break
         grad2_a_val = grad2_a[_idx, _a, _g]
         g_val = g[_b, _m, _g]
@@ -576,6 +580,14 @@ def conv_sv_2d_sp(a: Tensor, idx: Tensor, g: Tensor) -> Tensor:
 
     Notes
     -----
+    ``idx`` rows must follow the packed-padding contract: real neighbor indices
+    come first and padding sentinels (values >= B-1, the padding row) are
+    contiguous at the end of each row. The Warp kernels stop scanning a row at
+    the first sentinel, so interleaved padding would silently drop real
+    neighbors. ``nvalchemiops.torch.neighbors.neighbor_list`` produces this
+    layout. The contract is not checked at runtime: validating ``idx`` values
+    would require a device-to-host sync on the hot path.
+
     Only the first- and second-order backward primitives are vmap-registered.
     `torch.func.vmap` directly over the forward (e.g. vmap over a non-vjp
     closure that calls this function) will raise `Batching rule not implemented

--- a/aimnet/modules/aev.py
+++ b/aimnet/modules/aev.py
@@ -156,7 +156,9 @@ class ConvSV(nn.Module):
         g_sv = data["g_sv"]
         mode = nbops.get_nb_mode(data)
         if self.d2features:
-            if mode > 0 and a.device.type == "cuda":
+            # The Warp kernel is float32-only; float64 (and mixed-dtype) inputs
+            # fall through to the pure-torch einsum branch below.
+            if mode > 0 and a.device.type == "cuda" and a.dtype == torch.float32 and g_sv.dtype == torch.float32:
                 avf_sv = conv_sv_2d_sp(a, data["nbmat"], g_sv)
             elif mode > 0:
                 a_j = a.index_select(0, data["nbmat"].flatten()).unflatten(0, data["nbmat"].shape)

--- a/aimnet/nbops.py
+++ b/aimnet/nbops.py
@@ -58,6 +58,13 @@ def calc_masks(data: dict[str, Tensor]) -> dict[str, Tensor]:
         data["mol_sizes"] = torch.bincount(data["mol_idx"])
         # last atom is padding
         data["mol_sizes"][-1] -= 1
+        # cache number of molecules as a CPU tensor (same pattern as _nb_mode),
+        # so mol_sum does not need a device-to-host sync on every call. Not
+        # cached under torch.compile: materializing bincount's data-dependent
+        # shape as a tensor inside the traced graph trips inductor codegen,
+        # and compiled mol_sum does not read the cache.
+        if not torch.compiler.is_compiling():
+            data["_num_mol"] = torch.tensor(data["mol_sizes"].shape[0])
     elif nb_mode == 2:
         data["mask_i"] = data["numbers"] == 0
         # Track processed arrays by their data pointer to avoid redundant mask calculations
@@ -244,8 +251,20 @@ def mol_sum(x: Tensor, data: dict[str, Tensor]) -> Tensor:
             2,
         ), "Invalid tensor shape for mol_sum, ndim should be 1 or 2"
         idx = data["mol_idx"]
-        # assuming mol_idx is sorted, replace with max if not
-        out_size = int(idx[-1].item()) + 1
+        if torch.compiler.is_compiling():
+            # under torch.compile, read the molecule count directly: dynamo
+            # handles the .item() graph break, while routing it through a
+            # cached scalar tensor trips inductor codegen
+            # assuming mol_idx is sorted, replace with max if not
+            out_size = int(idx[-1].item()) + 1
+        else:
+            # number of molecules is cached by calc_masks as a CPU tensor, so
+            # reading it does not sync the GPU; compute and cache it here for
+            # data dicts that were not built through calc_masks
+            if "_num_mol" not in data:
+                # assuming mol_idx is sorted, replace with max if not
+                data["_num_mol"] = torch.tensor(int(idx[-1].item()) + 1)
+            out_size = int(data["_num_mol"].item())
 
         if x.ndim == 1:
             res = torch.zeros(out_size, device=x.device, dtype=x.dtype)

--- a/aimnet/ops.py
+++ b/aimnet/ops.py
@@ -127,10 +127,23 @@ def nse(
         F_u = F_u.unsqueeze(-2)
         dQ = dQ.unsqueeze(-2)
     elif nb_mode == 1:
-        data["mol_sizes"][-1] += 1
-        F_u = torch.repeat_interleave(F_u, data["mol_sizes"], dim=0)
-        dQ = torch.repeat_interleave(dQ, data["mol_sizes"], dim=0)
-        data["mol_sizes"][-1] -= 1
+        if torch.compiler.is_compiling():
+            # under torch.compile keep the repeat_interleave formulation: the
+            # index_select gather below fuses with mol_sum's scatter into one
+            # graph and trips inductor's CPU codegen
+            data["mol_sizes"][-1] += 1
+            F_u = torch.repeat_interleave(F_u, data["mol_sizes"], dim=0)
+            dQ = torch.repeat_interleave(dQ, data["mol_sizes"], dim=0)
+            data["mol_sizes"][-1] -= 1
+        else:
+            # broadcast per-molecule values to atoms with a gather on mol_idx;
+            # equivalent to repeat_interleave over mol_sizes (mol_idx is sorted)
+            # but stays on-device. The trailing padding atom picks up the value
+            # for its own mol_idx entry, exactly as repeat_interleave with the
+            # padding-inclusive mol_sizes did before.
+            mol_idx = data["mol_idx"]
+            F_u = torch.index_select(F_u, 0, mol_idx)
+            dQ = torch.index_select(dQ, 0, mol_idx)
     else:
         raise ValueError(f"Invalid neighbor mode: {nb_mode}")
     f = f_u / F_u

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -21,6 +21,10 @@ This section contains the selected public API reference for AIMNet2. Lower-level
 
 The `aimnet.ops`, `aimnet.nbops`, `aimnet.kernels`, `aimnet.train`, and `aimnet.cli` modules are importable but are primarily advanced or internal extension points. Their contracts may be narrower than the calculator and model APIs.
 
+## Serialization ABI
+
+Released model files embed a YAML configuration with fully qualified class paths (for example `aimnet.models.AIMNet2`, `aimnet.modules.Output`, `torch.nn.GELU`). Loading a checkpoint resolves these strings by import, so every class name and location reachable from `aimnet.models` and `aimnet.modules` is a frozen serialization contract: renaming or moving one of these classes breaks every published checkpoint that references it. Renames require a deprecation alias at the old import path plus a model-format migration; `tests/test_serialization_abi.py` pins the currently frozen names.
+
 ## Quick Links
 
 ### Calculators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,14 @@ Repository = "https://github.com/isayevlab/aimnetcentral"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aimnet"]
+# Package data (model YAMLs, registry, .pt tensors) ships via globs so new
+# assets are picked up automatically; the VCS-ignored download cache under
+# aimnet/calculators/assets/ stays excluded.
+include = [
+    "aimnet/**/*.py",
+    "aimnet/**/*.yaml",
+    "aimnet/**/*.pt",
+]
 
 [tool.hatch.version]
 source = "vcs"
@@ -101,14 +109,6 @@ include = [
     "aimnet/**/*.yaml",
     "aimnet/**/*.pt",
 ]
-
-[tool.hatch.build.targets.wheel.force-include]
-"aimnet/dftd3_data.pt" = "aimnet/dftd3_data.pt"
-"aimnet/calculators/model_registry.yaml" = "aimnet/calculators/model_registry.yaml"
-"aimnet/models/aimnet2.yaml" = "aimnet/models/aimnet2.yaml"
-"aimnet/models/aimnet2_dftd3_wb97m.yaml" = "aimnet/models/aimnet2_dftd3_wb97m.yaml"
-"aimnet/models/aimnet2_rxn.yaml" = "aimnet/models/aimnet2_rxn.yaml"
-"aimnet/train/default_train.yaml" = "aimnet/train/default_train.yaml"
 
 # UV configuration
 [tool.uv]

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -176,6 +176,73 @@ class TestCoulombMethods:
         assert calc._coulomb_method == "dsf"
         assert calc.cutoff_lr == 12.0
 
+    @staticmethod
+    def _water_gas_and_pbc():
+        gas = {
+            "coord": torch.tensor([[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]]),
+            "numbers": torch.tensor([8, 1, 1]),
+            "charge": torch.tensor(0.0),
+        }
+        pbc = {**gas, "cell": torch.eye(3) * 8.0}
+        return gas, pbc
+
+    def test_pbc_dsf_auto_switch_scoped_to_periodic_eval(self):
+        """The automatic simple->dsf PBC switch must not persist: after a periodic
+        eval the calculator returns to the trained "simple" full Coulomb, so
+        gas-phase results do not depend on call history."""
+        calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
+        assert calc._coulomb_method == "simple"
+        gas, pbc = self._water_gas_and_pbc()
+
+        e_before = calc(gas)["energy"].item()
+        with pytest.warns(UserWarning, match="Switching to DSF Coulomb for PBC"):
+            res_pbc = calc(pbc)
+        assert torch.isfinite(res_pbc["energy"]).all()
+        # The auto-switch is scoped to the periodic evaluation.
+        assert calc._coulomb_method == "simple"
+        assert calc.coulomb_method == "simple"
+        assert calc._coulomb_cutoff == float("inf")
+        assert calc.external_coulomb.method == "simple"
+        e_after = calc(gas)["energy"].item()
+        assert e_after == pytest.approx(e_before, abs=1e-6)
+
+        # Repeated periodic evals reuse the memoized DSF-side state and restore too.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Switching to DSF Coulomb", category=UserWarning)
+            calc(pbc)
+        assert calc._coulomb_method == "simple"
+
+    def test_pbc_dsf_auto_switch_restores_on_error(self):
+        """State is restored even when the eval raises after the auto-switch."""
+        calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
+        _, pbc = self._water_gas_and_pbc()
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        calc.set_grad_tensors = boom
+        with pytest.raises(RuntimeError, match="boom"), warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Switching to DSF Coulomb", category=UserWarning)
+            calc(pbc)
+        assert calc._coulomb_method == "simple"
+        assert calc._coulomb_cutoff == float("inf")
+
+    def test_explicit_set_lrcoulomb_method_persists_across_evals(self):
+        """An explicit set_lrcoulomb_method() call is persistent — it survives
+        both gas-phase and periodic evaluations (no auto-restore)."""
+        calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
+        gas, pbc = self._water_gas_and_pbc()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Model has embedded Coulomb module", category=UserWarning)
+            calc.set_lrcoulomb_method("dsf", cutoff=12.0)
+
+        calc(gas)
+        assert calc._coulomb_method == "dsf"
+        # Already periodic-capable: no auto-switch, no restore.
+        calc(pbc)
+        assert calc._coulomb_method == "dsf"
+        assert calc.external_coulomb.dsf_rc == 12.0
+
     @pytest.mark.parametrize("method", ["ewald", "pme"])
     def test_set_coulomb_ewald_pme_default_accuracy(self, method):
         """Default ``ewald_accuracy`` is 1e-6 and applies to both ewald and pme."""
@@ -1569,6 +1636,88 @@ def test_calculator_charge_guard_handles_batched_charges():
     data = {"coord": coords, "numbers": numbers, "charge": torch.tensor([0.0, -1.0])}
 
     with pytest.raises(ValueError, match=r"net-charged systems"):
+        calc(data)
+
+
+def test_mult_ignored_warns_once_on_closed_shell_model():
+    """mult != 1 on a num_charge_channels=1 model warns once per calculator
+    instance (not per MD step); mult=1 never warns."""
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    assert calc.is_nse is False
+    data = {
+        "coord": torch.tensor([[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]]),
+        "numbers": torch.tensor([8, 1, 1]),
+        "charge": torch.tensor(0.0),
+        "mult": torch.tensor(1.0),
+    }
+
+    # mult=1 (closed shell) matches the model: no warning.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        calc(data)
+    assert [w for w in caught if "is ignored" in str(w.message)] == []
+
+    # mult=2 is silently unusable by this model: warn on the first eval...
+    data["mult"] = torch.tensor(2.0)
+    with pytest.warns(UserWarning, match=r"mult=\[2\.0\] is ignored"):
+        calc(data)
+
+    # ...and only once per calculator instance.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        calc(data)
+    assert [w for w in caught if "is ignored" in str(w.message)] == []
+
+
+def test_mult_not_warned_for_nse_models(monkeypatch):
+    """NSE models consume mult, so no ignored-multiplicity warning is emitted."""
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    monkeypatch.setattr(AIMNet2Calculator, "is_nse", property(lambda self: True))
+    data = {
+        "coord": torch.tensor([[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]]),
+        "numbers": torch.tensor([8, 1, 1]),
+        "charge": torch.tensor(0.0),
+        "mult": torch.tensor(2.0),
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        calc(data)
+    assert [w for w in caught if "is ignored" in str(w.message)] == []
+
+
+def test_species_validation_cached_for_repeated_numbers_tensor(monkeypatch):
+    """Repeated evals with the same numbers tensor skip the D2H revalidation;
+    a different tensor or an in-place mutation revalidates."""
+    calc = AIMNet2Calculator("aimnet2", device="cpu")
+    coord = torch.tensor([[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [-0.24, 0.93, 0.0]])
+    numbers = torch.tensor([8, 1, 1])
+    data = {"coord": coord, "numbers": numbers, "charge": torch.tensor(0.0)}
+
+    calls = []
+    original = AIMNet2Calculator._validate_numbers
+
+    def spy(self, numbers, impl):
+        calls.append(numbers)
+        return original(self, numbers, impl)
+
+    monkeypatch.setattr(AIMNet2Calculator, "_validate_numbers", spy)
+
+    calc(data)
+    assert len(calls) == 1
+    # Same tensor object, unchanged (MD/optimization loop): cache hit.
+    calc(data)
+    assert len(calls) == 1
+    # A different tensor (even with the same contents) must revalidate.
+    data["numbers"] = numbers.clone()
+    calc(data)
+    assert len(calls) == 2
+    # In-place mutation bumps _version and must revalidate too.
+    data["numbers"][0] = 6
+    calc(data)
+    assert len(calls) == 3
+    # Unsupported elements still raise on the recheck.
+    data["numbers"][0] = 92
+    with pytest.raises(ValueError, match=r"implemented_species"):
         calc(data)
 
 

--- a/tests/test_conv_sv_2d_sp.py
+++ b/tests/test_conv_sv_2d_sp.py
@@ -21,8 +21,10 @@
 """
 Tests for conv_sv_2d_sp Warp kernels.
 
-These tests directly call the warp kernel functions (not through ConvSV dispatch)
-to enable testing on both CPU and CUDA devices.
+TestConvSV2dSP directly calls the warp kernel functions (not through ConvSV
+dispatch) to enable testing on both CPU and CUDA devices. TestConvSVDispatch
+covers the ConvSV.forward dtype/device dispatch: the Warp kernel for CUDA
+float32, and the pure-torch einsum fallback otherwise (e.g. CUDA float64).
 """
 
 import pytest
@@ -386,3 +388,85 @@ class TestConvSV2dSP:
         ref = call_kernel(grad_output[0])
         assert torch.allclose(batched[0][0], ref[0], atol=1e-5, rtol=1e-4)
         assert torch.allclose(batched[1][0], ref[1], atol=1e-5, rtol=1e-4)
+
+
+@pytest.mark.skipif(not WARP_AVAILABLE, reason="Warp not available")
+class TestConvSVDispatch:
+    """Tests for the ConvSV.forward Warp-kernel/einsum dispatch."""
+
+    @pytest.fixture
+    def convsv_data(self):
+        """Mode-1 (padded flat) inputs for ConvSV.forward on CUDA.
+
+        The last atom row is padding: its neighbor row is all sentinels and
+        g_sv is zeroed at padded neighbor slots, matching the AEVSV masking
+        contract (nbops.mask_ij_ zeroes the cutoff envelope there).
+        """
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        torch.manual_seed(0)
+        device = "cuda"
+        B, C, G, M = 8, 5, 12, 10  # M >= B to ensure padding sentinel works
+
+        idx = generate_valid_neighbor_idx(B, M, num_neighbors=6, device=device)
+        idx[-1] = B - 1  # padding atom has no neighbors
+        a = torch.randn(B, C, G, device=device, dtype=torch.float32)
+        g_sv = torch.randn(B, M, G, 4, device=device, dtype=torch.float32)
+        g_sv = g_sv * (idx < B - 1).view(B, M, 1, 1)
+        return a, idx, g_sv
+
+    def test_forward_float32_uses_warp_kernel(self, convsv_data, monkeypatch):
+        """CUDA float32 dispatches to the Warp kernel; float64 must not."""
+        from aimnet import nbops
+        from aimnet.modules import aev
+
+        a, idx, g_sv = convsv_data
+        conv = aev.ConvSV(nshifts_s=g_sv.shape[2], nchannel=a.shape[1], d2features=True).cuda()
+
+        calls = []
+        orig_kernel = aev.conv_sv_2d_sp
+
+        def spy(*args, **kwargs):
+            calls.append(1)
+            return orig_kernel(*args, **kwargs)
+
+        monkeypatch.setattr(aev, "conv_sv_2d_sp", spy)
+
+        data = nbops.set_nb_mode({"g_sv": g_sv, "nbmat": idx})
+        out_fp32 = conv(data, a)
+        assert len(calls) == 1, "CUDA float32 must dispatch to the Warp kernel"
+
+        # float64 reference on the same module goes through the einsum fallback
+        conv = conv.double()
+        data64 = nbops.set_nb_mode({"g_sv": g_sv.double(), "nbmat": idx})
+        out_fp64 = conv(data64, a.double())
+        assert len(calls) == 1, "CUDA float64 must not dispatch to the Warp kernel"
+
+        assert out_fp32.dtype == torch.float32
+        assert torch.allclose(out_fp32, out_fp64.float(), atol=1e-4, rtol=1e-3), (
+            f"Warp/einsum dispatch parity failed. Max diff: {torch.max(torch.abs(out_fp32 - out_fp64.float()))}"
+        )
+
+    def test_forward_float64_cuda_falls_back_to_einsum(self, convsv_data):
+        """CUDA float64 must not raise and must match the CPU float64 einsum result."""
+        from aimnet import nbops
+        from aimnet.modules.aev import ConvSV
+
+        a, idx, g_sv = convsv_data
+        conv = ConvSV(nshifts_s=g_sv.shape[2], nchannel=a.shape[1], d2features=True).double()
+
+        # CPU float64 einsum reference
+        data_cpu = nbops.set_nb_mode({"g_sv": g_sv.double().cpu(), "nbmat": idx.cpu()})
+        out_cpu = conv(data_cpu, a.double().cpu())
+
+        # CUDA float64: the Warp kernel is float32-only, so this must take the
+        # einsum fallback instead of raising TypeError
+        conv = conv.cuda()
+        data_cuda = nbops.set_nb_mode({"g_sv": g_sv.double(), "nbmat": idx})
+        out_cuda = conv(data_cuda, a.double())
+
+        assert out_cuda.dtype == torch.float64
+        assert torch.allclose(out_cuda.cpu(), out_cpu, atol=1e-10, rtol=1e-10), (
+            f"CUDA float64 einsum fallback parity failed. Max diff: {torch.max(torch.abs(out_cuda.cpu() - out_cpu))}"
+        )

--- a/tests/test_nbops.py
+++ b/tests/test_nbops.py
@@ -470,6 +470,67 @@ class TestMolSum:
         assert result.shape == (2, 5)  # (num_mols, features)
         assert result[0, 0].item() == 3.0  # sum of 3 atoms
 
+    def test_mol_sum_mode_1_matches_mode_0(self, device):
+        """Test that packed (mode 1) mol_sum matches dense (mode 0) result."""
+        torch.manual_seed(0)
+        sizes = [3, 2, 4]
+        B, N = len(sizes), max(sizes)
+        n_total = sum(sizes) + 1  # trailing padding atom
+
+        # dense batch (B, N) with zero-padded numbers and values
+        numbers_dense = torch.zeros((B, N), dtype=torch.long, device=device)
+        x_dense = torch.zeros((B, N), device=device)
+        for b, s in enumerate(sizes):
+            numbers_dense[b, :s] = torch.randint(1, 10, (s,), device=device)
+            x_dense[b, :s] = torch.randn(s, device=device)
+        data_dense = {"numbers": numbers_dense}
+        data_dense = nbops.set_nb_mode(data_dense)
+        data_dense = nbops.calc_masks(data_dense)
+
+        # same batch in packed layout; padding atom carries the last mol index
+        numbers_packed = torch.cat([numbers_dense[b, :s] for b, s in enumerate(sizes)])
+        numbers_packed = torch.cat([numbers_packed, torch.zeros(1, dtype=torch.long, device=device)])
+        x_packed = torch.cat([x_dense[b, :s] for b, s in enumerate(sizes)])
+        x_packed = torch.cat([x_packed, torch.zeros(1, device=device)])
+        mol_idx = torch.repeat_interleave(torch.arange(B, device=device), torch.tensor(sizes, device=device))
+        mol_idx = torch.cat([mol_idx, mol_idx[-1:]])
+        nbmat = torch.full((n_total, 2), n_total - 1, dtype=torch.long, device=device)
+        data_packed = {"numbers": numbers_packed, "mol_idx": mol_idx, "nbmat": nbmat}
+        data_packed = nbops.set_nb_mode(data_packed)
+        data_packed = nbops.calc_masks(data_packed)
+
+        res_dense = nbops.mol_sum(x_dense, data_dense)
+        res_packed = nbops.mol_sum(x_packed, data_packed)
+
+        assert res_packed.shape == res_dense.shape == (B,)
+        assert torch.allclose(res_packed, res_dense, atol=1e-6)
+
+    def test_mol_sum_mode_1_uses_cached_num_mol(self, device):
+        """Test that calc_masks caches _num_mol on CPU and mol_sum uses it."""
+        numbers = torch.tensor([6, 1, 1, 6, 1, 0], device=device)
+        mol_idx = torch.tensor([0, 0, 0, 1, 1, 1], device=device)  # padding atom in last mol
+        nbmat = torch.full((6, 2), 5, dtype=torch.long, device=device)
+
+        data = {"numbers": numbers, "mol_idx": mol_idx, "nbmat": nbmat}
+        data = nbops.set_nb_mode(data)
+        data = nbops.calc_masks(data)
+
+        # cached as a CPU tensor (same pattern as _nb_mode), so reading it
+        # in mol_sum does not sync the GPU
+        assert data["_num_mol"].device.type == "cpu"
+        assert data["_num_mol"].item() == 2
+
+        x = torch.ones(6, device=device)
+        result = nbops.mol_sum(x, data)
+        assert result.shape == (2,)
+
+        # dicts not built through calc_masks fall back to mol_idx and cache
+        bare = {"mol_idx": mol_idx, "_nb_mode": torch.tensor(1)}
+        result_bare = nbops.mol_sum(x, bare)
+        assert result_bare.shape == (2,)
+        assert bare["_num_mol"].item() == 2
+        assert torch.allclose(result_bare, result)
+
     def test_mol_sum_mode_2(self, device):
         """Test molecular summation for mode 2."""
         B, N = 2, 3

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -346,6 +346,56 @@ class TestNSE:
         q_total = q.sum(dim=-2)
         assert q_total.item() == pytest.approx(1.0, abs=1e-5)
 
+    @pytest.mark.parametrize("k", [1, 2])
+    def test_nse_packed_matches_dense(self, device, k):
+        """Test that packed (nb_mode=1) NSE matches dense (nb_mode=0) NSE."""
+        torch.manual_seed(42)
+        sizes = [3, 2, 4]
+        B, N = len(sizes), max(sizes)
+        n_total = sum(sizes) + 1  # trailing padding atom
+
+        # dense batch (B, N) with zero-padded numbers
+        numbers_dense = torch.zeros((B, N), dtype=torch.long, device=device)
+        for b, s in enumerate(sizes):
+            numbers_dense[b, :s] = torch.randint(1, 10, (s,), device=device)
+        data_dense = {"numbers": numbers_dense}
+        data_dense = nbops.set_nb_mode(data_dense)
+        data_dense = nbops.calc_masks(data_dense)
+
+        # same batch in packed layout; padding atom carries the last mol index
+        numbers_packed = torch.cat([numbers_dense[b, :s] for b, s in enumerate(sizes)])
+        numbers_packed = torch.cat([numbers_packed, torch.zeros(1, dtype=torch.long, device=device)])
+        mol_idx = torch.repeat_interleave(torch.arange(B, device=device), torch.tensor(sizes, device=device))
+        mol_idx = torch.cat([mol_idx, mol_idx[-1:]])
+        nbmat = torch.full((n_total, 2), n_total - 1, dtype=torch.long, device=device)
+        data_packed = {"numbers": numbers_packed, "mol_idx": mol_idx, "nbmat": nbmat}
+        data_packed = nbops.set_nb_mode(data_packed)
+        data_packed = nbops.calc_masks(data_packed)
+
+        # unconstrained charges / flexibilities, zeroed at padding positions
+        # (models mask them upstream before nse)
+        pad = data_dense["mask_i"].unsqueeze(-1)
+        q_u_dense = torch.randn((B, N, k), device=device).masked_fill(pad, 0.0)
+        f_u_dense = torch.rand((B, N, k), device=device).masked_fill(pad, 0.0)
+        q_u_packed = torch.cat([q_u_dense[b, :s] for b, s in enumerate(sizes)])
+        q_u_packed = torch.cat([q_u_packed, torch.zeros((1, k), device=device)])
+        f_u_packed = torch.cat([f_u_dense[b, :s] for b, s in enumerate(sizes)])
+        f_u_packed = torch.cat([f_u_packed, torch.zeros((1, k), device=device)])
+        Q = torch.randn((B, k), device=device)
+
+        q_dense = ops.nse(Q, q_u_dense, f_u_dense, data_dense)
+        q_packed = ops.nse(Q, q_u_packed, f_u_packed, data_packed)
+
+        # per-atom charges match between layouts
+        q_dense_flat = torch.cat([q_dense[b, :s] for b, s in enumerate(sizes)])
+        assert torch.allclose(q_packed[:-1], q_dense_flat, atol=1e-6)
+        # padding atom must stay at zero charge
+        assert q_packed[-1].abs().max().item() == 0.0
+
+        # total charge per molecule is conserved in both layouts
+        assert torch.allclose(nbops.mol_sum(q_packed, data_packed), Q, atol=1e-5)
+        assert torch.allclose(nbops.mol_sum(q_dense, data_dense), Q, atol=1e-5)
+
     def test_nse_gradient(self, device):
         """Test gradient flow through NSE."""
         coord = torch.rand((1, 3, 3), device=device)

--- a/tests/test_serialization_abi.py
+++ b/tests/test_serialization_abi.py
@@ -1,0 +1,216 @@
+"""Tests for the serialization ABI: import paths embedded in model configs and artifacts.
+
+Released AIMNet2 model files (.pt) embed a YAML document (``model_yaml``) with
+fully qualified class paths such as ``aimnet.models.aimnet2.AIMNet2``,
+``aimnet.modules.Output``, and ``torch.nn.GELU``. At load time,
+``aimnet.config.build_module`` resolves these strings with
+``importlib.import_module`` (aimnet/config.py), and the Hugging Face loader
+allowlists the ``aimnet.`` prefix (aimnet/calculators/hf_hub.py). Every dotted
+path reachable this way is therefore a serialization ABI shared with all
+released checkpoints: renaming or moving one of these classes breaks every
+published .pt file that references it.
+
+These tests pin that contract:
+
+1. Every import path in YAML files shipped inside the ``aimnet`` package
+   resolves through the same mechanism the loader uses (``config.get_module``).
+2. An explicit frozen list of names embedded in released artifacts resolves.
+3. The model YAML embedded in each bundled .pt asset resolves offline.
+"""
+
+import inspect
+from pathlib import Path
+
+import pytest
+import torch
+import yaml
+
+import aimnet
+from aimnet import config
+from aimnet.calculators.hf_hub import _validate_model_yaml
+
+_PACKAGE_ROOT = Path(aimnet.__file__).parent
+_ASSETS_DIR = _PACKAGE_ROOT / "calculators" / "assets"
+
+# YAML keys whose string values are dotted import paths resolved at runtime:
+# - "class": build_module/get_init_module (aimnet/config.py)
+# - "activation_fn", "weight_init_fn": MLP kwargs (aimnet/modules/core.py)
+# - "fn": loss component functions (aimnet/train/loss.py)
+# - "trainer", "evaluator": training loop entry points (aimnet/train/utils.py)
+_IMPORT_PATH_KEYS = frozenset({"class", "activation_fn", "weight_init_fn", "fn", "trainer", "evaluator"})
+
+# Top-level packages provided by the aimnet[train] extra. Import paths that
+# require them are resolved when the extra is installed and skipped otherwise.
+_OPTIONAL_EXTRA_ROOTS = frozenset({"ignite", "omegaconf", "wandb"})
+
+# ---------------------------------------------------------------------------
+# FROZEN SERIALIZATION ABI
+#
+# Every name below is embedded (or expected by loader machinery) in released
+# model artifacts and therefore FROZEN. Renaming or moving any of these classes
+# bricks every published .pt checkpoint that references it, because loading
+# resolves these strings by import at runtime. Removing a name from this list
+# is a conscious ABI-break decision and requires a deprecation alias at the old
+# import path plus a model-format migration for all released artifacts.
+# ---------------------------------------------------------------------------
+_FROZEN_CLASS_PATHS = (
+    # Model class. Released checkpoints reference BOTH spellings: the barrel
+    # path (aimnet2_rxn_0.pt) and the fully qualified submodule path (all
+    # other bundled artifacts), so both must keep resolving.
+    "aimnet.models.AIMNet2",
+    "aimnet.models.aimnet2.AIMNet2",
+    # Output modules named in the model_yaml embedded in released checkpoints.
+    "aimnet.modules.Output",
+    "aimnet.modules.AtomicShift",
+    "aimnet.modules.AtomicSum",
+    "aimnet.modules.SRCoulomb",
+    "aimnet.modules.Dipole",
+    "aimnet.modules.Quadrupole",
+    # Referenced by the shipped model definition YAMLs (aimnet/models/*.yaml)
+    # and string-matched by the loader machinery: aimnet/models/utils.py
+    # rewrites LRCoulomb/DFTD3 to SRCoulomb and detects D3TS by class name;
+    # hf_hub._find_srcoulomb_params matches on the SRCoulomb suffix.
+    "aimnet.modules.LRCoulomb",
+    "aimnet.modules.DFTD3",
+    "aimnet.modules.D3TS",
+    # Public configuration building blocks (documented in docs/api as intended
+    # for configuration and extension); external configs may reference them.
+    "aimnet.modules.AEVSV",
+    "aimnet.modules.Embedding",
+    # Activation embedded via 'activation_fn' in every released model_yaml.
+    "torch.nn.GELU",
+)
+
+# Frozen callables that are factories rather than classes.
+# aimnet.modules.MLP is a function that builds an nn.Sequential, but it is a
+# public config building block referenced by the same dotted-path mechanism.
+_FROZEN_FACTORY_PATHS = ("aimnet.modules.MLP",)
+
+
+def _iter_import_paths(obj):
+    """Recursively yield (key, dotted_path) pairs from a parsed YAML tree."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key in _IMPORT_PATH_KEYS and isinstance(value, str) and "." in value:
+                yield key, value
+            yield from _iter_import_paths(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_import_paths(item)
+
+
+def _collect_yaml_import_paths():
+    """Collect (relative_file, key, dotted_path) from every YAML in the package."""
+    entries = set()
+    for path in sorted(_PACKAGE_ROOT.rglob("*.yaml")) + sorted(_PACKAGE_ROOT.rglob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+        for key, dotted in _iter_import_paths(data):
+            entries.add((rel, key, dotted))
+    return sorted(entries)
+
+
+_YAML_IMPORT_PATHS = _collect_yaml_import_paths()
+
+
+def _resolve_or_skip_optional(dotted):
+    """Resolve a dotted path via config.get_module, skipping missing optional extras."""
+    try:
+        return config.get_module(dotted)
+    except ModuleNotFoundError as exc:
+        missing_root = (exc.name or "").split(".")[0]
+        if missing_root in _OPTIONAL_EXTRA_ROOTS:
+            pytest.skip(f"'{dotted}' requires optional extra package '{missing_root}' (install aimnet[train])")
+        raise
+
+
+class TestShippedYamlImportPaths:
+    """Every import path in YAML files shipped inside the package must resolve."""
+
+    def test_collector_found_shipped_configs(self):
+        """Guard against the glob silently matching nothing."""
+        files = {rel for rel, _, _ in _YAML_IMPORT_PATHS}
+        assert "models/aimnet2.yaml" in files
+        assert "models/aimnet2_dftd3_wb97m.yaml" in files
+        assert "models/aimnet2_rxn.yaml" in files
+        assert "train/default_train.yaml" in files
+
+    def test_model_registry_has_no_import_paths(self):
+        """model_registry.yaml is download metadata only (files, URLs, aliases)."""
+        registry_path = _PACKAGE_ROOT / "calculators" / "model_registry.yaml"
+        registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+        assert list(_iter_import_paths(registry)) == []
+
+    @pytest.mark.parametrize(
+        ("yaml_file", "key", "dotted"),
+        _YAML_IMPORT_PATHS,
+        ids=[f"{rel}:{key}={dotted}" for rel, key, dotted in _YAML_IMPORT_PATHS],
+    )
+    def test_import_path_resolves(self, yaml_file, key, dotted):
+        """Each dotted path resolves via the loader's own mechanism (get_module)."""
+        obj = _resolve_or_skip_optional(dotted)
+        assert callable(obj), f"{yaml_file}: '{key}: {dotted}' resolved to non-callable {type(obj)!r}"
+
+
+class TestFrozenSerializationAbi:
+    """The frozen list of names embedded in released model artifacts must resolve."""
+
+    @pytest.mark.parametrize("dotted", _FROZEN_CLASS_PATHS)
+    def test_frozen_class_path_resolves(self, dotted):
+        """Each frozen name imports and is a class."""
+        obj = config.get_module(dotted)
+        assert inspect.isclass(obj), f"Frozen ABI path '{dotted}' resolved to non-class {type(obj)!r}"
+
+    @pytest.mark.parametrize("dotted", _FROZEN_FACTORY_PATHS)
+    def test_frozen_factory_path_resolves(self, dotted):
+        """Each frozen factory imports and is callable."""
+        obj = config.get_module(dotted)
+        assert callable(obj), f"Frozen ABI path '{dotted}' resolved to non-callable {type(obj)!r}"
+
+    def test_frozen_list_covers_shipped_model_yamls(self):
+        """Every import path in aimnet/models/*.yaml must appear in the frozen list."""
+        frozen = set(_FROZEN_CLASS_PATHS) | set(_FROZEN_FACTORY_PATHS)
+        shipped = {dotted for rel, _, dotted in _YAML_IMPORT_PATHS if rel.startswith("models/")}
+        missing = shipped - frozen
+        assert not missing, (
+            f"Shipped model YAMLs reference paths not in the frozen ABI list: {sorted(missing)}. "
+            "Add them to _FROZEN_CLASS_PATHS (they become part of the serialization ABI)."
+        )
+
+
+_ASSET_FILES = sorted(_ASSETS_DIR.glob("*.pt")) if _ASSETS_DIR.is_dir() else []
+
+
+class TestBundledAssetEmbeddedYaml:
+    """The model YAML embedded in each bundled .pt asset must resolve offline."""
+
+    @pytest.mark.parametrize("asset", _ASSET_FILES, ids=[p.name for p in _ASSET_FILES])
+    def test_embedded_model_yaml_resolves(self, asset):
+        """Load bundled .pt with weights_only=True (as load_model does) and resolve its YAML."""
+        # weights_only=True is the secure code path load_model() tries first
+        # for the v2 .pt format (aimnet/models/base.py). No network involved.
+        data = torch.load(asset, map_location="cpu", weights_only=True)
+        assert isinstance(data, dict), f"{asset.name}: expected v2 state-dict format, got {type(data)!r}"
+        assert "model_yaml" in data, f"{asset.name}: missing embedded 'model_yaml'"
+
+        model_yaml = data["model_yaml"]
+        # Released YAML must stay within the HF loader allowlist (hf_hub.py).
+        _validate_model_yaml(model_yaml)
+
+        entries = list(_iter_import_paths(yaml.safe_load(model_yaml)))
+        assert any(key == "class" for key, _ in entries), f"{asset.name}: no 'class' entries in embedded YAML"
+        for key, dotted in entries:
+            obj = config.get_module(dotted)
+            assert callable(obj), f"{asset.name}: '{key}: {dotted}' resolved to non-callable {type(obj)!r}"
+
+    @pytest.mark.parametrize("asset", _ASSET_FILES, ids=[p.name for p in _ASSET_FILES])
+    def test_embedded_class_paths_are_frozen(self, asset):
+        """Every class path embedded in a bundled artifact must be on the frozen list."""
+        data = torch.load(asset, map_location="cpu", weights_only=True)
+        embedded = {dotted for key, dotted in _iter_import_paths(yaml.safe_load(data["model_yaml"]))}
+        frozen = set(_FROZEN_CLASS_PATHS) | set(_FROZEN_FACTORY_PATHS)
+        missing = embedded - frozen
+        assert not missing, (
+            f"{asset.name} embeds paths not in the frozen ABI list: {sorted(missing)}. "
+            "Add them to _FROZEN_CLASS_PATHS (they become part of the serialization ABI)."
+        )


### PR DESCRIPTION
## Summary

Fixes ten findings from a full-codebase review, spanning two silent-behavior traps in the calculator, GPU hot-path syncs, a float64 dispatch gap, the model serialization ABI, and packaging hygiene.

### Calculator behavior
- **`mult` is no longer silently ignored**: closed-shell (1-channel) models now warn once per calculator instance when `mult != 1` is passed (the ASE/pysisyphus/torch-sim wrappers pass it unconditionally, so an open-shell request used to return a closed-shell result with no signal).
- **The automatic `simple`->`dsf` Coulomb switch is now scoped to the periodic evaluation** and restored in a `finally` block, so one PBC call no longer permanently flips a gas-phase calculator off its trained full Coulomb. Explicit `set_lrcoulomb_method()` remains persistent, and the DSF-side adaptive neighbor lists are memoized so periodic MD keeps them warm.
- **Species validation is cached on `numbers` tensor identity** (id/data_ptr/`_version` plus a weakref guard), removing a per-step device-to-host `tolist()` from MD/optimization loops. Charge validation still runs every call.

### Hot-path syncs (packed mode 1, the MD/PBC path)
- `mol_sum` reads a molecule count cached by `calc_masks` as a CPU tensor (same pattern as `_nb_mode`) instead of syncing on `mol_idx[-1].item()` several times per message-passing pass.
- `nse` broadcasts per-molecule values with a `mol_idx` gather instead of `repeat_interleave` over an in-place-mutated `mol_sizes`. Verified bit-identical on CPU; the CUDA difference equals the pre-existing `scatter_add_` nondeterminism baseline. `torch.cuda.set_sync_debug_mode("error")` confirms both now run sync-free.
- Compiled graphs keep the original formulations behind `torch.compiler.is_compiling()`: the new gather/scatter fusion trips an inductor CPU codegen assertion (caught by `TestTorchCompile` during the gate), so `torch.compile` behavior is unchanged from main while eager gets the sync-free path.

### Kernels
- `ConvSV` now gates the Warp kernel on both operands being float32, so float64 (and mixed-dtype) CUDA inputs fall back to the einsum path instead of raising. GPU fp64 fallback matches CPU fp64 to 2e-13.
- The packed-padding contract the `conv_sv_2d_sp` kernels rely on (padding sentinels contiguous at the row end, per nvalchemiops `neighbor_list`) is documented at each early-`break` site and in the op docstring.

### Serialization ABI
- New `tests/test_serialization_abi.py` (61 tests) pins the fully qualified class paths embedded in released `.pt` model files: every `class:`/factory path in shipped YAMLs and in the six bundled model artifacts must resolve, and a frozen-names list makes renames in `aimnet.models`/`aimnet.modules` a conscious ABI-break decision. Released artifacts embed both `aimnet.models.AIMNet2` and `aimnet.models.aimnet2.AIMNet2` spellings; both are pinned. Documented in `docs/api/index.md`.

### Packaging
- Wheel data files (model YAMLs, registry, `dftd3_data.pt`) ship via include globs instead of hand-enumerated `force-include` entries, so a new YAML can no longer be silently dropped from wheels. Verified by before/after wheel file-list diff (identical data set; the gitignored download cache stays excluded).
- Removed the empty `aimnet.interfaces` package (docstring-only, zero references; the real adapters live in `aimnet.calculators`).

## Testing
- Full CPU gate (`-m "not gpu and not network"`, CUDA hidden): 474 passed at the pre-compile-fix state; the compile fix only changes `torch.compile`d paths and `TestTorchCompile` now passes 5/5 (+1 skip).
- Full GPU suite (`-m gpu` on an L40S): 116 passed.
- Targeted after the compile fix: `test_nbops`+`test_ops`+`test_calculator` 174 passed; `test_calculator_gpu`+`test_conv_sv_2d_sp` 31 passed; PBC compile tests 2 passed; TorchScript compilation of `mol_sum`/`nse` verified.
- `ruff check` and `ruff format --check` clean.

Note: `test_static_cache_reuses_dftd3_terms_for_same_resident_tensors` flaked once during a full `-m gpu` run but passes in isolation and on identical-order reruns, on both this branch and main - it looks like a pre-existing flake in the identity-keyed static cache from #84, not something this change introduces.

## Deferred follow-ups
- Dipole origin-dependence for net-charged systems (`center_coord=False` in the released rxn YAML) - needs a release decision since changing it alters published model outputs.
- Centralizing family policy (currently split across `model_registry.py`, `calculator.py`, `hf_hub.py` with three string conventions) as per-family data in `model_registry.yaml`.