### PR TITLE
chore: remove dead code confirmed unused downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- Removed unused `DataGroup.to_dict`, `DataGroup.merge`, `DataGroup.rename_key`, `SizeGroupedDataset.merge`, and `SizeGroupedDataset.rename_datakey` (no callers in-repo or in downstream projects).
+- Removed unused `aimnet.train.utils.make_seed` and `aimnet.ops.lazy_calc_dij_lr`.
+- Removed unused `LRCoulomb.coul_ewald` and `LRCoulomb.coul_pme` convenience wrappers; use `LRCoulomb.forward` with `method="ewald"`/`"pme"`.
+- Removed unused `aimnet.modules.core.DSequential` and `aimnet.constants.get_dftd3_param`.
+- Removed unused `aimnet.models.utils.has_dftd3_in_config` (and its `aimnet.models` re-export).
+
+### Added
+
+- Added unit tests for the public `SizeGroupedDataset.save_h5`, `AIMNet2Calculator.set_lr_cutoff`, and `aimnet.train.loss.mse_loss_fn` APIs, which are kept.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/aimnet/constants.py
+++ b/aimnet/constants.py
@@ -1,5 +1,3 @@
-import os
-
 import torch
 
 # from ase.units
@@ -450,18 +448,3 @@ def get_r4r2(device="cpu"):
 
     r4r2 = (0.5 * torch.tensor(sqrt_z_r4_over_r2) * torch.arange(len(sqrt_z_r4_over_r2)).sqrt()).sqrt()
     return r4r2.to(device)
-
-
-def get_dftd3_param(device="cpu"):
-    """Collection of parameters for DFT-D3 model"""
-    dirname = os.path.dirname(__file__)
-    filename = os.path.join(dirname, "dftd3_data.pt")
-    if not os.path.exists(filename):
-        raise FileNotFoundError(f"dftd3_data.pt not found in {dirname}.")
-    param = torch.load(filename, map_location=device, weights_only=True)
-    assert isinstance(param, dict)
-    assert "c6ab" in param
-    assert "r4r2" in param
-    assert "rcov" in param
-    assert "cnmax" in param
-    return param

--- a/aimnet/data/sgdataset.py
+++ b/aimnet/data/sgdataset.py
@@ -82,9 +82,6 @@ class DataGroup:
     def __len__(self):
         return len(next(iter(self.values()))) if self._data else 0
 
-    def to_dict(self):
-        return self._data
-
     def items(self):
         return self._data.items()
 
@@ -96,9 +93,6 @@ class DataGroup:
 
     def pop(self, key):
         return self._data.pop(key)
-
-    def rename_key(self, old, new):
-        self[new] = self.pop(old)
 
     def sample(self, idx, keys=None) -> "DataGroup":
         """Return a new `DataGroup` with the data indexed by `idx`."""
@@ -159,19 +153,6 @@ class DataGroup:
             keys = self.keys()
         for idx in idxs:
             yield {k: v[idx] for k, v in self.items() if k in keys}
-
-    def merge(self, other, strict=True):
-        if strict:
-            if set(self.keys()) != set(other.keys()):
-                raise ValueError("Data keys do not match between the datasets.")
-            keys = self.keys()
-        else:
-            keys = set(self.keys()) & set(other.keys())
-        for k in list(self.keys()):
-            if k in keys:
-                self._data[k] = np.concatenate([self[k], other[k]], axis=0)
-            else:
-                self.pop(k)
 
     def apply_peratom_shift(self, sap_dict, key_in="energy", key_out="energy", numbers_key="numbers"):
         ntyp = max(sap_dict.keys()) + 1
@@ -276,35 +257,9 @@ class SizeGroupedDataset:
     def __contains__(self, value):
         return value in self.keys()
 
-    def rename_datakey(self, old, new):
-        for g in self.groups:
-            g.rename_key(old, new)
-
     def apply(self, fn):
         for grp in self.groups:
             fn(grp)
-
-    def merge(self, other, strict=True):
-        if not isinstance(other, self.__class__):
-            other = self.__class__(other)
-        if strict:
-            if set(other.datakeys()) != set(self.datakeys()):
-                raise ValueError("Data keys do not match between the datasets.")
-        else:
-            keys = set(other.datakeys()) & set(self.datakeys())
-            for k in list(self.datakeys()):
-                if k not in keys:
-                    for g in self.groups:
-                        g.pop(k)
-            for k in list(other.datakeys()):
-                if k not in keys:
-                    for g in other.groups:
-                        g.pop(k)
-        for k in other:
-            if k in self:
-                self[k].cat(other[k])  # type: ignore[attr-defined]
-            else:
-                self[k] = other[k]  # type: ignore[attr-defined]
 
     def random_split(self, *fractions, seed=None):
         splitted_groups = {}

--- a/aimnet/models/__init__.py
+++ b/aimnet/models/__init__.py
@@ -6,7 +6,6 @@ from .utils import (  # noqa: F401
     extract_species,
     has_d3ts,
     has_d3ts_in_config,
-    has_dftd3_in_config,
     has_dispersion,
     has_externalizable_dftd3,
     has_lrcoulomb,

--- a/aimnet/models/utils.py
+++ b/aimnet/models/utils.py
@@ -290,23 +290,6 @@ def has_d3ts_in_config(config: dict) -> bool:
     return "d3ts" in outputs
 
 
-def has_dftd3_in_config(config: dict) -> bool:
-    """Check if YAML config contains DFTD3 or D3BJ module.
-
-    Parameters
-    ----------
-    config : dict
-        Model YAML configuration dictionary.
-
-    Returns
-    -------
-    bool
-        True if DFTD3 or D3BJ is in the outputs section.
-    """
-    outputs = config.get("kwargs", {}).get("outputs", {})
-    return "dftd3" in outputs or "d3bj" in outputs
-
-
 # --- State dict key validation ---
 
 

--- a/aimnet/modules/core.py
+++ b/aimnet/modules/core.py
@@ -68,17 +68,6 @@ class Embedding(nn.Embedding):
                 self.weight[self.padding_idx].fill_(0)
 
 
-class DSequential(nn.Module):
-    def __init__(self, *modules):
-        super().__init__()
-        self.module = nn.ModuleList(modules)
-
-    def forward(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
-        for m in self.module:
-            data = m(data)
-        return data
-
-
 class AtomicShift(nn.Module):
     def __init__(
         self,

--- a/aimnet/modules/lr.py
+++ b/aimnet/modules/lr.py
@@ -888,16 +888,6 @@ class LRCoulomb(nn.Module):
             hv = -(fp - fm) / (2.0 * step)
         return hv  # (N, 3), float64
 
-    def coul_ewald(self, data: dict[str, Tensor]) -> Tensor:
-        """Per-system Ewald energy in eV. Requires ``cell`` and ``nbmat_lr``/``shifts_lr``."""
-        energy, _terms = self._coul_nvalchemi(data, backend="ewald")
-        return energy
-
-    def coul_pme(self, data: dict[str, Tensor]) -> Tensor:
-        """Per-system PME energy in eV. Requires ``cell`` and ``nbmat_lr``/``shifts_lr``."""
-        energy, _terms = self._coul_nvalchemi(data, backend="pme")
-        return energy
-
     def forward(
         self,
         data: dict[str, Tensor],

--- a/aimnet/ops.py
+++ b/aimnet/ops.py
@@ -6,16 +6,6 @@ from torch import Tensor
 from aimnet import nbops
 
 
-def lazy_calc_dij_lr(data: dict[str, Tensor]) -> dict[str, Tensor]:
-    if "d_ij_lr" not in data:
-        nb_mode = nbops.get_nb_mode(data)
-        if nb_mode == 0:
-            data["d_ij_lr"] = data["d_ij"]
-        else:
-            data["d_ij_lr"] = calc_distances(data, suffix="_lr")[0]
-    return data
-
-
 def lazy_calc_dij(data: dict[str, Tensor], suffix: str) -> dict[str, Tensor]:
     """Lazily calculate distances for a given suffix.
 

--- a/aimnet/train/utils.py
+++ b/aimnet/train/utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 from collections.abc import Callable
 
@@ -32,14 +31,6 @@ def enable_tf32(enable=True):
     # cudnn keeps a dedicated flag not covered by set_float32_matmul_precision.
     if hasattr(torch.backends.cudnn, "allow_tf32"):
         torch.backends.cudnn.allow_tf32 = enable
-
-
-def make_seed(all_reduce=True):
-    # create seed
-    seed = int.from_bytes(os.urandom(2), "big")
-    if all_reduce and idist.get_world_size() > 1:
-        seed = idist.all_reduce(seed)
-    return seed
 
 
 def _to_config_dict(cfg: omegaconf.DictConfig, name: str) -> dict:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1950,3 +1950,15 @@ def test_aimnet2rxn_alias_calculator_e2e():
     assert calc.external_dftd3 is not None
     assert calc.metadata.get("implemented_species") == [1, 6, 7, 8]
     assert abs(calc.metadata.get("cutoff") - 5.0) < 1e-6
+
+
+def test_set_lr_cutoff_updates_lr_state(water_molecule):
+    calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
+    e_before = calc(dict(water_molecule))["energy"]
+    calc.set_lr_cutoff(12.0)
+    assert calc.cutoff_lr == 12.0
+    assert calc.dftd3_cutoff == 12.0
+    e_after = calc(dict(water_molecule))["energy"]
+    assert torch.isfinite(e_after).all()
+    # Water is far smaller than either cutoff, so the energy must not change.
+    assert torch.allclose(e_before, e_after)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -180,3 +180,13 @@ def test_split_fractions():
     ds1, ds2 = ds.random_split(0.8, 0.2)
     assert len(ds1) + len(ds2) == len(ds)
     assert len(ds1) > len(ds2)
+
+
+def test_save_h5_roundtrip(tmp_path):
+    ds = dataset()
+    out = tmp_path / "roundtrip.h5"
+    ds.save_h5(str(out))
+    ds2 = SizeGroupedDataset(str(out))
+    assert sorted(ds2.keys()) == sorted(ds.keys())
+    assert len(ds2) == len(ds)
+    assert sorted(ds2.datakeys()) == sorted(ds.datakeys())

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -37,3 +37,14 @@ def test_state_dict_roundtrip_weights_only(tmp_path):
     loaded = torch.load(p, map_location="cpu", weights_only=True)
     assert set(loaded) == {"w", "b"}
     torch.testing.assert_close(loaded["w"], sd["w"])
+
+
+def test_mse_loss_fn_matches_torch_mse():
+    torch = pytest.importorskip("torch")
+    from aimnet.train.loss import mse_loss_fn
+
+    pred = {"energy": torch.tensor([1.0, 2.0, 3.0])}
+    true = {"energy": torch.tensor([1.5, 2.0, 2.0])}
+    loss = mse_loss_fn(pred, true, key_pred="energy", key_true="energy")
+    expected = torch.nn.functional.mse_loss(true["energy"], pred["energy"])
+    assert torch.allclose(loss, expected)


### PR DESCRIPTION
Removes symbols with no callers in-repo, in examples/scripts/docs, or in downstream repos (aimnet-solvate, aimnet-thermo, cosmonext*, saddleforge, protonator, LoQI, pyscf_at, poymers_rxn), per static call-graph audit plus cross-repo grep.

Removed: `DataGroup.to_dict`/`.merge`/`.rename_key`, `SizeGroupedDataset.merge`/`.rename_datakey`, `train.utils.make_seed`, `ops.lazy_calc_dij_lr`, `LRCoulomb.coul_ewald`/`.coul_pme`, `modules.core.DSequential`, `constants.get_dftd3_param`, `models.utils.has_dftd3_in_config` (+ its re-export).

Kept deliberately: symbols instantiated via YAML `class:`/`fn:` keys, framework-dispatched methods (torch/ASE/TorchSim/PySisyphus/ignite/console scripts), deprecated-with-warning helpers (`has_dispersion`, `iter_lrcoulomb_mods`), documented back-compat (`ops.coulomb_matrix_ewald`), and three public-but-untested APIs that now gain unit tests: `SizeGroupedDataset.save_h5`, `AIMNet2Calculator.set_lr_cutoff`, `train.loss.mse_loss_fn`.

Gate: full CPU suite (482 passed), deptry, ruff; mypy unchanged vs main (pre-existing errors only).