### PR TITLE
chore: harden make test against GPU OOM and CPU thread oversubscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,14 @@ check: ## Run code quality tools.
 	@uv run deptry .
 
 .PHONY: test
-test: ## Test the code with pytest (parallel execution)
+test: ## Test the code with pytest (parallel CPU execution)
 	@echo "🚀 Testing code: Running pytest"
-	@uv run pytest -n auto -m "not gpu and not network" --cov --cov-config=pyproject.toml --cov-report=xml
+	@CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1 uv run pytest -n auto -m "not gpu and not network" --cov --cov-config=pyproject.toml --cov-report=xml
+
+.PHONY: test-gpu
+test-gpu: ## Run GPU-marked tests serially on CUDA
+	@echo "🚀 Testing code: Running GPU-marked pytest serially"
+	@uv run pytest -m gpu
 
 .PHONY: gpu-validate
 gpu-validate: ## Validate torch/warp-lang/nvalchemiops coupling across torch 2.8-2.12 on a CUDA box


### PR DESCRIPTION
Two measured failure modes of `pytest -n auto` on this codebase: on a CUDA box every xdist worker auto-selects cuda:0 and stacks models onto it until OOM (reproduced: 185 failures, all torch.OutOfMemoryError); with CUDA hidden, each worker spawns a full torch thread pool and a 3-file run took 92 minutes of wall time from core thrashing.

Fix: `make test` now runs with `CUDA_VISIBLE_DEVICES="" OMP_NUM_THREADS=1` — measured full parallel CPU suite: 434 passed in 2:44 (52 min of user time spread across cores). A new `make test-gpu` target runs the gpu-marked tests serially with CUDA visible, which is the fastest safe configuration measured for them.