### PR TITLE
test: cover dark branches; fix cv_split fold corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `DataGroup.cv_split` corrupting cross-validation folds: building each fold's train split mutated the shared parts in place via `cat()`, so later folds contained duplicated samples and validation splits larger than the dataset. Folds are now built without mutating the shared parts.
+
+### Added
+
+- Added targeted unit tests for previously untested code: `RegMultiMetric`/`regression_stats`, the `aimnet export` helper functions (`load_sae`, `bake_sae_into_model`, `mask_not_implemented_species`), `SizeGroupedDataset.cv_split`/`concatenate`, `train.utils` config/parameter helpers, and `LRCoulomb` constructor validation.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/aimnet/data/sgdataset.py
+++ b/aimnet/data/sgdataset.py
@@ -126,9 +126,10 @@ class DataGroup:
         splits = []
         for icv in range(cv):
             val = parts[icv]
-            _idx = [_i for _i in range(cv) if _i != icv]
-            train = parts[_idx[0]]
-            train.cat(*[parts[_i] for _i in _idx[1:]])
+            train_parts = [parts[_i] for _i in range(cv) if _i != icv]
+            # Build a fresh DataGroup: cat() mutates its receiver in place, which
+            # would corrupt the shared parts for the remaining folds.
+            train = self.__class__({k: np.concatenate([p[k] for p in train_parts], axis=0) for k in self.keys()})
             splits.append((train, val))
         return splits
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -197,6 +197,7 @@ def test_concatenate_gathers_all_groups():
     numbers = ds.concatenate("numbers")
     assert isinstance(numbers, np.ndarray)
 
+
 def test_save_h5_roundtrip(tmp_path):
     ds = dataset()
     out = tmp_path / "roundtrip.h5"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -180,3 +180,19 @@ def test_split_fractions():
     ds1, ds2 = ds.random_split(0.8, 0.2)
     assert len(ds1) + len(ds2) == len(ds)
     assert len(ds1) > len(ds2)
+
+
+def test_cv_split_partitions_dataset():
+    ds = dataset()
+    folds = ds.cv_split(cv=3, seed=0)
+    assert len(folds) == 3
+    for train, val in folds:
+        assert len(train) + len(val) == len(ds)
+
+
+def test_concatenate_gathers_all_groups():
+    import numpy as np
+
+    ds = dataset()
+    numbers = ds.concatenate("numbers")
+    assert isinstance(numbers, np.ndarray)

--- a/tests/test_lr.py
+++ b/tests/test_lr.py
@@ -1198,3 +1198,12 @@ class TestLRCoulombTraining:
 
         assert charges.grad is not None
         assert torch.isfinite(charges.grad).all()
+
+
+def test_lrcoulomb_rejects_unknown_method_and_envelope():
+    from aimnet.modules import LRCoulomb
+
+    with pytest.raises(ValueError, match="Unknown method"):
+        LRCoulomb(method="not-a-method")
+    with pytest.raises(ValueError, match="Unknown envelope"):
+        LRCoulomb(envelope="not-an-envelope")

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -37,3 +37,103 @@ def test_state_dict_roundtrip_weights_only(tmp_path):
     loaded = torch.load(p, map_location="cpu", weights_only=True)
     assert set(loaded) == {"w", "b"}
     torch.testing.assert_close(loaded["w"], sd["w"])
+
+
+def test_regression_stats_and_metric_compute():
+    torch = pytest.importorskip("torch")
+    import numpy as np
+
+    from aimnet.train.metrics import RegMultiMetric, regression_stats
+
+    pred = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    true = torch.tensor([1.5, 2.0, 2.5, 5.0])
+    stats = regression_stats(pred, true)
+    err = (true - pred).numpy()
+    assert np.isclose(stats["mae"].item(), np.abs(err).mean())
+    assert np.isclose(stats["rmse"].item(), np.sqrt((err**2).mean()))
+
+    cfg = {"energy": {"abbr": "E", "peratom": False}}
+    metric = RegMultiMetric(cfg)
+    metric.reset()
+    # Four samples with one energy each: E_mae = sum|err| / n_samples.
+    y_pred = {
+        "energy": pred,
+        "_natom": torch.tensor([2.0, 2.0, 2.0, 2.0]),
+        "numbers": torch.tensor([[1, 8]] * 4),
+    }
+    y_true = {"energy": true}
+    metric.update((y_pred, y_true))
+    result = metric.compute()
+    assert np.isclose(result["E_mae"], np.abs(err).mean())
+    assert np.isclose(result["E_rmse"], np.sqrt((err**2).mean()))
+
+
+def test_reg_multi_metric_raises_when_empty():
+    pytest.importorskip("torch")
+    from ignite.exceptions import NotComputableError
+
+    from aimnet.train.metrics import RegMultiMetric
+
+    metric = RegMultiMetric({})
+    metric.reset()
+    with pytest.raises(NotComputableError):
+        metric.compute()
+
+
+def test_export_model_helpers(tmp_path):
+    torch = pytest.importorskip("torch")
+    from torch import nn
+
+    from aimnet.train.export_model import (
+        bake_sae_into_model,
+        get_implemented_species,
+        load_sae,
+        mask_not_implemented_species,
+    )
+
+    sae_file = tmp_path / "sae.yaml"
+    sae_file.write_text("1: -0.5\n8: -75.0\n")
+    sae = load_sae(str(sae_file))
+    assert sae == {1: -0.5, 8: -75.0}
+    assert get_implemented_species(sae) == [1, 8]
+
+    bad_file = tmp_path / "bad.yaml"
+    bad_file.write_text("- 1\n- 2\n")
+    with pytest.raises(TypeError, match="dictionary"):
+        load_sae(str(bad_file))
+
+    class Shifts(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.shifts = nn.Embedding(10, 1)
+            nn.init.zeros_(self.shifts.weight)
+
+    model = nn.Module()
+    model.outputs = nn.Module()
+    model.outputs.atomic_shift = Shifts()
+    model.afv = nn.Embedding(10, 4)
+    model = bake_sae_into_model(model, sae)
+    assert model.outputs.atomic_shift.shifts.weight.dtype == torch.float64
+    assert model.outputs.atomic_shift.shifts.weight[8, 0].item() == -75.0
+    model = mask_not_implemented_species(model, [1, 8])
+    assert torch.isnan(model.afv.weight[2]).all()
+    assert not torch.isnan(model.afv.weight[1]).any()
+
+
+def test_train_utils_param_helpers():
+    torch = pytest.importorskip("torch")
+    OmegaConf = pytest.importorskip("omegaconf").OmegaConf
+
+    from aimnet.modules import Forces
+    from aimnet.train.utils import _to_config_dict, set_trainable_parameters, unwrap_module
+
+    with pytest.raises(TypeError, match="dictionary"):
+        _to_config_dict(OmegaConf.create([1, 2]), "Broken")
+
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.Linear(2, 2))
+    model = set_trainable_parameters(model, force_train=["0\\."], force_no_train=["1\\."])
+    assert all(p.requires_grad for p in model[0].parameters())
+    assert not any(p.requires_grad for p in model[1].parameters())
+
+    inner = torch.nn.Linear(2, 2)
+    assert unwrap_module(Forces(inner)) is inner

--- a/tests/test_train_utils.py
+++ b/tests/test_train_utils.py
@@ -138,6 +138,7 @@ def test_train_utils_param_helpers():
     inner = torch.nn.Linear(2, 2)
     assert unwrap_module(Forces(inner)) is inner
 
+
 def test_mse_loss_fn_matches_torch_mse():
     torch = pytest.importorskip("torch")
     from aimnet.train.loss import mse_loss_fn


### PR DESCRIPTION
Coverage measurement (full local run incl. GPU and slow markers: 65.3% lines, 800 missing branches) ranked the training stack as the darkest area (metrics.py 10%, export_model.py 0%, train/utils.py 16%). This adds seven targeted tests for the top unit-testable gaps: RegMultiMetric/regression_stats, the aimnet-export helper layer, SizeGroupedDataset.cv_split/concatenate, train.utils config/parameter helpers, and LRCoulomb constructor validation.

Writing the cv_split test surfaced a real bug, fixed here: DataGroup.cv_split built each fold's train split by cat()-ing shared parts **in place**, corrupting the parts used by subsequent folds — later folds contained duplicated samples and validation splits larger than the whole dataset (e.g. 3-fold on 195 samples produced a 260-sample val fold). Folds are now assembled without mutating the shared parts.

Gate: full CPU suite 486 passed, ruff/format clean.