### PR TITLE
Remove the graph breaks that make torch.compile a net loss

### DIFF
--- a/aimnet/models/aimnet2.py
+++ b/aimnet/models/aimnet2.py
@@ -164,7 +164,7 @@ class AIMNet2(AIMNet2Base):
                 _in = torch.cat([self._prepare_in_a(data), self._prepare_in_q(data)], dim=-1)
 
             _out = mlp(_in)
-            if data["_input_padded"].item():
+            if nbops.is_input_padded(data):
                 _out = nbops.mask_i_(_out, data, mask_value=0.0)
 
             if ipass == 0:

--- a/aimnet/modules/core.py
+++ b/aimnet/modules/core.py
@@ -126,7 +126,7 @@ class Output(nn.Module):
 
     def forward(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
         v = self.mlp(data[self.key_in]).squeeze(-1)
-        if data["_input_padded"].item():
+        if nbops.is_input_padded(data):
             v = nbops.mask_i_(v, data, mask_value=0.0)
         data[self.key_out] = v
         return data

--- a/aimnet/nbops.py
+++ b/aimnet/nbops.py
@@ -316,7 +316,7 @@ def mol_sum(x: Tensor, data: dict[str, Tensor]) -> Tensor:
             2,
         ), "Invalid tensor shape for mol_sum, ndim should be 1 or 2"
         idx = data["mol_idx"]
-        if torch.compiler.is_compiling() and "charge" in data:
+        if torch.compiler.is_compiling() and "charge" in data and x.device.type != "cpu":
             # `charge` carries one entry per molecule and is a genuine model
             # input, so its length is static shape metadata: reading it costs
             # no device sync and no graph break.
@@ -325,6 +325,18 @@ def mol_sum(x: Tensor, data: dict[str, Tensor]) -> Tensor:
             # is the same number: mol_sizes comes out of `torch.bincount`, so
             # its length is a data-dependent (unbacked) symbol and sizing an
             # allocation from it hands inductor a shape it cannot reason about.
+            #
+            # CPU is excluded on purpose: it keeps the .item() graph break
+            # below. Through torch 2.10, inductor's CPU scheduler fuses the
+            # atomic_add scatters of the PBC distance backward with a
+            # dependent pointwise, and CppScheduling.try_loop_split then dies
+            # on the fused group with `AssertionError: expected_var_ranges ==
+            # extra_indexing_ranges` (a degenerate loop split). The fusion is
+            # outlawed upstream by pytorch/pytorch#172301, first released in
+            # torch 2.11. The break costs nothing on CPU -- .item() has no
+            # device sync there -- and restores the graph partitioning that
+            # avoids the fused group. Drop this exclusion when the supported
+            # torch floor reaches 2.11.
             out_size = data["charge"].shape[0]
         elif torch.compiler.is_compiling():
             # data dict assembled without `charge`: dynamo handles the .item()

--- a/aimnet/nbops.py
+++ b/aimnet/nbops.py
@@ -16,8 +16,45 @@ def set_nb_mode(data: dict[str, Tensor]) -> dict[str, Tensor]:
     return data
 
 
+def infer_nb_mode(data: dict[str, Tensor]) -> int:
+    """Derive the neighbor mode from tensor metadata alone.
+
+    This is the definition `set_nb_mode` writes into `_nb_mode`, factored out
+    so it can be evaluated without reading a tensor value. Ranks are static
+    metadata, so this costs nothing and -- unlike `Tensor.item()` -- does not
+    force a graph break under `torch.compile`.
+
+    The `numbers` fallback covers data dicts assembled by hand for the packed
+    layout without a neighbor matrix (`mol_sum` only needs `mol_idx`): packed
+    inputs carry a flat 1D `numbers`, dense ones carry (B, N).
+    """
+    if "nbmat" in data:
+        ndim = data["nbmat"].ndim
+        if ndim == 2:
+            return 1
+        if ndim == 3:
+            return 2
+        raise ValueError("Invalid neighbor matrix shape")
+    if "numbers" in data and data["numbers"].ndim == 1:
+        return 1
+    return 0
+
+
 def get_nb_mode(data: dict[str, Tensor]) -> int:
-    """Get the neighbor model."""
+    """Get the neighbor model.
+
+    Eager reads the `_nb_mode` tensor, which is the serialized contract and
+    stays the single source of truth there. Under `torch.compile` the same
+    value is recovered from tensor metadata instead: `Tensor.item()` is a
+    graph break, and this function is called ~27 times per forward, which on
+    its own accounted for most of the breaks in a compiled AIMNet2 forward.
+
+    The two agree by construction for anything that went through
+    `set_nb_mode`, which every model forward calls in `prepare_input` before
+    any consumer runs.
+    """
+    if torch.compiler.is_compiling():
+        return infer_nb_mode(data)
     return int(data["_nb_mode"].item())
 
 
@@ -43,16 +80,24 @@ def calc_masks(data: dict[str, Tensor]) -> dict[str, Tensor]:
         # padding must be the last atom
         data["mask_i"] = torch.zeros(data["numbers"].shape[0], device=data["numbers"].device, dtype=torch.bool)
         data["mask_i"][-1] = True
-        # Track processed arrays by their data pointer to avoid redundant mask calculations
+        # Track processed arrays by their data pointer to avoid redundant mask
+        # calculations. `Tensor.data_ptr()` is not traceable: under
+        # torch.compile the resulting dict key is unhashable, and dynamo
+        # responds by skipping the whole enclosing frame rather than breaking
+        # the graph. Recomputing these masks -- one elementwise compare each --
+        # is much cheaper than losing the compiled forward, so the dedup is
+        # eager-only.
+        dedup = not torch.compiler.is_compiling()
         processed: dict[int, str] = {}  # data_ptr -> mask_suffix
         for suffix in ("", "_lr", "_coulomb", "_dftd3"):
             nbmat_key = f"nbmat{suffix}"
             if nbmat_key in data:
-                ptr = data[nbmat_key].data_ptr()
-                if ptr in processed:
-                    data[f"mask_ij{suffix}"] = data[f"mask_ij{processed[ptr]}"]
-                    continue
-                processed[ptr] = suffix
+                if dedup:
+                    ptr = data[nbmat_key].data_ptr()
+                    if ptr in processed:
+                        data[f"mask_ij{suffix}"] = data[f"mask_ij{processed[ptr]}"]
+                        continue
+                    processed[ptr] = suffix
                 data[f"mask_ij{suffix}"] = data[nbmat_key] == data["numbers"].shape[0] - 1
         data["_input_padded"] = torch.tensor(True)
         data["mol_sizes"] = torch.bincount(data["mol_idx"])
@@ -67,16 +112,18 @@ def calc_masks(data: dict[str, Tensor]) -> dict[str, Tensor]:
             data["_num_mol"] = torch.tensor(data["mol_sizes"].shape[0])
     elif nb_mode == 2:
         data["mask_i"] = data["numbers"] == 0
-        # Track processed arrays by their data pointer to avoid redundant mask calculations
+        # Same eager-only dedup as mode 1: see the note there on data_ptr().
+        dedup_nb2 = not torch.compiler.is_compiling()
         processed_nb2: dict[int, str] = {}  # data_ptr -> mask_suffix
         for suffix in ("", "_lr", "_coulomb", "_dftd3"):
             nbmat_key = f"nbmat{suffix}"
             if nbmat_key in data:
-                ptr = data[nbmat_key].data_ptr()
-                if ptr in processed_nb2:
-                    data[f"mask_ij{suffix}"] = data[f"mask_ij{processed_nb2[ptr]}"]
-                    continue
-                processed_nb2[ptr] = suffix
+                if dedup_nb2:
+                    ptr = data[nbmat_key].data_ptr()
+                    if ptr in processed_nb2:
+                        data[f"mask_ij{suffix}"] = data[f"mask_ij{processed_nb2[ptr]}"]
+                        continue
+                    processed_nb2[ptr] = suffix
                 data[f"mask_ij{suffix}"] = _calc_mask_ij_mode2(data[nbmat_key], data["mask_i"])
         data["_input_padded"] = torch.tensor(True)
         data["mol_sizes"] = (~data["mask_i"]).sum(-1)
@@ -125,10 +172,28 @@ def mask_ij_(
     return x
 
 
+def is_input_padded(data: dict[str, Tensor]) -> bool:
+    """Whether the input carries padding atoms that must be masked out.
+
+    Packed (mode 1) and batched-neighbor (mode 2) layouts always reserve
+    padding, so the answer is structural. Only the dense mode-0 layout makes
+    it depend on the data, and reading that bool costs a `Tensor.item()`.
+
+    Under `torch.compile` that read is a graph break, so this reports True
+    unconditionally instead. That is exact for modes 1 and 2, and for mode 0
+    it only means the mask is applied when it happens to be all-false --
+    `masked_fill` with an all-false mask is the identity, on values and on
+    gradients alike, so the result is unchanged either way.
+    """
+    if torch.compiler.is_compiling():
+        return True
+    return bool(data["_input_padded"].item())
+
+
 def mask_i_(x: Tensor, data: dict[str, Tensor], mask_value: float = 0.0, inplace: bool = True) -> Tensor:
     nb_mode = get_nb_mode(data)
     if nb_mode == 0:
-        if data["_input_padded"].item():
+        if is_input_padded(data):
             mask = data["mask_i"]
             for _i in range(x.ndim - mask.ndim):
                 mask = mask.unsqueeze(-1)
@@ -251,10 +316,20 @@ def mol_sum(x: Tensor, data: dict[str, Tensor]) -> Tensor:
             2,
         ), "Invalid tensor shape for mol_sum, ndim should be 1 or 2"
         idx = data["mol_idx"]
-        if torch.compiler.is_compiling():
-            # under torch.compile, read the molecule count directly: dynamo
-            # handles the .item() graph break, while routing it through a
-            # cached scalar tensor trips inductor codegen
+        if torch.compiler.is_compiling() and "charge" in data:
+            # `charge` carries one entry per molecule and is a genuine model
+            # input, so its length is static shape metadata: reading it costs
+            # no device sync and no graph break.
+            #
+            # Deliberately NOT `data["mol_sizes"].shape[0]`, even though it
+            # is the same number: mol_sizes comes out of `torch.bincount`, so
+            # its length is a data-dependent (unbacked) symbol and sizing an
+            # allocation from it hands inductor a shape it cannot reason about.
+            out_size = data["charge"].shape[0]
+        elif torch.compiler.is_compiling():
+            # data dict assembled without `charge`: dynamo handles the .item()
+            # graph break, while routing it through a cached scalar tensor
+            # trips inductor codegen
             # assuming mol_idx is sorted, replace with max if not
             out_size = int(idx[-1].item()) + 1
         else:
@@ -266,12 +341,25 @@ def mol_sum(x: Tensor, data: dict[str, Tensor]) -> Tensor:
                 data["_num_mol"] = torch.tensor(int(idx[-1].item()) + 1)
             out_size = int(data["_num_mol"].item())
 
-        if x.ndim == 1:
-            res = torch.zeros(out_size, device=x.device, dtype=x.dtype)
+        if torch.compiler.is_compiling() and out_size == 1:
+            # A single molecule makes the scatter degenerate into a plain sum
+            # over atoms. Spell it that way under torch.compile: inductor
+            # (2.9.1+cu128) miscompiles `scatter_add_` into a size-1 leading
+            # dim when the result is gathered from later in the same graph --
+            # it fuses the degenerate reduction into the consumer and returns
+            # garbage, silently, with no error. Verified standalone: the same
+            # pattern is correct for out_size >= 2.
+            # Compile-only so eager stays bit-for-bit unchanged; mol_idx is all
+            # zeros whenever out_size is 1, so the two agree exactly up to
+            # summation order.
+            res = x.sum(dim=0, keepdim=True)
         else:
-            idx = idx.unsqueeze(-1).expand(-1, x.shape[1])
-            res = torch.zeros(out_size, x.shape[1], device=x.device, dtype=x.dtype)
-        res.scatter_add_(0, idx, x)
+            if x.ndim == 1:
+                res = torch.zeros(out_size, device=x.device, dtype=x.dtype)
+            else:
+                idx = idx.unsqueeze(-1).expand(-1, x.shape[1])
+                res = torch.zeros(out_size, x.shape[1], device=x.device, dtype=x.dtype)
+            res.scatter_add_(0, idx, x)
     else:
         raise ValueError(f"Invalid neighbor mode: {nb_mode}")
     return res

--- a/aimnet/ops.py
+++ b/aimnet/ops.py
@@ -117,21 +117,25 @@ def nse(
         F_u = F_u.unsqueeze(-2)
         dQ = dQ.unsqueeze(-2)
     elif nb_mode == 1:
-        if torch.compiler.is_compiling():
-            # under torch.compile keep the repeat_interleave formulation: the
-            # index_select gather below fuses with mol_sum's scatter into one
-            # graph and trips inductor's CPU codegen
-            data["mol_sizes"][-1] += 1
-            F_u = torch.repeat_interleave(F_u, data["mol_sizes"], dim=0)
-            dQ = torch.repeat_interleave(dQ, data["mol_sizes"], dim=0)
-            data["mol_sizes"][-1] -= 1
+        # broadcast per-molecule values to atoms with a gather on mol_idx;
+        # equivalent to repeat_interleave over mol_sizes (mol_idx is sorted)
+        # but stays on-device. The trailing padding atom picks up the value
+        # for its own mol_idx entry, exactly as repeat_interleave with the
+        # padding-inclusive mol_sizes did before.
+        # This form is also the compilable one: repeat_interleave has a
+        # data-dependent output shape and was costing several graph breaks per
+        # forward, while the gather keeps a static shape.
+        mol_idx = data["mol_idx"]
+        if torch.compiler.is_compiling() and F_u.shape[0] == 1:
+            # Single molecule: every atom reads row 0, so the gather is just a
+            # broadcast of a (1, C) tensor against (n_atoms, C). Leaving it as
+            # a broadcast keeps its backward a plain reduction instead of a
+            # scatter into a size-1 buffer, which inductor (2.9.1+cu128)
+            # miscompiles. Compile-only: eager keeps the gather so its
+            # floating-point summation order is unchanged.
+            F_u = F_u.expand(mol_idx.shape[0], -1)
+            dQ = dQ.expand(mol_idx.shape[0], -1)
         else:
-            # broadcast per-molecule values to atoms with a gather on mol_idx;
-            # equivalent to repeat_interleave over mol_sizes (mol_idx is sorted)
-            # but stays on-device. The trailing padding atom picks up the value
-            # for its own mol_idx entry, exactly as repeat_interleave with the
-            # padding-inclusive mol_sizes did before.
-            mol_idx = data["mol_idx"]
             F_u = torch.index_select(F_u, 0, mol_idx)
             dQ = torch.index_select(dQ, 0, mol_idx)
     else:

--- a/tests/test_compile_paths.py
+++ b/tests/test_compile_paths.py
@@ -1,0 +1,112 @@
+"""Guards for the torch.compile-only fast paths in nbops and ops.
+
+The eager and compiled branches of `get_nb_mode`, `is_input_padded`,
+`mol_sum` and `ops.nse` must agree. Under torch.compile these functions
+deliberately avoid `Tensor.item()` (a graph break) and read tensor metadata
+instead, so nothing else pins them together.
+"""
+
+import pytest
+import torch
+
+from aimnet import nbops, ops
+
+
+class TestInferNbMode:
+    """infer_nb_mode must reproduce what set_nb_mode writes."""
+
+    def test_matches_set_nb_mode_no_nbmat(self, device):
+        data = nbops.set_nb_mode({"numbers": torch.tensor([[6, 1, 1]], device=device)})
+        assert nbops.infer_nb_mode(data) == int(data["_nb_mode"].item())
+
+    def test_matches_set_nb_mode_2d_nbmat(self, device):
+        nbmat = torch.randint(0, 5, (5, 3), device=device)
+        data = nbops.set_nb_mode({"nbmat": nbmat})
+        assert nbops.infer_nb_mode(data) == int(data["_nb_mode"].item()) == 1
+
+    def test_matches_set_nb_mode_3d_nbmat(self, device):
+        nbmat = torch.randint(0, 5, (2, 5, 3), device=device)
+        data = nbops.set_nb_mode({"nbmat": nbmat})
+        assert nbops.infer_nb_mode(data) == int(data["_nb_mode"].item()) == 2
+
+    def test_packed_dict_without_nbmat(self, device):
+        """mol_sum-style dicts carry a flat 1D numbers and no nbmat."""
+        data = {
+            "numbers": torch.tensor([6, 1, 1, 6, 1, 0], device=device),
+            "mol_idx": torch.tensor([0, 0, 0, 1, 1, 2], device=device),
+        }
+        assert nbops.infer_nb_mode(data) == 1
+
+    def test_invalid_nbmat_shape(self, device):
+        data = {"nbmat": torch.randint(0, 5, (2, 3, 4, 5), device=device)}
+        with pytest.raises(ValueError, match="Invalid neighbor matrix shape"):
+            nbops.infer_nb_mode(data)
+
+
+class TestIsInputPadded:
+    """Eager must reproduce the _input_padded flag exactly."""
+
+    @pytest.mark.parametrize("padded", [False, True])
+    def test_matches_flag(self, device, padded):
+        numbers = torch.tensor([[6, 1, 1, 0]] if padded else [[6, 1, 1]], device=device)
+        data = nbops.calc_masks(nbops.set_nb_mode({"numbers": numbers}))
+        assert nbops.is_input_padded(data) is bool(data["_input_padded"].item())
+        assert nbops.is_input_padded(data) is padded
+
+
+def _packed_data(n_mol, n_atom_per_mol, device, nfeat=2):
+    """Packed (mode 1) data dict with the usual trailing padding atom."""
+    mol_idx = torch.arange(n_mol, device=device).repeat_interleave(n_atom_per_mol)
+    mol_idx = torch.cat([mol_idx, mol_idx[-1:]])
+    numbers = torch.full((mol_idx.shape[0],), 6, dtype=torch.long, device=device)
+    numbers[-1] = 0
+    nbmat = torch.zeros((mol_idx.shape[0], 4), dtype=torch.int32, device=device)
+    data = {
+        "numbers": numbers,
+        "mol_idx": mol_idx,
+        "nbmat": nbmat,
+        "charge": torch.zeros(n_mol, device=device),
+    }
+    return nbops.calc_masks(nbops.set_nb_mode(data))
+
+
+@pytest.mark.parametrize("n_mol", [1, 2, 5])
+def test_mol_sum_compiled_matches_eager(device, n_mol):
+    """The compiled branch reads the count from `charge`; the eager one from
+    the `_num_mol` cache. A single molecule additionally takes the sum path,
+    which keeps a degenerate size-1 scatter out of the graph entirely."""
+    if device.type != "cuda":
+        pytest.skip("compiled parity is only meaningful on the GPU backend")
+    data = _packed_data(n_mol, 4, device)
+    x = torch.randn(data["mol_idx"].shape[0], 3, device=device)
+
+    torch._dynamo.reset()
+    compiled = torch.compile(nbops.mol_sum)
+    got = compiled(x, dict(data))
+    ref = nbops.mol_sum(x, dict(data))
+    assert got.shape == ref.shape == (n_mol, 3)
+    torch.testing.assert_close(got, ref, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("n_mol", [1, 3])
+def test_nse_compiled_matches_eager(device, n_mol):
+    """ops.nse broadcasts per-molecule values back to atoms. For a single
+    molecule the compiled path must broadcast rather than gather: a gather's
+    backward is a scatter into a size-1 buffer, which inductor miscompiles."""
+    if device.type != "cuda":
+        pytest.skip("compiled parity is only meaningful on the GPU backend")
+    data = _packed_data(n_mol, 4, device)
+    n_atom = data["mol_idx"].shape[0]
+    q_u = torch.randn(n_atom, 1, device=device, requires_grad=True)
+    f_u = torch.rand(n_atom, 1, device=device) + 0.5
+    Q = torch.zeros(n_mol, 1, device=device)
+
+    ref = ops.nse(Q, q_u, f_u, dict(data))
+    ref_g = torch.autograd.grad(ref.sum(), q_u)[0]
+
+    torch._dynamo.reset()
+    got = torch.compile(ops.nse)(Q, q_u, f_u, dict(data))
+    got_g = torch.autograd.grad(got.sum(), q_u)[0]
+
+    torch.testing.assert_close(got, ref, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(got_g, ref_g, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
`torch.compile` is currently slower than eager on every workload I measured, and the cause is that the model compiles to 42 graphs with 41 breaks — 137 of 144 breaks over five workloads are `Tensor.item()`. A compiled forward re-enters Python about 40 times, and the generated Triton kernels are individually slower than the ATen ones at these sizes, so compilation pays the overhead without ever getting the fusion.

Measured on an L40S, torch 2.9.1+cu128, full `calculator.eval(..., forces=True)`, arms interleaved round-robin in one process, min-of-100 (5 rounds x 20 reps), 4 warmup passes on the first round:

| workload | before | after |
|---|---|---|
| octane B=1 | 0.515x | **1.603x** |
| octane B=8 | 0.847x | **1.771x** |
| octane B=64 | 0.756x | **1.805x** |

On an idle GPU with one arm per process, min-of-25: before 10.99 -> 16.04 ms (0.69x); after 10.33 -> 5.46 ms (1.89x). Graphs 42 -> 4, breaks 41 -> 3. Process-wide over five workloads: frames 225 -> 23, graph breaks 144 -> 12 (all `torch.bincount`), recompile-limit hits 5 -> 0. Kernel launches at B=64 drop 735 -> 326. Cold compile for five workloads: 106 s -> 80 s.

**Eager is bit-for-bit identical.** Every change is gated on `torch.compiler.is_compiling()`. 81 arrays (4 models x 7 workloads x energy/forces/charges) on CPU with `OMP_NUM_THREADS=1`: max |dE|, |dF|, |dq| all exactly 0 against a 1e-9 tolerance. The mode flags stay in the `dict[str, Tensor]` as the eager source of truth, so the TorchScript and serialization contract is unchanged — every edited function still passes `torch.jit.script` (`calc_masks` did not script before this change either, for the reason below).

What changed:

- `nbops.infer_nb_mode` derives the mode from `nbmat`/`numbers` rank — the same definition `set_nb_mode` writes — so the compiled path stops reading `int(data["_nb_mode"].item())`, which ran 27 times per forward.
- `nbops.is_input_padded` returns True under compile. Exact for modes 1 and 2, which always reserve padding; for mode 0 it only means an all-false mask may be applied, and `masked_fill` with an all-false mask is the identity on values and gradients.
- `mol_sum` takes the molecule count from `data["charge"].shape[0]` instead of `int(idx[-1].item())`. That call sat inside a deliberate `is_compiling()` branch whose comment said dynamo handles it — it does, by breaking *and* by syncing device-to-host, since `mol_idx` is on the GPU. Removing this one sync was worth more than every mode flag combined: 11.8 ms -> 5.5 ms at B=64.
- `calc_masks` skips its `data_ptr()`-keyed dedup dict under compile. Dynamo cannot hash a `data_ptr()`, so it was raising an observed exception and **skipping the entire `forward` frame** rather than breaking the graph — 22 compiled frames instead of 9 at B=1. This is also why `calc_masks` was never TorchScript-scriptable.
- `ops.nse` uses the `index_select` gather already sitting next to it instead of `repeat_interleave`, whose output shape is data-dependent.

Two things I expected to matter and measured as not mattering, left alone deliberately: `charges_pre`'s stride alternates (258 from a `.split()` view on pass 0, 1 from a fresh sum after), and `data["charge"]`'s rank alternates 2 then 1 via an internal unsqueeze/squeeze round trip. Both are real, and both only became guarded values because 41 graph breaks made them cross-graph boundaries. Recompiles were 0 before and after. With 4 graphs neither is a boundary, and `charges_pre` is write-only in the whole library — nothing reads it. Adding a `.contiguous()` would have been a fix to a symptom that no longer exists, at a small eager cost.

**A silent inductor miscompile, worth reporting upstream.** Removing the `mol_sum` break let inductor fuse a `scatter_add_` with a downstream gather, and the compiled single-molecule forward returned E = 2.88e21 eV with charges of 4.3e5 — no error, no NaN. Minimal repro:

```python
def f(x, idx, n_out):
    res = torch.zeros(n_out, x.shape[1], device=x.device, dtype=x.dtype)
    res.scatter_add_(0, idx.unsqueeze(-1).expand(-1, x.shape[1]), x)
    res = res + 1.0e-6
    return torch.index_select(res, 0, idx)
```

`torch.compile(f)` against eager on torch 2.9.1+cu128 / L40S gives max |diff| = 2.7 at `n_out=1`, and is correct at 2, 3, 4 and 64. It fires only when the scatter's leading dimension is size 1 and the result is gathered from in the same graph; `index_add_`, out-of-place `index_add`, `.clone()` and `res[idx]` all fail identically, so it is not a mutation-form issue. Worked around here in two compile-gated places: `mol_sum` sums rather than scatters at `out_size == 1`, and `nse` broadcasts rather than gathers for one molecule — `index_select`'s backward is itself a size-1 scatter, and fixing only the forward left forces wrong by 8 eV/A. `test_nse_compiled_matches_eager[1]` fails by 100% on the gradient with that guard removed.

This is the largest risk in the change. If the inductor bug turns out to be broader than "size-1 leading dim gathered in the same graph", these workarounds are patches on a symptom, and the safe fallback is restoring the protective break in `mol_sum` — which costs the entire win.

**The CPU backend keeps the protective break.** CI caught a second member of the same bug family: on the CPU backend through torch 2.10, inductor fuses the `atomic_add` scatters of the PBC distance backward with a dependent pointwise, and `CppScheduling.try_loop_split` fails loudly on the fused group with a degenerate loop split (`AssertionError: expected_var_ranges == extra_indexing_ranges`, `test_torch_compile_pbc_forces`). Both manifestations — the silent CUDA miscompile above and this CPU assertion — are outlawed by the same upstream fusion-legality rule, pytorch/pytorch#172301, first released in 2.11: verified failing identically on CPU with 2.8/2.9.1/2.10 and passing on 2.11/2.12. The fix gates the compiled charge-shape fast path in `mol_sum` to non-CPU tensors, so CPU keeps the `.item()` break — free there, since `.item()` on a CPU tensor syncs nothing — and the graph partitioning that never forms the fused group. Measured wins above are CUDA, where nothing changes on any version. The gate drops when the supported torch floor reaches 2.11.

Compiled-vs-eager fidelity is unchanged by this PR: worst relative force error over 2 models x 5 workloads goes 2.07e-5 -> 1.80e-5, absolute worst 1.6e-4 eV/A on forces of magnitude 16 eV/A. That is fp32 reassociation from different fusion, not a semantic change.

`tests/test_compile_paths.py` adds 12 tests: `infer_nb_mode` equivalent to `set_nb_mode`, `is_input_padded` equivalent to the flag, and compiled-vs-eager parity for `mol_sum` and `ops.nse` including gradients at n_mol in {1, 2, 3, 5}.

Test status: 620 passed, 10 failed. All 10 failures reproduce on clean `main` at 6550e0c and are one upstream cause — `RuntimeError: Trying to backward through alchemiops._batch_ewald_real_space_energy_matrix_backward.default but no autograd formula was registered`, i.e. any second derivative through the Ewald real-space term. Unrelated to this branch.

Two limits worth stating. Only nb_mode 1 was exercised end-to-end, because that is what `AIMNet2Calculator` produces; modes 0 and 2 have unit coverage but no compiled full-model run, and `is_input_padded` returning True under compile is provably the identity for mode 0 rather than empirically confirmed. And `torch.bincount` in `calc_masks` is the last remaining break on CUDA (`mol_sum` keeps one more on CPU, see above) — a statically-sized scatter would remove it, but that creates exactly the size-1 scatter shape inductor miscompiles, so I left it.
