### PR TITLE
refactor(calculator): extract model resolution into resolve.py

### DIFF
--- a/aimnet/calculators/calculator.py
+++ b/aimnet/calculators/calculator.py
@@ -1,7 +1,5 @@
 import copy
 import math
-import os
-import re
 import warnings
 import weakref
 from collections.abc import Mapping
@@ -13,11 +11,10 @@ from nvalchemiops.neighbors import NeighborOverflowError
 from nvalchemiops.torch.neighbors import neighbor_list
 from torch import Tensor, nn
 
-from aimnet.models.base import load_model
 from aimnet.modules import DFTD3, LRCoulomb
 from aimnet.modules.lr import ExternalDerivativeTerms
 
-from .model_registry import get_family_policy, get_model_path, get_registry_model_family
+from .resolve import resolve_model
 
 # Sentinel for "attribute did not exist" when snapshotting/restoring instance state.
 _SENTINEL = object()
@@ -53,39 +50,6 @@ def _combine_external_terms(
         virial=_sum_optional_tensor(a.virial, b.virial),
         hessian=_sum_optional_tensor(a.hessian, b.hessian),
     )
-
-
-def _apply_family_defaults(metadata: Mapping[str, Any], registry_family: str | None) -> dict[str, Any]:
-    """Apply calculator-side compatibility defaults for released model families."""
-    metadata = dict(metadata)
-    if registry_family is not None:
-        metadata_family = metadata.get("family")
-        if metadata_family is None:
-            metadata["family"] = registry_family
-        elif metadata_family != registry_family:
-            raise ValueError(
-                f"Registry family '{registry_family}' does not match model metadata family "
-                f"'{metadata_family}'. Refusing to load ambiguous energy scale."
-            )
-
-    policy = get_family_policy(metadata.get("family"))
-
-    if policy.supports_charged_systems is not None:
-        supports_charged = metadata.get("supports_charged_systems")
-        if supports_charged is None:
-            metadata["supports_charged_systems"] = policy.supports_charged_systems
-        elif supports_charged is not policy.supports_charged_systems:
-            raise ValueError(
-                f"aimnet2-{policy.family} models must declare "
-                f"supports_charged_systems={policy.supports_charged_systems}."
-            )
-
-    if policy.posthoc_d3_params is not None and not metadata.get("has_embedded_d3ts", False):
-        metadata["needs_dispersion"] = True
-        if metadata.get("d3_params") is None:
-            metadata["d3_params"] = dict(policy.posthoc_d3_params)
-
-    return metadata
 
 
 class AdaptiveNeighborList:
@@ -324,59 +288,13 @@ class AIMNet2Calculator:
         self._default_dftd3_smoothing = 0.2
 
         # Load model and get metadata
-        metadata: Mapping[str, Any] | None = None
-        registry_family: str | None = None
-        # Inline org/name pattern — exactly one slash, both segments alphanumeric+._-
-        # This avoids importing optional HF deps for ordinary file paths containing slashes.
-        _HF_ID_RE = re.compile(r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$")
-        if isinstance(model, str):
-            # Check for HF repo ID or local HF-style directory
-            # (lazy import to keep safetensors/huggingface_hub optional)
-            _is_hf_dir = os.path.isdir(model)
-            _looks_like_hf = bool(_HF_ID_RE.match(model))
-            if _looks_like_hf or _is_hf_dir:
-                try:
-                    from aimnet.calculators.hf_hub import is_hf_repo_id, load_from_hf_repo
-                except ImportError:
-                    raise ImportError(
-                        f"Loading from HF repo '{model}' requires optional dependencies. "
-                        "Install with: pip install aimnet[hf]"
-                    ) from None
-                if is_hf_repo_id(model) or _is_hf_dir:
-                    _model, metadata = load_from_hf_repo(
-                        model,
-                        ensemble_member=ensemble_member,
-                        device=self.device,
-                        revision=revision,
-                        token=token,
-                    )
-                    self.model = _model
-                    self.cutoff = metadata["cutoff"]
-                else:
-                    # _looks_like_hf matched but it's a local file path — fall through
-                    if not os.path.isfile(model):
-                        registry_family = get_registry_model_family(model)
-                    p = get_model_path(model)
-                    self.model, metadata = load_model(p, device=self.device)
-                    self.cutoff = metadata["cutoff"]
-            else:
-                if not os.path.isfile(model):
-                    registry_family = get_registry_model_family(model)
-                p = get_model_path(model)
-                self.model, metadata = load_model(p, device=self.device)
-                self.cutoff = metadata["cutoff"]
-        elif isinstance(model, nn.Module):
-            self.model = model.to(self.device)
-            self.cutoff = getattr(self.model, "cutoff", 5.0)
-            metadata = cast(Mapping[str, Any] | None, getattr(self.model, "metadata", None))
-            if metadata is None:
-                metadata = cast(Mapping[str, Any] | None, getattr(self.model, "_metadata", None))
-        else:
-            raise TypeError("Invalid model type/name.")
-
-        if metadata is not None:
-            metadata = _apply_family_defaults(metadata, registry_family)
-            self.model._metadata = metadata  # type: ignore[assignment]
+        self.model, metadata, self.cutoff = resolve_model(
+            model,
+            device=self.device,
+            ensemble_member=ensemble_member,
+            revision=revision,
+            token=token,
+        )
 
         # Compile model if requested
         self._was_compiled = bool(compile_model)

--- a/aimnet/calculators/resolve.py
+++ b/aimnet/calculators/resolve.py
@@ -1,0 +1,120 @@
+"""Model-source resolution for :class:`~aimnet.calculators.AIMNet2Calculator`.
+
+Owns the dispatch between registry names/aliases, Hugging Face repo ids,
+local HF-style directories, plain file paths, and raw ``nn.Module`` objects,
+plus the family-policy reconciliation applied to the resolved metadata.
+"""
+
+import os
+import re
+from collections.abc import Mapping
+from typing import Any, cast
+
+from torch import nn
+
+from aimnet.models.base import load_model
+
+from .model_registry import get_family_policy, get_model_path, get_registry_model_family
+
+# Inline org/name pattern — exactly one slash, both segments alphanumeric+._-
+# This avoids importing optional HF deps for ordinary file paths containing slashes.
+_HF_ID_RE = re.compile(r"^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$")
+
+
+def _apply_family_defaults(metadata: Mapping[str, Any], registry_family: str | None) -> dict[str, Any]:
+    """Apply calculator-side compatibility defaults for released model families."""
+    metadata = dict(metadata)
+    if registry_family is not None:
+        metadata_family = metadata.get("family")
+        if metadata_family is None:
+            metadata["family"] = registry_family
+        elif metadata_family != registry_family:
+            raise ValueError(
+                f"Registry family '{registry_family}' does not match model metadata family "
+                f"'{metadata_family}'. Refusing to load ambiguous energy scale."
+            )
+
+    policy = get_family_policy(metadata.get("family"))
+
+    if policy.supports_charged_systems is not None:
+        supports_charged = metadata.get("supports_charged_systems")
+        if supports_charged is None:
+            metadata["supports_charged_systems"] = policy.supports_charged_systems
+        elif supports_charged is not policy.supports_charged_systems:
+            raise ValueError(
+                f"aimnet2-{policy.family} models must declare "
+                f"supports_charged_systems={policy.supports_charged_systems}."
+            )
+
+    if policy.posthoc_d3_params is not None and not metadata.get("has_embedded_d3ts", False):
+        metadata["needs_dispersion"] = True
+        if metadata.get("d3_params") is None:
+            metadata["d3_params"] = dict(policy.posthoc_d3_params)
+
+    return metadata
+
+
+def resolve_model(
+    model: str | nn.Module,
+    *,
+    device: str,
+    ensemble_member: int = 0,
+    revision: str | None = None,
+    token: str | None = None,
+) -> tuple[nn.Module, Mapping[str, Any] | None, float]:
+    """Resolve a model spec to ``(module_on_device, metadata, cutoff)``.
+
+    ``metadata`` has family-policy defaults applied and, when not ``None``,
+    is also attached to the returned module as ``_metadata``.
+    """
+    metadata: Mapping[str, Any] | None = None
+    registry_family: str | None = None
+    if isinstance(model, str):
+        # Check for HF repo ID or local HF-style directory
+        # (lazy import to keep safetensors/huggingface_hub optional)
+        _is_hf_dir = os.path.isdir(model)
+        _looks_like_hf = bool(_HF_ID_RE.match(model))
+        if _looks_like_hf or _is_hf_dir:
+            try:
+                from aimnet.calculators.hf_hub import is_hf_repo_id, load_from_hf_repo
+            except ImportError:
+                raise ImportError(
+                    f"Loading from HF repo '{model}' requires optional dependencies. "
+                    "Install with: pip install aimnet[hf]"
+                ) from None
+            if is_hf_repo_id(model) or _is_hf_dir:
+                module, metadata = load_from_hf_repo(
+                    model,
+                    ensemble_member=ensemble_member,
+                    device=device,
+                    revision=revision,
+                    token=token,
+                )
+                cutoff = metadata["cutoff"]
+            else:
+                # _looks_like_hf matched but it's a local file path — fall through
+                if not os.path.isfile(model):
+                    registry_family = get_registry_model_family(model)
+                p = get_model_path(model)
+                module, metadata = load_model(p, device=device)
+                cutoff = metadata["cutoff"]
+        else:
+            if not os.path.isfile(model):
+                registry_family = get_registry_model_family(model)
+            p = get_model_path(model)
+            module, metadata = load_model(p, device=device)
+            cutoff = metadata["cutoff"]
+    elif isinstance(model, nn.Module):
+        module = model.to(device)
+        cutoff = getattr(module, "cutoff", 5.0)
+        metadata = cast(Mapping[str, Any] | None, getattr(module, "metadata", None))
+        if metadata is None:
+            metadata = cast(Mapping[str, Any] | None, getattr(module, "_metadata", None))
+    else:
+        raise TypeError("Invalid model type/name.")
+
+    if metadata is not None:
+        metadata = _apply_family_defaults(metadata, registry_family)
+        module._metadata = metadata  # type: ignore[assignment]
+
+    return module, metadata, cutoff

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1798,7 +1798,7 @@ def test_registry_family_metadata_mismatch_raises(monkeypatch):
     from torch import nn
 
     from aimnet.calculators import AIMNet2Calculator
-    from aimnet.calculators import calculator as calculator_mod
+    from aimnet.calculators import resolve as resolve_mod
 
     class DummyModel(nn.Module):
         pass
@@ -1816,8 +1816,8 @@ def test_registry_family_metadata_mismatch_raises(monkeypatch):
         model._metadata = metadata
         return model, metadata
 
-    monkeypatch.setattr(calculator_mod, "get_model_path", lambda _model: "/fake/model.pt")
-    monkeypatch.setattr(calculator_mod, "load_model", fake_load_model)
+    monkeypatch.setattr(resolve_mod, "get_model_path", lambda _model: "/fake/model.pt")
+    monkeypatch.setattr(resolve_mod, "load_model", fake_load_model)
 
     with pytest.raises(ValueError, match=r"Registry family 'wb97m-d3'"):
         AIMNet2Calculator("aimnet2", device="cpu")


### PR DESCRIPTION
Moves registry/HF/file/raw-module dispatch and family-policy reconciliation out of AIMNet2Calculator.__init__ into a resolve_model() function in a new calculators/resolve.py. The constructor shrinks to a single resolve_model() call plus wiring; no public API or behavior change. One test updated to monkeypatch the new module location.

Verification: calculator/registry/HF/serialization suites plus full CPU suite green; A/B numerics check (energy/forces/Hessian on caffeine, forces/stress on a PBC crystal) bit-identical to main at rtol=atol=1e-10.