### PR TITLE
docs: document rxn dipole origin convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Documented the rxn dipole origin convention: `center_coord=False` is origin-safe because the family is net-neutral-only; any future charged-system family must ship `center_coord=True`.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/docs/models/aimnet2_rxn.md
+++ b/docs/models/aimnet2_rxn.md
@@ -35,6 +35,12 @@ Runtime corrections and safeguards fire regardless of `validate_species`:
 
 A separate one-time `UserWarning` fires if the same Python process constructs calculators from two different AIMNet2 families (rxn vs. wb97m-d3 etc.), because their absolute energy scales are not comparable.
 
+## Dipole origin convention
+
+The rxn models compute dipole and quadrupole outputs with `center_coord=False`, i.e. moments are taken about the laboratory-frame origin. This is origin-independent for every input the family accepts: the calculator rejects non-zero net charge (see above), and for net-neutral systems — including zwitterions — the dipole does not depend on the choice of origin. The released model YAML is intentionally left unchanged, since editing it would alter the published model artifacts.
+
+The invariant to preserve going forward: any future model family that supports net-charged systems must ship its `Dipole`/`Quadrupole` outputs with `center_coord=True` (center-of-mass origin), because for charged systems the laboratory-frame moment is origin-dependent. The only bypass of the neutrality check is `validate_species=False`, which is unsupported for production use.
+
 ## Canonical model card
 
 Full content (energy convention, training data details, full limitations list, citation) lives at the Hugging Face model card:


### PR DESCRIPTION
Resolves the deferred rxn dipole-origin question. The released rxn YAML computes dipole/quadrupole with center_coord=False (laboratory-frame origin), which is origin-independent for every reachable input because the calculator hard-rejects net-charged systems for this family; neutral-system moments (zwitterions included) do not depend on origin choice. The YAML stays unchanged — editing it would alter published model artifacts. The documented invariant going forward: any future family that supports charged systems must ship center_coord=True. Docs build clean (make docs-test).