### PR TITLE
chore: bump nvalchemi-toolkit-ops to 0.4.0 and warp-lang to 1.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Bumped `nvalchemi-toolkit-ops` to `>=0.4.0` and `warp-lang` to `>=1.13,<2` (installs 1.15). Energies, charges, and Hessians are bit-identical to 0.3.1; explicit force/virial outputs shift within float32 accumulation noise (max 6.7e-05 eV/A on a periodic system, 40x inside the project's cross-version acceptance of 1e-4 Hartree/A). The 0.4.0 direct-output flags used by the Ewald/PME path (`compute_forces`/`compute_virial`) are deprecated upstream and now emit `DeprecationWarning`; migrating to the autograd-based API is tracked as follow-up work.
+
 - Marked the expensive tail of the test suite (~60 test nodes ≥2 s each: torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) with the `slow` marker; the default CPU test run now completes in under two minutes. Run `pytest -m slow` for the marked tail. The cheapest representative of each critical path (dense Hessian, HVP correctness, legacy `.jpt` loading, torch.compile smoke) stays in the default set.
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dynamic = ["version"]
 dependencies = [
     "torch>=2.8",
     "numpy",
-    "warp-lang>=1.11,<2",
-    "nvalchemi-toolkit-ops>=0.3.1",
+    "warp-lang>=1.13,<2",
+    "nvalchemi-toolkit-ops>=0.4.0",
     "requests>=2.32.3",
     "click>=8.1.7",
     "pyyaml>=6.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=0.20" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "numpy" },
-    { name = "nvalchemi-toolkit-ops", specifier = ">=0.3.1" },
+    { name = "nvalchemi-toolkit-ops", specifier = ">=0.4.0" },
     { name = "omegaconf", marker = "extra == 'train'", specifier = ">=2.3.0" },
     { name = "pysisyphus", marker = "extra == 'pysis'", specifier = ">=1.0.0" },
     { name = "pytorch-ignite", marker = "extra == 'train'", specifier = ">=0.5.1" },
@@ -95,7 +95,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.8" },
     { name = "torch-sim-atomistic", marker = "python_full_version >= '3.12' and extra == 'torchsim'", specifier = ">=0.6.0,<0.7.0" },
     { name = "wandb", marker = "extra == 'train'", specifier = ">=0.18.5" },
-    { name = "warp-lang", specifier = ">=1.11,<2" },
+    { name = "warp-lang", specifier = ">=1.13,<2" },
 ]
 provides-extras = ["ase", "hf", "pysis", "sella", "torchsim", "train"]
 
@@ -2422,7 +2422,7 @@ wheels = [
 
 [[package]]
 name = "nvalchemi-toolkit-ops"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
@@ -2430,7 +2430,7 @@ dependencies = [
     { name = "warp-lang" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/44/7c7e8d52460755918810a1486c08ed4cc7bb810c9fbc186f8e2e02c0b856/nvalchemi_toolkit_ops-0.3.1-py3-none-any.whl", hash = "sha256:1c0f37c0a798c81d0a7d617591968d71f4187ba3c32515db16d2efa712edb4e7", size = 464233, upload-time = "2026-04-14T09:26:07.706Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ff/d0b5333356a9a3efda851ffb23820b874b05fbe1caabaa6fad3c4005bda6/nvalchemi_toolkit_ops-0.4.0-py3-none-any.whl", hash = "sha256:f245c393c210a78160eab783d01c3d2d7fda54014bad1885c4210ced8000a3f7", size = 1254925, upload-time = "2026-07-13T18:03:52.887Z" },
 ]
 
 [package.optional-dependencies]
@@ -3949,17 +3949,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.0"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/0e/aa6c2a57d987d18d6463a30a358f5454599ae5d03bbfe889a6330e0b9931/warp_lang-1.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a4f1c9a6e721d7de7d6dad6b242c54afaf20c6e14a767c0da03e5e963fcc13c", size = 24025392, upload-time = "2026-01-02T13:18:13.517Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/56/935b926526075149fdf8851e7593ea63880458c5303798852d9c99c30382/warp_lang-1.11.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:524dce20de6162ba25333552168ebf430973050e00d9f8116b8df41a60d25d6e", size = 134812535, upload-time = "2026-01-02T13:13:23.908Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b7/8915e42cb10bbe7d2ff1b32554b52d4c90234119aab4de48476ebf700147/warp_lang-1.11.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:1ae6cfc226107f96e4d495b41a3dab32488e8ee8f074b0e1bcaf22e7fb8c904d", size = 136105356, upload-time = "2026-01-02T13:15:37.795Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/cc/6261315e43fa879d30b1bd79904ce8075a8a7d42fc49dd235de337f2ac02/warp_lang-1.11.0-py3-none-win_amd64.whl", hash = "sha256:80d8493cbe243a3510134f3af289646d7bd7484217a30ecf565d676466ef8a5e", size = 118919958, upload-time = "2026-01-02T13:17:20.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a2/712bcea055b80135e20a7a142f5dc1fa617bf3b5557dd4cc3afcc1048ab4/warp_lang-1.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ee06e2e76bff84088a09e64315e71ed0e55e94c936ec664d7b05ebd56f66a363", size = 25048790, upload-time = "2026-07-07T22:26:18.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ba/36023c3161c45f1c509c20c501b17980705fdd3b6c20b7ee9267f50f44a2/warp_lang-1.15.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:95c169f28bd7d6c78ac4ad62e2df1e61a096033748f757157fa4551aed80d010", size = 166711381, upload-time = "2026-07-07T22:26:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/2c06013209ad4edb1f9e52692d43738b4945fceaa6acc30f34e2d25fc087/warp_lang-1.15.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3c0711b39ad98ff924d29654b028ec4eaa02330e207ae3efc72445e9cde05b34", size = 171756145, upload-time = "2026-07-07T22:28:07.427Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/00/4de2563f88c882e6621349654cee770ce5ae86c8113b63c09bd8aa3e5274/warp_lang-1.15.0-py3-none-win_amd64.whl", hash = "sha256:06ef42c3ce522749268056653ea253645eb4a96ca164af74ae5113f0d55a6970", size = 149948459, upload-time = "2026-07-07T22:28:32.767Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps nvalchemi-toolkit-ops 0.3.1 -> 0.4.0 (warp-lang 1.11 -> 1.15, required >=1.13 by upstream).

Verification on an L40S box:
- All aimnet-used imports intact (neighbors, NeighborOverflowError, dispersion.dftd3, electrostatics).
- Default CPU suite 435 passed / 0 skipped; GPU marker suite 116 passed; full PBC suite 56 passed; kernel-registration and conv_sv_2d_sp suites green on warp 1.15.
- Cross-version numerics vs 0.3.1: energies, charges, and Hessians bit-identical; explicit force/virial outputs shift by at most 6.7e-05 eV/A (periodic DSF+D3 case) — 40x inside the project's own cross-version acceptance (compare_observables force_atol = 1e-4 Hartree/A). Consistent with upstream's rework of the direct-output force paths.

Two observations for follow-up:
1. Upstream deprecated the direct-output flags (compute_forces/compute_virial) that aimnet's Ewald/PME path passes; they still work but now emit DeprecationWarnings (thousands per PBC test run). Migrating to the autograd-based API should be its own PR.
2. Issue #93 note: under 0.4.0 the batched nondeterminism (~1e-7 eV) now also appears at B=2 (previously bitwise-stable below B=4). Same noise floor, slightly wider surface.