### PR TITLE
test: mark slow tests so the default suite runs under two minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Marked the expensive tail of the test suite (~60 test nodes ≥2 s each: torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) with the `slow` marker; the default CPU test run now completes in under two minutes. Run `pytest -m slow` for the marked tail. The cheapest representative of each critical path (dense Hessian, HVP correctness, legacy `.jpt` loading, torch.compile smoke) stays in the default set.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -95,6 +95,7 @@ class TestForces:
 class TestPBC:
     """Tests for periodic boundary conditions."""
 
+    @pytest.mark.slow
     def test_pbc_energy(self):
         """Test energy calculation for periodic system."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -114,6 +115,7 @@ class TestPBC:
         assert isinstance(e, float)
         assert np.isfinite(e)
 
+    @pytest.mark.slow
     def test_pbc_forces(self):
         """Test force calculation for periodic system."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -133,6 +135,7 @@ class TestPBC:
         assert f.shape == (len(atoms), 3)
         assert np.isfinite(f).all()
 
+    @pytest.mark.slow
     def test_pbc_stress_tensor(self):
         """Test stress tensor calculation for periodic system."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -153,6 +156,7 @@ class TestPBC:
         assert stress.shape == (6,)
         assert np.isfinite(stress).all()
 
+    @pytest.mark.slow
     def test_pbc_stress_volume_normalized(self):
         """Test that stress is volume normalized (units are pressure)."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -411,6 +415,7 @@ class TestAtomsInfoChargeSpin:
         assert float(atoms.calc._t_mult) == pytest.approx(2.0)
         assert abs(atoms.calc.get_spin_charges().sum() - 1.0) < 1e-3
 
+    @pytest.mark.slow
     def test_robustness_with_tensors_in_info(self):
         """Dictionary comparison must not crash when info contains complex types like Tensors or Arrays."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -444,6 +449,7 @@ class TestAtomsInfoChargeSpin:
 class TestHessian:
     """Hessian property — used by Sella analytic-Hessian callback."""
 
+    @pytest.mark.slow
     def test_hessian_shape_and_finite(self):
         pytest.importorskip("ase", reason="ASE not installed")
         from ase.io import read
@@ -458,6 +464,7 @@ class TestHessian:
         assert H.shape == (3 * N, 3 * N)
         assert np.isfinite(H).all()
 
+    @pytest.mark.slow
     def test_hessian_symmetric(self):
         pytest.importorskip("ase", reason="ASE not installed")
         from ase.io import read
@@ -473,6 +480,7 @@ class TestHessian:
         # |H|_max would still catch a real index transposition bug.
         assert np.max(np.abs(H - H.T)) / np.max(np.abs(H)) < 1e-3
 
+    @pytest.mark.slow
     def test_hessian_callback_signature(self):
         """Must be usable as Sella's hessian_function=callable callback."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -489,6 +497,7 @@ class TestHessian:
         assert H.shape == (9, 9)
         assert isinstance(H, np.ndarray)
 
+    @pytest.mark.slow
     def test_hessian_default_atoms(self):
         """get_hessian() with no argument should use the attached atoms."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -534,6 +543,7 @@ class TestHessian:
         with pytest.raises(PropertyNotImplementedError, match="attached"):
             calc.get_hessian()
 
+    @pytest.mark.slow
     def test_hessian_species_swap_invalidates_cache(self):
         """get_hessian() must rebuild _t_numbers when called with different species at same N."""
         pytest.importorskip("ase", reason="ASE not installed")
@@ -563,6 +573,7 @@ class TestHessian:
         cached = calc._t_numbers.detach().cpu().tolist()
         assert cached == hcn.numbers.tolist()
 
+    @pytest.mark.slow
     def test_hessian_nse_open_shell(self):
         """NSE (open-shell) Hessian must run on a doublet without exception."""
         pytest.importorskip("ase", reason="ASE not installed")

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -13,6 +13,7 @@ from aimnet.calculators import AIMNet2Calculator
 pytestmark = [pytest.mark.ase]
 
 
+@pytest.mark.slow
 def test_from_zoo():
     """Test basic model loading and inference from model registry."""
     pytest.importorskip("ase", reason="ASE not installed. Install with: pip install aimnet[ase]")
@@ -340,6 +341,7 @@ class TestCoulombMethods:
         calc._train = False
         torch.testing.assert_close(f_kernel, f_torch, rtol=1e-3, atol=1e-3)
 
+    @pytest.mark.slow
     def test_dsf_torch_energy_matches_kernel(self):
         """Pure-torch DSF energy (Hessian path) matches the nvalchemiops kernel energy."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
@@ -355,6 +357,7 @@ class TestCoulombMethods:
         e_torch = calc(data, hessian=True)["energy"]
         torch.testing.assert_close(e_kernel, e_torch, rtol=1e-4, atol=1e-5)
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("method", ["ewald", "pme"])
     def test_ewald_pme_hessian_finite_symmetric_sumrule(self, method):
         """Ewald/PME Hessian is finite, symmetric, and obeys the acoustic sum rule."""
@@ -377,6 +380,7 @@ class TestCoulombMethods:
         assert (H_flat - H_flat.T).abs().max().item() < 5e-3
         assert H.sum(dim=2).abs().max().item() < 5e-3
 
+    @pytest.mark.slow
     def test_dftd3_hessian_is_finite(self):
         """External DFT-D3 uses its differentiable fallback for Hessian calls."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
@@ -652,6 +656,7 @@ class TestDerivatives:
         force_sum = res["forces"].sum(dim=-2)
         assert force_sum.abs().max().item() < 1e-4
 
+    @pytest.mark.slow
     def test_hessian_shape(self):
         """Test that Hessian has correct shape."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
@@ -709,6 +714,7 @@ class TestDerivatives:
         assert g is not None, "Autograd graph was broken — coord gradient is None"
         assert g.shape == coords.shape
 
+    @pytest.mark.slow
     def test_external_hessian_nonzero(self):
         """External Hessian via torch.autograd.functional.hessian must be non-zero.
 
@@ -729,6 +735,7 @@ class TestDerivatives:
         H = torch.autograd.functional.hessian(energy_fn, coords)
         assert H.abs().max().item() > 0, "External Hessian is all-zeros — autograd graph broken"
 
+    @pytest.mark.slow
     def test_external_hessian_matches_internal(self, device):
         """External Hessian must agree with the calculator's own hessian=True output."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0, device=device)
@@ -762,6 +769,7 @@ class TestDerivatives:
         res = calc(data, hessian=True)
         assert res["hessian"].shape == (2, 3, 2, 3)
 
+    @pytest.mark.slow
     def test_hessian_batched_input_stacks(self):
         """A B>1 3D batch returns a per-structure stacked Hessian (B, N, 3, N, 3)."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=1000)
@@ -782,6 +790,7 @@ class TestDerivatives:
         # Other requested per-structure quantities stack along the same batch dim.
         assert res["forces"].shape == (2, 3, 3)
 
+    @pytest.mark.slow
     def test_hessian_batched_matches_per_structure(self):
         """Each batched Hessian block equals the standalone single-structure Hessian."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=1000)
@@ -805,6 +814,7 @@ class TestDerivatives:
         torch.testing.assert_close(H_batched[0], H0, rtol=1e-4, atol=1e-4)
         torch.testing.assert_close(H_batched[1], H1, rtol=1e-4, atol=1e-4)
 
+    @pytest.mark.slow
     def test_hessian_batched_pbc_ewald_stacks(self):
         """Batched Hessian composes with the periodic Ewald FD-Hessian path: a 3D
         batch with a cell + Ewald Coulomb runs per-structure and stacks the
@@ -840,6 +850,7 @@ class TestDerivatives:
         res = calc(data, forces=True)
         assert "forces" in res and res["forces"].shape[-2:] == torch.Size([3, 3])
 
+    @pytest.mark.slow
     def test_hessian_multiple_molecules_returns_list(self):
         """A flat mol_idx batch returns one Hessian per molecule (list, even when equal-size)."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
@@ -859,6 +870,7 @@ class TestDerivatives:
         assert res["hessian"][0].shape == (2, 3, 2, 3)
         assert res["hessian"][1].shape == (2, 3, 2, 3)
 
+    @pytest.mark.slow
     def test_hessian_ragged_molecules_returns_list(self):
         """Different-size molecules return a list with correct per-molecule Hessian shapes."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
@@ -1051,6 +1063,7 @@ class TestBatchCorrectness:
         np.testing.assert_allclose(res_batch["energy"][0].item(), e1, atol=1e-5)
         np.testing.assert_allclose(res_batch["energy"][1].item(), e2, atol=1e-5)
 
+    @pytest.mark.slow
     def test_forces_batch_vs_individual(self):
         """Verify forces match for batched vs individual inference."""
         calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
@@ -1225,6 +1238,7 @@ class TestTorchCompile:
         assert "energy" in res
         assert torch.isfinite(res["energy"]).all()
 
+    @pytest.mark.slow
     @pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile requires PyTorch 2.0+")
     def test_torch_compile_with_gradients(self):
         """Test that gradients work through compiled model."""
@@ -1278,6 +1292,7 @@ class TestTorchCompile:
         res = calc(data)
         assert res["energy"].device.type == "cpu"
 
+    @pytest.mark.slow
     @pytest.mark.skipif(not hasattr(torch, "compile"), reason="torch.compile requires PyTorch 2.0+")
     def test_compile_model_parameter(self):
         """Test compile_model constructor parameter."""
@@ -1513,6 +1528,7 @@ class TestCutoffConfiguration:
         assert torch.isfinite(res["energy"]).all()
 
 
+@pytest.mark.slow
 def test_relative_path_with_slash_loads_correctly(tmp_path, monkeypatch):
     """Relative two-segment paths like 'subdir/model.pt' must not be misrouted to HF."""
     import shutil

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -74,6 +74,7 @@ def test_validate_model_yaml_blocks_untrusted():
         _validate_model_yaml(yaml_str)
 
 
+@pytest.mark.slow
 @pytest.mark.hf
 def test_load_from_hf_repo_local(fake_hf_repo):
     """Test loading model from a local directory mimicking HF repo structure."""
@@ -83,6 +84,7 @@ def test_load_from_hf_repo_local(fake_hf_repo):
     assert len(metadata["implemented_species"]) > 0
 
 
+@pytest.mark.slow
 @pytest.mark.hf
 def test_calculator_with_hf_repo(fake_hf_repo):
     """Test that AIMNet2Calculator accepts a local HF-style directory."""
@@ -144,6 +146,7 @@ def fake_hf_repo_with_family(tmp_path):
     return tmp_path
 
 
+@pytest.mark.slow
 @pytest.mark.hf
 def test_load_from_hf_repo_propagates_family_and_charge_fields(fake_hf_repo_with_family):
     _, metadata = load_from_hf_repo(str(fake_hf_repo_with_family), ensemble_member=0, device="cpu")

--- a/tests/test_hvp.py
+++ b/tests/test_hvp.py
@@ -54,6 +54,7 @@ def _coulomb_state(calc):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("method", ["simple", "dsf"])
 def test_hvp_matches_dense_nonperiodic(method):
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=(method != "simple"))
@@ -72,6 +73,7 @@ def test_hvp_matches_dense_nonperiodic(method):
     torch.testing.assert_close(hv.double().cpu(), ref.cpu(), rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("method", ["ewald", "pme"])
 def test_hvp_matches_dense_periodic(method):
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
@@ -90,6 +92,7 @@ def test_hvp_matches_dense_periodic(method):
     torch.testing.assert_close(hv.double().cpu(), ref.cpu(), rtol=5e-2, atol=5e-3)
 
 
+@pytest.mark.slow
 def test_hvp_multiple_vectors_shape():
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
     calc.external_dftd3 = None
@@ -130,6 +133,7 @@ def test_hvp_wrong_vector_shape_raises():
         calc.hessian_vector_product(data, torch.zeros(5, 3))  # wrong N
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("method", ["simple", "ewald"])
 def test_hvp_matches_dense_with_dftd3(method):
     """HVP must include DFTD3 curvature (regression for dropped-D3 bug)."""
@@ -172,6 +176,7 @@ def test_hvp_validates_unsupported_element():
     calc.hessian_vector_product(data, v, validate_species=False)
 
 
+@pytest.mark.slow
 def test_hvp_periodic_returns_float64():
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
     calc.external_dftd3 = None
@@ -204,6 +209,7 @@ def test_hvp_pbc_auto_switch_restores_full_coulomb_state():
     assert _coulomb_state(calc) == before
 
 
+@pytest.mark.slow
 def test_batched_hessian_pbc_auto_switch_restores_full_coulomb_state():
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0, needs_coulomb=True)
     calc.external_dftd3 = None
@@ -227,6 +233,7 @@ def test_batched_hessian_pbc_auto_switch_restores_full_coulomb_state():
     assert _coulomb_state(calc) == before
 
 
+@pytest.mark.slow
 def test_hvp_create_graph_contract():
     calc = AIMNet2Calculator("aimnet2", nb_threshold=0)
     calc.external_dftd3 = None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,11 +39,13 @@ def test_validate_state_dict_keys_ignores_legacy_dipole_mass_buffers():
     assert real_unexpected == ["outputs.energy_mlp.mlp.0.weight"]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("model_def", model_defs)
 def test_model_from_yaml(model_def):
     build_model(model_def)
 
 
+@pytest.mark.slow
 @pytest.mark.ase
 def test_aimnet2():
     """Test building model from YAML and loading weights from zoo model.
@@ -94,6 +96,7 @@ def test_aimnet2():
 class TestFromFile:
     """Tests for load_model() model loading."""
 
+    @pytest.mark.slow
     def test_from_file_returns_module(self):
         """Test that loading model returns nn.Module."""
         p = get_model_path("aimnet2")
@@ -102,6 +105,7 @@ class TestFromFile:
         # Should return an nn.Module
         assert isinstance(model, nn.Module)
 
+    @pytest.mark.slow
     def test_from_file_preserves_rxn_atomic_shift_precision(self, tmp_path):
         """load_model must preserve float64 rxn SAE values from the state dict."""
         from pathlib import Path
@@ -153,6 +157,7 @@ class TestFromFile:
         torch.testing.assert_close(actual[species, 0], expected, rtol=0.0, atol=0.0)
         assert metadata["family"] == "rxn"
 
+    @pytest.mark.slow
     def test_from_file_metadata(self):
         """Test that model returns correct metadata."""
         p = get_model_path("aimnet2")
@@ -199,6 +204,7 @@ class TestFromFile:
         assert abs(d3["a1"] - 0.566) < 0.001
         assert abs(d3["a2"] - 3.128) < 0.001
 
+    @pytest.mark.slow
     def test_from_file_legacy_jit_extracts_species(self):
         """Test that implemented species are extracted from legacy JIT model."""
         p = get_model_path("aimnet2")
@@ -213,6 +219,7 @@ class TestFromFile:
         assert 7 in species  # N
         assert 8 in species  # O
 
+    @pytest.mark.slow
     def test_from_file_model_inference(self):
         """Test that load_model returns working model with correct metadata.
 
@@ -294,6 +301,7 @@ class TestNewFormat:
         torch.save(new_format, model_path)
         return str(model_path)
 
+    @pytest.mark.slow
     def test_from_file_new_format_loads(self, new_format_model):
         """Test that new format model loads correctly."""
         model, _metadata = load_model(new_format_model, device="cpu")
@@ -302,6 +310,7 @@ class TestNewFormat:
         assert isinstance(model, nn.Module)
         assert not isinstance(model, torch.jit.ScriptModule)
 
+    @pytest.mark.slow
     def test_from_file_new_format_metadata(self, new_format_model):
         """Test that new format model returns correct metadata."""
         _, metadata = load_model(new_format_model, device="cpu")
@@ -317,6 +326,7 @@ class TestNewFormat:
         assert metadata["d3_params"] is not None
         assert metadata["implemented_species"] == [1, 6, 7, 8, 9, 16, 17]
 
+    @pytest.mark.slow
     def test_from_file_new_format_d3_params(self, new_format_model):
         """Test that D3 parameters are correctly returned in metadata."""
         _, metadata = load_model(new_format_model, device="cpu")
@@ -327,6 +337,7 @@ class TestNewFormat:
         assert abs(d3["a1"] - 0.566) < 0.001
         assert abs(d3["a2"] - 3.128) < 0.001
 
+    @pytest.mark.slow
     def test_calculator_attaches_external_coulomb(self, new_format_model):
         """Test that calculator attaches external LRCoulomb for new format models."""
         from aimnet.calculators import AIMNet2Calculator
@@ -338,6 +349,7 @@ class TestNewFormat:
         assert calc.external_coulomb.method == "simple"
         assert calc.external_coulomb.subtract_sr is False
 
+    @pytest.mark.slow
     def test_calculator_attaches_external_dftd3(self, new_format_model):
         """Test that calculator attaches external DFTD3 for new format models."""
         from aimnet.calculators import AIMNet2Calculator
@@ -348,6 +360,7 @@ class TestNewFormat:
         assert calc.external_dftd3 is not None
         assert abs(calc.external_dftd3.s8 - 0.3908) < 0.001
 
+    @pytest.mark.slow
     def test_set_dftd3_cutoff_method(self, new_format_model):
         """Test set_dftd3_cutoff() method on calculator."""
         from aimnet.calculators import AIMNet2Calculator
@@ -396,6 +409,7 @@ class TestNewFormat:
         torch.save(new_format, model_path)
         return str(model_path)
 
+    @pytest.mark.slow
     def test_calculator_no_external_modules_when_not_needed(self, new_format_no_coulomb):
         """Test that calculator doesn't attach external modules when not needed."""
         from aimnet.calculators import AIMNet2Calculator
@@ -433,6 +447,7 @@ class TestNewFormat:
         assert "energy" in result
         assert result["energy"].shape == (1,)
 
+    @pytest.mark.slow
     def test_export_load_roundtrip(self, tmp_path):
         """Test export -> load -> inference produces valid results.
 
@@ -586,6 +601,7 @@ def test_model_metadata_typeddict_includes_family_and_charge_fields():
     assert "supports_charged_systems" in hints, "ModelMetadata missing 'supports_charged_systems' field"
 
 
+@pytest.mark.slow
 def test_load_model_propagates_family_and_charge_fields(tmp_path):
     """load_model must include family/supports_charged_systems in metadata when present in .pt."""
     import torch
@@ -607,6 +623,7 @@ def test_load_model_propagates_family_and_charge_fields(tmp_path):
     assert metadata.get("supports_charged_systems") is False
 
 
+@pytest.mark.slow
 def test_load_v1_model_species_override_nan_pads_other_rows():
     """load_v1_model with implemented_species override must NaN-pad AFV rows
     for elements outside the supported set, write family/supports_charged_systems
@@ -652,6 +669,7 @@ def test_load_v1_model_species_override_nan_pads_other_rows():
     assert model.outputs.atomic_shift.shifts.weight.dtype == torch.float64
 
 
+@pytest.mark.slow
 def test_load_v1_model_without_overrides_is_backward_compatible():
     """Existing four families' conversions must still work when the new kwargs are omitted."""
     from pathlib import Path
@@ -672,6 +690,7 @@ def test_load_v1_model_without_overrides_is_backward_compatible():
     assert metadata.get("supports_charged_systems") is None
 
 
+@pytest.mark.slow
 def test_aimnet2_rxn_yaml_builds():
     """The architecture YAML for aimnet2-rxn must be loadable and produce a real AIMNet2 module."""
     import importlib.resources


### PR DESCRIPTION
Marks ~60 test nodes (each >=2 s serial on CPU) with the existing `slow` marker, cutting the default run (`pytest -m "not gpu and not network and not slow"`) from ~9 min to **1:53** serial. The marked tail (torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) still passes: 63 tests in 6:31 via `-m slow`.

Kept in the default set deliberately: the cheapest representative of each critical path — dense Hessian, HVP correctness, legacy `.jpt` loading, and a torch.compile smoke test — so no public API path loses default coverage entirely.

Two things reviewers should weigh in on:

1. **All CI lanes deselect `slow`**, so the newly marked tests now run in no lane. Proposal (not implemented here): a nightly or weekly `-m slow` lane.
2. **`make test` uses `pytest -n auto` with GPU auto-detection** — on a CUDA box the xdist workers each initialize CUDA and can OOM the device (reproduced locally: 185 failures, all `torch.OutOfMemoryError`). Worth forcing `CUDA_VISIBLE_DEVICES=""` in `make test` or serializing GPU tests; happy to do that in a follow-up.

Note: this branch and #91 both add an `[Unreleased]` CHANGELOG section; whichever merges second needs a one-line conflict resolution combining them.