### PR TITLE
Upstream hardening for conda-forge release (phase 0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,15 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   groups: dev
 
+            - name: Cache model weights
+              uses: actions/cache@v6
+              with:
+                  path: ~/.cache/aimnet
+                  key: aimnet-weights-${{ hashFiles('aimnet/calculators/model_registry.yaml') }}
+
+            - name: Pre-fetch model weights
+              run: uv run aimnet download --all
+
             - name: Run tests
               run: uv run pytest tests -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow" --cov --cov-config=pyproject.toml --cov-report=xml
 
@@ -75,7 +84,7 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                torch-version: ["2.8.*", "2.9.*", "2.10.*", "2.11.*", "2.12.*"]
+                torch-version: ["2.8.*", "2.9.*", "2.10.*", "2.11.*", "2.12.*", "2.13.*"]
             fail-fast: false
         defaults:
             run:
@@ -103,12 +112,19 @@ jobs:
                       --index-url https://download.pytorch.org/whl/cpu
                   uv run --no-sync python -c "import torch; print('torch', torch.__version__)"
 
+            - name: Cache model weights
+              uses: actions/cache@v6
+              with:
+                  path: ~/.cache/aimnet
+                  key: aimnet-weights-${{ hashFiles('aimnet/calculators/model_registry.yaml') }}
+
             - name: Run core tests against torch ${{ matrix.torch-version }}
               env:
                   UV_NO_SYNC: "1"
                   # Eager only: see job comment — inductor/triton can't be tested via reinstall-on-top.
                   TORCHDYNAMO_DISABLE: "1"
               run: |
+                  uv run --no-sync aimnet download --all
                   uv run --no-sync pytest tests \
                       -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,8 @@ jobs:
         timeout-minutes: 20
         strategy:
             matrix:
-                torch-version: ["2.8.*", "2.9.*", "2.10.*", "2.11.*", "2.12.*", "2.13.*"]
+                torch-version:
+                    ["2.8.*", "2.9.*", "2.10.*", "2.11.*", "2.12.*", "2.13.*"]
             fail-fast: false
         defaults:
             run:

--- a/.github/workflows/registry-fleet.yml
+++ b/.github/workflows/registry-fleet.yml
@@ -16,8 +16,6 @@ jobs:
     registry-fleet:
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        env:
-            AIMNET_CACHE_DIR: ${{ runner.temp }}/aimnet-registry-cache
         steps:
             - uses: actions/checkout@v7
 
@@ -27,6 +25,8 @@ jobs:
                   groups: dev
 
             - name: Verify registry fleet
+              env:
+                  AIMNET_CACHE_DIR: ${{ runner.temp }}/aimnet-registry-cache
               run: >-
                   uv run pytest -q
                   tests/test_model_registry.py::test_registry_digests_match

--- a/.github/workflows/torch-latest.yml
+++ b/.github/workflows/torch-latest.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Run core tests against latest torch
               env:
                   UV_NO_SYNC: "1"
-                  # Eager only: see job comment — inductor/triton can't be tested via reinstall-on-top.
+                  # Eager only: see the tests-torch job comment in main.yml — inductor/triton can't be tested via reinstall-on-top.
                   TORCHDYNAMO_DISABLE: "1"
               run: |
                   uv run --no-sync aimnet download --all

--- a/.github/workflows/torch-latest.yml
+++ b/.github/workflows/torch-latest.yml
@@ -1,0 +1,55 @@
+name: torch-latest
+
+on:
+    schedule:
+        - cron: "0 6 * * 1" # Mondays 06:00 UTC
+    workflow_dispatch:
+
+jobs:
+    # Early-warning lane for the unbounded `torch>=2.8` pin: reinstalls the
+    # latest stable torch CPU wheel on top of the locked env (same
+    # reinstall-on-top idiom as the tests-torch matrix in main.yml) and runs
+    # the core test suite against it. Non-blocking — this is a scheduled
+    # signal, not a PR gate.
+    tests-torch-latest:
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        defaults:
+            run:
+                shell: bash
+        steps:
+            - name: Check out
+              uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Set up the environment
+              uses: ./.github/actions/setup-uv-env
+              with:
+                  python-version: "3.11"
+                  groups: dev
+
+            - name: Override torch with latest stable (CPU wheel) — desyncs from uv.lock, intentional
+              env:
+                  UV_NO_SYNC: "1"
+              run: |
+                  set -e
+                  uv pip install --python .venv/bin/python --reinstall-package torch \
+                      --upgrade torch --index-url https://download.pytorch.org/whl/cpu
+                  uv run --no-sync python -c "import torch; print('torch', torch.__version__)"
+
+            - name: Cache model weights
+              uses: actions/cache@v6
+              with:
+                  path: ~/.cache/aimnet
+                  key: aimnet-weights-${{ hashFiles('aimnet/calculators/model_registry.yaml') }}
+
+            - name: Run core tests against latest torch
+              env:
+                  UV_NO_SYNC: "1"
+                  # Eager only: see job comment — inductor/triton can't be tested via reinstall-on-top.
+                  TORCHDYNAMO_DISABLE: "1"
+              run: |
+                  uv run --no-sync aimnet download --all
+                  uv run --no-sync pytest tests \
+                      -m "not gpu and not network and not ase and not pysis and not train and not hf and not torch_sim and not slow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Documentation
 
 - Documented the rxn dipole origin convention: `center_coord=False` is origin-safe because the family is net-neutral-only; any future charged-system family must ship `center_coord=True`.
+- Documented offline/HPC installation (cache pre-seeding via `aimnet download`, `AIMNET_CACHE_DIR`, `WARP_CACHE_PATH`) and the model weight hosting immutability policy.
 
 ## [0.2.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Security
 
-- Upgraded transitive lockfile dependencies to patched versions for all open Dependabot alerts with available fixes (GitPython, Mako, Pillow, cryptography, idna, msgpack, pymdown-extensions, setuptools, tornado, urllib3). Remaining open alerts: paramiko (no patch released) and two low-severity torch advisories fixed only in torch 2.13, outside the supported 2.8-2.12 matrix.
+- Upgraded transitive lockfile dependencies to patched versions for all open Dependabot alerts with available fixes (GitPython, Mako, Pillow, cryptography, idna, msgpack, pymdown-extensions, setuptools, tornado, urllib3). Remaining open alerts: paramiko (no patch released) and one low-severity torch advisory (torch.jit.script) fixed in torch 2.13; the supported matrix now includes 2.13 (see below), and the locked version upgrade is tracked separately.
 - Verified official model-registry downloads and cached artifacts against their SHA-256 digests before loading. Registry names and aliases now take precedence over same-named implicit local paths, preventing unverified local files from shadowing registry models. Official distributions currently bundle no model artifacts and continue to download them on demand.
 - Restricted v2 `.pt` artifact deserialization to weights and basic data. Legacy `.jpt` files are loaded only through the TorchScript loader and must come from a trusted source.
 - Validated Python class and function references in model YAML against a default trusted set. Direct local and Hugging Face artifacts can extend or replace that set, or explicitly select unsafe loading for trusted custom code; registry models always use the fixed default set.
 - Enriched and structurally validated complete Hugging Face metadata before weight access, including unambiguous `SRCoulomb` parameter recovery. Registry-backed HF fallback now treats digest-verified registry YAML and metadata as authoritative and rejects conflicting family metadata.
-- Bumped the locked torch from 2.9.1 to 2.12.1 (with triton 3.7.1), staying inside the supported 2.8-2.12 matrix. This clears the low-severity `torch.lstm_cell` memory-corruption advisory (patched in 2.10.0; the earlier note that both torch advisories required 2.13 no longer matches the updated advisory data) and moves the default CI lane onto an inductor with the upstream fusion-legality fix (pytorch/pytorch#172301). The `torch.jit.script` advisory remains open: patched only in 2.13, still outside the supported matrix.
+- Bumped the locked torch from 2.9.1 to 2.12.1 (with triton 3.7.1), staying inside the supported 2.8-2.13 matrix. This clears the low-severity `torch.lstm_cell` memory-corruption advisory (patched in 2.10.0; the earlier note that both torch advisories required 2.13 no longer matches the updated advisory data) and moves the default CI lane onto an inductor with the upstream fusion-legality fix (pytorch/pytorch#172301). The torch.jit.script advisory is resolvable now that the supported matrix includes 2.13; clearing it requires bumping the locked torch to 2.13.
 
 ### Added
 
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added weekly and manually dispatched strict fleet CI covering every official registry digest, strict-policy artifact load, and exact role-specific YAML defaults.
 - Added `aimnet info` reporting package/torch/warp versions, CUDA availability, registered kernel ops, and the model cache location.
 - Added a `weights` pytest marker on modules that need model weights, enabling a verified fully-offline test run (`-m "not weights ..."`) for packaging environments.
+- Added unit tests for the public `SizeGroupedDataset.save_h5`, `AIMNet2Calculator.set_lr_cutoff`, and `aimnet.train.loss.mse_loss_fn` APIs, which are kept.
+- Added targeted unit tests for previously untested code: `RegMultiMetric`/`regression_stats`, the `aimnet export` helper functions (`load_sae`, `bake_sae_into_model`, `mask_not_implemented_species`), `SizeGroupedDataset.cv_split`/`concatenate`, `train.utils` config/parameter helpers, and `LRCoulomb` constructor validation.
 
 ### Changed
 
@@ -35,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Marked the expensive tail of the test suite (~60 test nodes ≥2 s each: torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) with the `slow` marker; the default CPU test run now completes in under two minutes. Run `pytest -m slow` for the marked tail. The cheapest representative of each critical path (dense Hessian, HVP correctness, legacy `.jpt` loading, torch.compile smoke) stays in the default set.
 - Silenced the spurious "Warp CUDA error 100" stderr line emitted at import on CPU-only hosts.
 - Made optional-dependency install hints installer-neutral (conda equivalents where they exist; pysisyphus named directly since it is pip-only).
+- Extended the supported torch matrix to 2.8-2.13: CI covers torch 2.13 on CPU; GPU-side validation on torch 2.13 is performed on CUDA hardware as part of the release gate.
 
 ### Fixed
 
@@ -49,11 +52,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Removed unused `LRCoulomb.coul_ewald` and `LRCoulomb.coul_pme` convenience wrappers; use `LRCoulomb.forward` with `method="ewald"`/`"pme"`.
 - Removed unused `aimnet.modules.core.DSequential` and `aimnet.constants.get_dftd3_param`.
 - Removed unused `aimnet.models.utils.has_dftd3_in_config` (and its `aimnet.models` re-export).
-
-### Added
-
-- Added unit tests for the public `SizeGroupedDataset.save_h5`, `AIMNet2Calculator.set_lr_cutoff`, and `aimnet.train.loss.mse_loss_fn` APIs, which are kept.
-- Added targeted unit tests for previously untested code: `RegMultiMetric`/`regression_stats`, the `aimnet export` helper functions (`load_sae`, `bake_sae_into_model`, `mask_not_implemented_species`), `SizeGroupedDataset.cv_split`/`concatenate`, `train.utils` config/parameter helpers, and `LRCoulomb` constructor validation.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Bumped `nvalchemi-toolkit-ops` to `>=0.4.0` and `warp-lang` to `>=1.13,<2` (installs 1.15). Energies, charges, and Hessians are bit-identical to 0.3.1; explicit force/virial outputs shift within float32 accumulation noise (max 6.7e-05 eV/A on a periodic system, 40x inside the project's cross-version acceptance of 1e-4 Hartree/A). The 0.4.0 direct-output flags used by the Ewald/PME path (`compute_forces`/`compute_virial`) are deprecated upstream and now emit `DeprecationWarning`; migrating to the autograd-based API is tracked as follow-up work.
 
 - Marked the expensive tail of the test suite (~60 test nodes ≥2 s each: torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) with the `slow` marker; the default CPU test run now completes in under two minutes. Run `pytest -m slow` for the marked tail. The cheapest representative of each critical path (dense Hessian, HVP correctness, legacy `.jpt` loading, torch.compile smoke) stays in the default set.
+- Silenced the spurious "Warp CUDA error 100" stderr line emitted at import on CPU-only hosts.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added `aimnet download <model...|--all>` to prefetch registry model weights into the local cache for offline/HPC use.
 - Added `deterministic=True` calculator option: routes external DFT-D3 and DSF Coulomb through their differentiable pure-torch paths, making repeated identical evaluations bitwise reproducible on the same machine/build (issue #93). Ewald/PME kernels are not covered and warn once.
 - Added weekly and manually dispatched strict fleet CI covering every official registry digest, strict-policy artifact load, and exact role-specific YAML defaults.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `aimnet download <model...|--all>` to prefetch registry model weights into the local cache for offline/HPC use.
 - Added `deterministic=True` calculator option: routes external DFT-D3 and DSF Coulomb through their differentiable pure-torch paths, making repeated identical evaluations bitwise reproducible on the same machine/build (issue #93). Ewald/PME kernels are not covered and warn once.
 - Added weekly and manually dispatched strict fleet CI covering every official registry digest, strict-policy artifact load, and exact role-specific YAML defaults.
+- Added `aimnet info` reporting package/torch/warp versions, CUDA availability, registered kernel ops, and the model cache location.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Excluded the local weight cache (`aimnet/calculators/assets/`) from wheels and sdists explicitly, instead of relying on hatchling's `.gitignore` handling.
 - Fixed `DataGroup.cv_split` corrupting cross-validation folds: building each fold's train split mutated the shared parts in place via `cat()`, so later folds contained duplicated samples and validation splits larger than the dataset. Folds are now built without mutating the shared parts.
 - Fixed a crash when torch has CUDA but warp-lang does not (possible with conda-forge variant packages): the AEV kernel gate now checks warp CUDA availability and falls back to the pure-torch path with a one-time warning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Fixed `DataGroup.cv_split` corrupting cross-validation folds: building each fold's train split mutated the shared parts in place via `cat()`, so later folds contained duplicated samples and validation splits larger than the dataset. Folds are now built without mutating the shared parts.
+- Fixed a crash when torch has CUDA but warp-lang does not (possible with conda-forge variant packages): the AEV kernel gate now checks warp CUDA availability and falls back to the pure-torch path with a one-time warning.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Marked the expensive tail of the test suite (~60 test nodes ≥2 s each: torch.compile, model-format roundtrips, dense-Hessian/HVP comparisons, multi-model ASE runs) with the `slow` marker; the default CPU test run now completes in under two minutes. Run `pytest -m slow` for the marked tail. The cheapest representative of each critical path (dense Hessian, HVP correctness, legacy `.jpt` loading, torch.compile smoke) stays in the default set.
 - Silenced the spurious "Warp CUDA error 100" stderr line emitted at import on CPU-only hosts.
+- Made optional-dependency install hints installer-neutral (conda equivalents where they exist; pysisyphus named directly since it is pip-only).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `deterministic=True` calculator option: routes external DFT-D3 and DSF Coulomb through their differentiable pure-torch paths, making repeated identical evaluations bitwise reproducible on the same machine/build (issue #93). Ewald/PME kernels are not covered and warn once.
 - Added weekly and manually dispatched strict fleet CI covering every official registry digest, strict-policy artifact load, and exact role-specific YAML defaults.
 - Added `aimnet info` reporting package/torch/warp versions, CUDA availability, registered kernel ops, and the model cache location.
+- Added a `weights` pytest marker on modules that need model weights, enabling a verified fully-offline test run (`-m "not weights ..."`) for packaging environments.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-gpu: ## Run GPU-marked tests serially on CUDA
 	@uv run pytest -m gpu
 
 .PHONY: gpu-validate
-gpu-validate: ## Validate torch/warp-lang/nvalchemiops coupling across torch 2.8-2.12 on a CUDA box
+gpu-validate: ## Validate torch/warp-lang/nvalchemiops coupling across torch 2.8-2.13 on a CUDA box
 	@bash scripts/gpu_validate.sh
 
 .PHONY: typecheck

--- a/aimnet/calculators/aimnet2ase.py
+++ b/aimnet/calculators/aimnet2ase.py
@@ -51,7 +51,7 @@ class AIMNet2ASE(Calculator):
     ):
         if _ASE_IMPORT_ERROR is not None:
             raise ImportError(
-                'AIMNet2ASE requires ASE. Install it with `pip install "aimnet[ase]"`.'
+                'AIMNet2ASE requires ASE. Install with `pip install "aimnet[ase]"` — or on conda: conda install -c conda-forge ase'
             ) from _ASE_IMPORT_ERROR
 
         super().__init__()

--- a/aimnet/calculators/aimnet2pysis.py
+++ b/aimnet/calculators/aimnet2pysis.py
@@ -32,7 +32,7 @@ class AIMNet2Pysis(Calculator):
     ):
         if _PYSIS_IMPORT_ERROR is not None:
             raise ImportError(
-                'AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge).'
+                "AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge)."
             ) from _PYSIS_IMPORT_ERROR
 
         super().__init__(charge=charge, mult=mult, **kwargs)
@@ -109,7 +109,7 @@ class AIMNet2Pysis(Calculator):
 def run_pysis():
     if _PYSIS_IMPORT_ERROR is not None:
         raise ImportError(
-            'AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge).'
+            "AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge)."
         ) from _PYSIS_IMPORT_ERROR
 
     pysisyphus.run.CALC_DICT["aimnet"] = AIMNet2Pysis

--- a/aimnet/calculators/aimnet2pysis.py
+++ b/aimnet/calculators/aimnet2pysis.py
@@ -32,7 +32,7 @@ class AIMNet2Pysis(Calculator):
     ):
         if _PYSIS_IMPORT_ERROR is not None:
             raise ImportError(
-                'AIMNet2Pysis requires PySisyphus. Install it with `pip install "aimnet[pysis]"`.'
+                'AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge).'
             ) from _PYSIS_IMPORT_ERROR
 
         super().__init__(charge=charge, mult=mult, **kwargs)
@@ -109,7 +109,7 @@ class AIMNet2Pysis(Calculator):
 def run_pysis():
     if _PYSIS_IMPORT_ERROR is not None:
         raise ImportError(
-            'AIMNet2Pysis requires PySisyphus. Install it with `pip install "aimnet[pysis]"`.'
+            'AIMNet2Pysis requires PySisyphus. Install it with `pip install pysisyphus` (pysisyphus is not available on conda-forge).'
         ) from _PYSIS_IMPORT_ERROR
 
     pysisyphus.run.CALC_DICT["aimnet"] = AIMNet2Pysis

--- a/aimnet/calculators/aimnet2torchsim.py
+++ b/aimnet/calculators/aimnet2torchsim.py
@@ -70,7 +70,7 @@ class AIMNet2TorchSim(ModelInterface):
     ) -> None:
         if _TORCHSIM_IMPORT_ERROR is not None:
             raise ImportError(
-                'AIMNet2TorchSim requires TorchSim. Install it on Python 3.12+ with `pip install "aimnet[torchsim]"`.'
+                'AIMNet2TorchSim requires TorchSim (Python 3.12+ only). Install it with `pip install torch-sim-atomistic` (torch-sim-atomistic is not available on conda-forge).'
             ) from _TORCHSIM_IMPORT_ERROR
 
         super().__init__()

--- a/aimnet/calculators/aimnet2torchsim.py
+++ b/aimnet/calculators/aimnet2torchsim.py
@@ -70,7 +70,7 @@ class AIMNet2TorchSim(ModelInterface):
     ) -> None:
         if _TORCHSIM_IMPORT_ERROR is not None:
             raise ImportError(
-                'AIMNet2TorchSim requires TorchSim (Python 3.12+ only). Install it with `pip install torch-sim-atomistic` (torch-sim-atomistic is not available on conda-forge).'
+                "AIMNet2TorchSim requires TorchSim (Python 3.12+ only). Install it with `pip install torch-sim-atomistic` (torch-sim-atomistic is not available on conda-forge)."
             ) from _TORCHSIM_IMPORT_ERROR
 
         super().__init__()

--- a/aimnet/calculators/hf_hub.py
+++ b/aimnet/calculators/hf_hub.py
@@ -381,7 +381,7 @@ def load_from_hf_repo(
         raise FileNotFoundError(f"{st_name} not found in {local_dir}")
     if _load_safetensors_file is None:
         raise ImportError(
-            'Loading Hugging Face weights requires the "hf" extra. Install with: pip install "aimnet[hf]"'
+            'Hugging Face support requires huggingface_hub and safetensors. Install with `pip install "aimnet[hf]"` — or on conda: conda install -c conda-forge huggingface_hub safetensors'
         )
     state_dict = _load_safetensors_file(str(st_path), device="cpu")
 
@@ -431,7 +431,7 @@ def _resolve_repo(
         allow_patterns.append(f"ensemble_{ensemble_member}.safetensors")
     if _snapshot_download is None:
         raise ImportError(
-            'Loading Hugging Face repositories requires the "hf" extra. Install with: pip install "aimnet[hf]"'
+            'Hugging Face support requires huggingface_hub and safetensors. Install with `pip install "aimnet[hf]"` — or on conda: conda install -c conda-forge huggingface_hub safetensors'
         )
     local_dir = _snapshot_download(
         repo_id=repo_id_or_path,

--- a/aimnet/calculators/model_registry.py
+++ b/aimnet/calculators/model_registry.py
@@ -251,3 +251,27 @@ def clear_assets():
         if os.path.isfile(fil):
             logging.warning(f"Removing {fil}")
             os.remove(fil)
+
+
+@click.command(short_help="Download model weights into the local cache.")
+@click.argument("models", nargs=-1)
+@click.option("--all", "download_all", is_flag=True, default=False, help="Download every model in the registry.")
+def download_assets(models: tuple[str, ...], download_all: bool):
+    """Prefetch registry model weights for offline use.
+
+    MODELS are registry names or aliases (e.g. ``aimnet2``). With ``--all``,
+    every registered model is fetched. Files are stored in the cache directory
+    (``$AIMNET_CACHE_DIR`` or ``~/.cache/aimnet``) and verified against their
+    registry SHA-256 digests, so a pre-seeded cache works fully offline.
+    """
+    registry = load_model_registry()
+    if download_all:
+        names = sorted(registry["models"])
+    elif models:
+        names = [resolve_registry_model_name(m) for m in models]
+    else:
+        known = "\n  ".join(sorted(registry["models"]))
+        raise click.UsageError(f"Specify model names or --all. Known models:\n  {known}")
+    for name in names:
+        path = get_registry_model_path(name)
+        click.echo(f"{name}: {path}")

--- a/aimnet/calculators/model_registry.py
+++ b/aimnet/calculators/model_registry.py
@@ -272,6 +272,14 @@ def download_assets(models: tuple[str, ...], download_all: bool):
     else:
         known = "\n  ".join(sorted(registry["models"]))
         raise click.UsageError(f"Specify model names or --all. Known models:\n  {known}")
+    failed = []
     for name in names:
-        path = get_registry_model_path(name)
+        try:
+            path = get_registry_model_path(name)
+        except Exception as exc:
+            click.echo(f"{name}: FAILED ({exc})", err=True)
+            failed.append(name)
+            continue
         click.echo(f"{name}: {path}")
+    if failed:
+        raise click.ClickException(f"{len(failed)} of {len(names)} downloads failed: {', '.join(failed)}")

--- a/aimnet/calculators/resolve.py
+++ b/aimnet/calculators/resolve.py
@@ -137,8 +137,8 @@ def resolve_model(
                     from aimnet.calculators.hf_hub import is_hf_repo_id, load_from_hf_repo
                 except ImportError:
                     raise ImportError(
-                        f"Loading from HF repo '{model}' requires optional dependencies. "
-                        "Install with: pip install aimnet[hf]"
+                        f"Loading from HF repo '{model}' requires huggingface_hub and safetensors. "
+                        "Install with: pip install 'aimnet[hf]' — or on conda: conda install -c conda-forge huggingface_hub safetensors"
                     ) from None
                 if is_hf_repo_id(model) or _is_hf_dir:
                     module, metadata = load_from_hf_repo(

--- a/aimnet/cli.py
+++ b/aimnet/cli.py
@@ -118,6 +118,26 @@ def calc_sae_cmd(ds, output, samples=100000):
     calc_sae.callback(ds, output, samples)  # type: ignore[union-attr]
 
 
+@cli.command(name="info")
+def info_cmd():
+    """Show environment and kernel-path diagnostics."""
+    import torch
+    import warp as wp
+
+    from . import __version__
+    from .calculators.model_registry import get_cache_dir
+    from .kernels import WARP_CUDA_AVAILABLE, load_ops
+
+    click.echo(f"aimnet        {__version__}")
+    click.echo(f"torch         {torch.__version__} (CUDA available: {torch.cuda.is_available()})")
+    click.echo(f"warp-lang     {wp.config.version} (CUDA devices: {wp.get_cuda_device_count()})")
+    ops = load_ops()
+    click.echo(f"registered ops: {', '.join(ops) if ops else 'NONE'}")
+    if torch.cuda.is_available() and not WARP_CUDA_AVAILABLE:
+        click.echo("WARNING: torch has CUDA but warp-lang does not — AEV will use the pure-torch fallback path.")
+    click.echo(f"model cache   {get_cache_dir()}")
+
+
 if __name__ == "__main__":
     import logging
 

--- a/aimnet/cli.py
+++ b/aimnet/cli.py
@@ -26,7 +26,7 @@ except ImportError:
     def convert_stub():
         """Convert legacy JIT model to new format (requires aimnet[train])"""
         click.echo(
-            "Training dependencies not installed.\nInstall with: pip install aimnet[train]",
+            "Training dependencies not installed.\nInstall with: pip install 'aimnet[train]' — or on conda: conda install -c conda-forge pytorch-ignite omegaconf wandb",
             err=True,
         )
         sys.exit(1)
@@ -34,7 +34,7 @@ except ImportError:
 
 def _missing_train_deps(exc: ImportError):
     click.echo(
-        f"Training dependencies not installed or incomplete: {exc}\nInstall with: pip install aimnet[train]",
+        f"Training dependencies not installed or incomplete: {exc}\nInstall with: pip install 'aimnet[train]' — or on conda: conda install -c conda-forge pytorch-ignite omegaconf wandb",
         err=True,
     )
     sys.exit(1)

--- a/aimnet/cli.py
+++ b/aimnet/cli.py
@@ -2,7 +2,7 @@ import sys
 
 import click
 
-from .calculators.model_registry import clear_assets
+from .calculators.model_registry import clear_assets, download_assets
 
 
 @click.group()
@@ -12,6 +12,7 @@ def cli():
 
 # Always available commands
 cli.add_command(clear_assets, name="clear_model_cache")
+cli.add_command(download_assets, name="download")
 
 
 # Register convert command (doesn't need heavy training dependencies)

--- a/aimnet/kernels/__init__.py
+++ b/aimnet/kernels/__init__.py
@@ -21,8 +21,14 @@
 """AIMNet Kernels Package - GPU-accelerated custom operations."""
 
 import torch
+import warp as wp
 
 from .conv_sv_2d_sp_wp import conv_sv_2d_sp  # type: ignore[attr-defined]
+
+# Computed once after wp.init(); conda-forge can legally solve a CUDA pytorch
+# together with a CPU-only warp-lang build, so torch.cuda alone is not proof
+# that the Warp kernels can execute.
+WARP_CUDA_AVAILABLE: bool = wp.get_cuda_device_count() > 0
 
 
 def load_ops():
@@ -56,6 +62,7 @@ def load_ops():
 
 
 __all__ = [
+    "WARP_CUDA_AVAILABLE",
     "conv_sv_2d_sp",
     "load_ops",
 ]

--- a/aimnet/kernels/conv_sv_2d_sp_wp.py
+++ b/aimnet/kernels/conv_sv_2d_sp_wp.py
@@ -21,11 +21,58 @@
 
 # type: ignore
 
+import os
+import sys
+import tempfile
+
 import torch
 import warp as wp
 from torch import Tensor
 
-wp.init()
+_BENIGN_WARP_INIT_PATTERN = "Warp CUDA error 100"  # CUDA_ERROR_NO_DEVICE: expected on CPU-only hosts
+
+
+def _filter_benign_warp_init_noise(captured: str) -> str:
+    """Drop the expected no-CUDA-device line; keep every other diagnostic."""
+    kept = [line for line in captured.splitlines() if _BENIGN_WARP_INIT_PATTERN not in line]
+    return "\n".join(kept)
+
+
+def _init_warp_quietly() -> None:
+    """Run wp.init() while suppressing only the benign no-CUDA-device stderr line.
+
+    warp 1.15 prints that line from native code (cuda_util.cpp), below the reach of
+    warp.config, so the only handle is the process-level stderr fd. The fd swap is
+    fully guarded: on any host where stderr has no real fd (Jupyter, embedded
+    interpreters) or fd setup fails, fall back to a plain, noisy wp.init().
+    Captured non-benign output is re-emitted so genuine init diagnostics survive.
+    """
+    try:
+        stderr_fileno = sys.stderr.fileno()
+        saved_fd = os.dup(stderr_fileno)
+    except Exception:
+        wp.init()
+        return
+    try:
+        with tempfile.TemporaryFile(mode="w+b") as tmp:
+            os.dup2(tmp.fileno(), stderr_fileno)
+            try:
+                wp.init()
+            finally:
+                os.dup2(saved_fd, stderr_fileno)
+            tmp.seek(0)
+            captured = tmp.read().decode(errors="replace")
+    except Exception:
+        wp.init()  # singleton: no-op if init already succeeded; otherwise a plain retry
+        return
+    finally:
+        os.close(saved_fd)
+    kept = _filter_benign_warp_init_noise(captured)
+    if kept:
+        print(kept, file=sys.stderr)
+
+
+_init_warp_quietly()
 
 
 def _get_stream(device: torch.device):

--- a/aimnet/modules/aev.py
+++ b/aimnet/modules/aev.py
@@ -1,11 +1,12 @@
 import math
+import warnings
 from typing import cast
 
 import torch
 from torch import Tensor, nn
 
 from aimnet import nbops, ops
-from aimnet.kernels import conv_sv_2d_sp
+from aimnet.kernels import WARP_CUDA_AVAILABLE, conv_sv_2d_sp
 
 
 class AEVSV(nn.Module):
@@ -156,10 +157,22 @@ class ConvSV(nn.Module):
         g_sv = data["g_sv"]
         mode = nbops.get_nb_mode(data)
         if self.d2features:
-            # The Warp kernel is float32-only; float64 (and mixed-dtype) inputs
-            # fall through to the pure-torch einsum branch below.
+            # The Warp kernel is float32-only and needs a CUDA-capable warp-lang
+            # build (a CUDA pytorch + CPU warp-lang env is solver-reachable on
+            # conda-forge); anything else falls through to the pure-torch einsum.
             if mode > 0 and a.device.type == "cuda" and a.dtype == torch.float32 and g_sv.dtype == torch.float32:
-                avf_sv = conv_sv_2d_sp(a, data["nbmat"], g_sv)
+                if WARP_CUDA_AVAILABLE:
+                    avf_sv = conv_sv_2d_sp(a, data["nbmat"], g_sv)
+                else:
+                    warnings.warn(
+                        "warp-lang has no CUDA support in this environment; "
+                        "using the slower pure-torch AEV path on CUDA tensors. "
+                        "Install a CUDA build of warp-lang (conda-forge: warp-lang=*=cuda*).",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+                    a_j = a.index_select(0, data["nbmat"].flatten()).unflatten(0, data["nbmat"].shape)
+                    avf_sv = torch.einsum("...mag,...mgd->...agd", a_j, g_sv)
             elif mode > 0:
                 a_j = a.index_select(0, data["nbmat"].flatten()).unflatten(0, data["nbmat"].shape)
                 avf_sv = torch.einsum("...mag,...mgd->...agd", a_j, g_sv)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,9 @@ pip install "aimnet[train]"
 | `aimnet export` | Export trained weights to inference format | After training |
 | `aimnet convert` | Convert legacy .jpt to new .pt format | Migrating old models |
 | `aimnet calc_sae` | Calculate self-atomic energies | Before training |
+| `aimnet download` | Prefetch registry model weights into the local cache | Preparing for offline/HPC use |
+| `aimnet info` | Print environment and kernel-path diagnostics | Troubleshooting |
+| `aimnet clear_model_cache` | Remove cached model artifacts | Recovering from a corrupt cache |
 
 ## aimnet train
 
@@ -318,6 +321,45 @@ aimnet train \
 ### How SAE Is Computed
 
 `aimnet calc_sae` does not require a separate single-atom dataset. It operates on the same `SizeGroupedDataset` HDF5 file used for training, fits a per-element energy shift via a least-squares regression on `(numbers, energy)`, trims outliers (2nd/98th percentiles of the residual), and refits. The element list is inferred automatically from the dataset.
+
+## aimnet download
+
+Prefetch registry model weights into the local cache.
+
+### Basic Usage
+
+```bash
+aimnet download aimnet2
+aimnet download aimnet2-wb97m aimnet2-b973c
+aimnet download --all
+```
+
+### Options
+
+```bash
+aimnet download [MODELS]... [OPTIONS]
+```
+
+| Argument/Option | Description |
+| --- | --- |
+| `MODELS` | Registry names or aliases (e.g. `aimnet2`) to fetch. Repeatable. |
+| `--all` | Download every model in the registry. |
+
+Files are stored in the cache directory (`$AIMNET_CACHE_DIR` or `~/.cache/aimnet`) and verified against their registry SHA-256 digests, so a pre-seeded cache works fully offline. When multiple models are requested (including with `--all`), a failure on one model is reported and the remaining models are still downloaded; the command exits non-zero if any model failed.
+
+See [offline_hpc.md](offline_hpc.md) for pre-seeding a cache on air-gapped or HPC compute nodes.
+
+## aimnet info
+
+Print environment and kernel-path diagnostics.
+
+### Basic Usage
+
+```bash
+aimnet info
+```
+
+Reports the `aimnet`, `torch`, and `warp-lang` versions, CUDA availability, the registered kernel ops, and the model cache directory path. Useful for confirming the accelerated kernel path is active before troubleshooting performance or numerics.
 
 ## Common Workflows
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ Check [pytorch.org](https://pytorch.org/get-started/locally/) for other CUDA ver
 
 ### PyTorch & CUDA compatibility
 
-AIMNet2 is tested against PyTorch 2.8–2.12 (CPU API + numerics in CI; the GPU/kernel path is validated separately). Across this range PyTorch's default CUDA wheel advanced through the CUDA 12.x series to CUDA 13. Older GPUs (Volta/Pascal/Maxwell) may not be supported on the newest default wheels — consult the current [PyTorch install matrix](https://pytorch.org/get-started/locally/) to pick the right CUDA channel for your hardware rather than relying on the default. The Warp + nvalchemiops accelerated kernel path is GPU-only and is validated manually; it is not exercised in CPU CI.
+AIMNet2 is tested against PyTorch 2.8–2.13 (CPU API + numerics in CI; the GPU/kernel path is validated separately). Across this range PyTorch's default CUDA wheel advanced through the CUDA 12.x series to CUDA 13. Older GPUs (Volta/Pascal/Maxwell) may not be supported on the newest default wheels — consult the current [PyTorch install matrix](https://pytorch.org/get-started/locally/) to pick the right CUDA channel for your hardware rather than relying on the default. The Warp + nvalchemiops accelerated kernel path is GPU-only and is validated manually; it is not exercised in CPU CI.
 
 ## Verify Your Installation
 

--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -1,6 +1,6 @@
 # GPU Validation (torch / warp-lang / nvalchemiops coupling)
 
-The CPU CI matrix verifies torch-core API and CPU numerics across PyTorch 2.8–2.12, but it cannot validate three GPU-only concerns: that `warp-lang` and `nvalchemiops` install coherently with each torch version, that the Warp custom op kernels execute, and that full-model energies/forces stay reproducible across the range. This manual tool covers them on a CUDA machine.
+The CPU CI matrix verifies torch-core API and CPU numerics across PyTorch 2.8–2.13, but it cannot validate three GPU-only concerns: that `warp-lang` and `nvalchemiops` install coherently with each torch version, that the Warp custom op kernels execute, and that full-model energies/forces stay reproducible across the range. This manual tool covers them on a CUDA machine.
 
 ## Running it
 
@@ -8,7 +8,7 @@ The CPU CI matrix verifies torch-core API and CPU numerics across PyTorch 2.8–
 make gpu-validate
 ```
 
-This loops over PyTorch 2.8, 2.9, 2.10, 2.11, 2.12. For each it creates a fresh virtualenv, installs a **resolver-coherent** environment (the matching CUDA torch wheel and its `triton`, plus `aimnet` + `warp-lang` + `nvalchemiops`), runs `pytest -m gpu`, and computes deterministic energies/forces for a fixed set of systems (water, methane, caffeine, a periodic spiro crystal). A same-run torch 2.9 baseline is then used to diff every other version.
+This loops over PyTorch 2.8, 2.9, 2.10, 2.11, 2.12, 2.13. For each it creates a fresh virtualenv, installs a **resolver-coherent** environment (the matching CUDA torch wheel and its `triton`, plus `aimnet` + `warp-lang` + `nvalchemiops`), runs `pytest -m gpu`, and computes deterministic energies/forces for a fixed set of systems (water, methane, caffeine, a periodic spiro crystal). A same-run torch 2.9 baseline is then used to diff every other version.
 
 Inspect the commands without running anything:
 
@@ -22,7 +22,7 @@ DRY_RUN=1 bash scripts/gpu_validate.sh
 | --- | --- | --- |
 | `CUDA_INDEX` | `https://download.pytorch.org/whl/cu126` | Pick the channel matching your driver. torch 2.12 defaults to CUDA 13; if a `cu126` wheel is unavailable for a version, that leg reports `INSTALL-FAIL` — re-run that version with the appropriate `--index-url`. |
 | `PYTHON` | `python3.12` | aimnet itself supports Python ≥ 3.11, but validation defaults to 3.12 because `nvalchemiops`'s torch extra activates only at Python ≥ 3.12 — i.e. 3.12+ is where the coupling under test actually engages. |
-| `TORCH_VERSIONS` | `2.8 2.9 2.10 2.11 2.12` | Space-separated minor versions. |
+| `TORCH_VERSIONS` | `2.8 2.9 2.10 2.11 2.12 2.13` | Space-separated minor versions. |
 | `BASELINE` | `2.9` | torch version used as the energy/force reference. |
 | `ENERGY_ATOL` | `1e-5` | Hartree. Matches the repo's `ENERGY_ATOL`. |
 | `FORCE_ATOL` | `1e-4` | Hartree/Å. Looser than `FORCE_ATOL=1e-5` to absorb legitimate cross-version GPU reduction-order variation; tighten if your hardware is stable. |

--- a/docs/model_format.md
+++ b/docs/model_format.md
@@ -604,3 +604,13 @@ aimnet convert model.jpt config.yaml output.pt
 # Calculate SAE from dataset
 aimnet calc_sae dataset.h5 sae.yaml
 ```
+
+## Weight hosting and immutability policy
+
+Published model artifacts are hosted under
+`https://storage.googleapis.com/aimnetcentral/aimnet2v2/`. Objects under this
+prefix are immutable: once a file is referenced by a released model registry,
+its bytes are never overwritten or deleted. Updated weights always get a new
+object path and a new registry entry. Released packages pin each artifact's
+SHA-256, so any hosting change that altered bytes would hard-fail rather than
+load silently different physics.

--- a/docs/model_format.md
+++ b/docs/model_format.md
@@ -607,10 +607,4 @@ aimnet calc_sae dataset.h5 sae.yaml
 
 ## Weight hosting and immutability policy
 
-Published model artifacts are hosted under
-`https://storage.googleapis.com/aimnetcentral/aimnet2v2/`. Objects under this
-prefix are immutable: once a file is referenced by a released model registry,
-its bytes are never overwritten or deleted. Updated weights always get a new
-object path and a new registry entry. Released packages pin each artifact's
-SHA-256, so any hosting change that altered bytes would hard-fail rather than
-load silently different physics.
+Published model artifacts are hosted under `https://storage.googleapis.com/aimnetcentral/aimnet2v2/`. Objects under this prefix are immutable: once a file is referenced by a released model registry, its bytes are never overwritten or deleted. Updated weights always get a new object path and a new registry entry. Released packages pin each artifact's SHA-256, so any hosting change that altered bytes would hard-fail rather than load silently different physics.

--- a/docs/offline_hpc.md
+++ b/docs/offline_hpc.md
@@ -1,0 +1,43 @@
+# Offline and HPC Installation
+
+AIMNet2 model weights are not bundled with the package. They are downloaded on
+first use from `https://storage.googleapis.com/aimnetcentral/` into a local
+cache and verified against SHA-256 digests pinned in the model registry.
+
+## Pre-seeding the cache (air-gapped compute nodes)
+
+On a node with internet access (e.g. a login node):
+
+```bash
+aimnet download aimnet2          # one model (registry name or alias)
+aimnet download --all            # every registered model (~212 MB)
+```
+
+Then point compute jobs at the cache:
+
+```bash
+export AIMNET_CACHE_DIR=/shared/software/aimnet-cache   # default: ~/.cache/aimnet
+```
+
+The cache is read-only-safe: files are verified by checksum on load and are
+never rewritten unless the checksum fails. A shared, read-only
+`AIMNET_CACHE_DIR` serves any number of jobs and users.
+
+## Warp kernel JIT cache
+
+The CUDA AEV kernel is JIT-compiled by NVIDIA Warp at first use and cached
+(default: `~/.cache/warp`). On quota-limited or read-only home directories,
+redirect it:
+
+```bash
+export WARP_CACHE_PATH=/tmp/$USER/warp-cache
+```
+
+First kernel launch on a fresh node pays a one-time compile cost; subsequent
+runs start warm.
+
+## Diagnostics
+
+`aimnet info` prints the resolved cache location, torch/warp versions, CUDA
+availability, and which AEV kernel path (Warp CUDA kernel vs. pure-torch
+fallback) will run.

--- a/docs/offline_hpc.md
+++ b/docs/offline_hpc.md
@@ -1,8 +1,6 @@
 # Offline and HPC Installation
 
-AIMNet2 model weights are not bundled with the package. They are downloaded on
-first use from `https://storage.googleapis.com/aimnetcentral/` into a local
-cache and verified against SHA-256 digests pinned in the model registry.
+AIMNet2 model weights are not bundled with the package. They are downloaded on first use from `https://storage.googleapis.com/aimnetcentral/` into a local cache and verified against SHA-256 digests pinned in the model registry.
 
 ## Pre-seeding the cache (air-gapped compute nodes)
 
@@ -19,25 +17,18 @@ Then point compute jobs at the cache:
 export AIMNET_CACHE_DIR=/shared/software/aimnet-cache   # default: ~/.cache/aimnet
 ```
 
-The cache is read-only-safe: files are verified by checksum on load and are
-never rewritten unless the checksum fails. A shared, read-only
-`AIMNET_CACHE_DIR` serves any number of jobs and users.
+The cache is read-only-safe: files are verified by checksum on load and are never rewritten unless the checksum fails. A shared, read-only `AIMNET_CACHE_DIR` serves any number of jobs and users.
 
 ## Warp kernel JIT cache
 
-The CUDA AEV kernel is JIT-compiled by NVIDIA Warp at first use and cached
-(default: `~/.cache/warp`). On quota-limited or read-only home directories,
-redirect it:
+The CUDA AEV kernel is JIT-compiled by NVIDIA Warp at first use and cached (default: `~/.cache/warp`). On quota-limited or read-only home directories, redirect it:
 
 ```bash
 export WARP_CACHE_PATH=/tmp/$USER/warp-cache
 ```
 
-First kernel launch on a fresh node pays a one-time compile cost; subsequent
-runs start warm.
+First kernel launch on a fresh node pays a one-time compile cost; subsequent runs start warm.
 
 ## Diagnostics
 
-`aimnet info` prints the resolved cache location, torch/warp versions, CUDA
-availability, and which AEV kernel path (Warp CUDA kernel vs. pure-torch
-fallback) will run.
+`aimnet info` prints the resolved cache location, torch/warp versions, CUDA availability, and which AEV kernel path (Warp CUDA kernel vs. pure-torch fallback) will run.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
           - Training: train.md
           - CLI Tools: cli.md
           - GPU Validation: gpu_validation.md
+          - Offline / HPC: offline_hpc.md
     - API Reference:
           - Overview: api/index.md
           - Calculators: api/calculators.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ include = [
     "aimnet/**/*.yaml",
     "aimnet/**/*.pt",
 ]
+exclude = [
+    "aimnet/calculators/assets/**",
+]
 
 [tool.hatch.version]
 source = "vcs"
@@ -108,6 +111,9 @@ include = [
     "aimnet/**/*.py",
     "aimnet/**/*.yaml",
     "aimnet/**/*.pt",
+]
+exclude = [
+    "aimnet/calculators/assets/**",
 ]
 
 # UV configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ markers = [
     "slow: marks tests that are intentionally expensive (deselect with: -m 'not slow')",
     "torch_sim: marks tests that require TorchSim (deselect with: -m 'not torch_sim')",
     "train: marks tests that require training dependencies (deselect with: -m 'not train')",
+    "weights: marks tests that need model weights (registry download or pre-seeded cache; deselect with: -m 'not weights')",
 ]
 
 # Coverage configuration

--- a/scripts/gpu_validate.sh
+++ b/scripts/gpu_validate.sh
@@ -9,7 +9,7 @@
 #   DRY_RUN=1 bash scripts/gpu_validate.sh  # print the per-version commands only
 #
 # Tunables (env vars):
-#   TORCH_VERSIONS  default "2.8 2.9 2.10 2.11 2.12"
+#   TORCH_VERSIONS  default "2.8 2.9 2.10 2.11 2.12 2.13"
 #   CUDA_INDEX      default "https://download.pytorch.org/whl/cu126"
 #   PYTHON          default "python3.12"
 #   RESULTS         default "./gpu-validation-results"
@@ -18,7 +18,7 @@
 #   FORCE_ATOL      default "1e-4"   (Hartree/Angstrom)
 set -u
 
-TORCH_VERSIONS="${TORCH_VERSIONS:-2.8 2.9 2.10 2.11 2.12}"
+TORCH_VERSIONS="${TORCH_VERSIONS:-2.8 2.9 2.10 2.11 2.12 2.13}"
 CUDA_INDEX="${CUDA_INDEX:-https://download.pytorch.org/whl/cu126}"
 PYTHON="${PYTHON:-python3.12}"
 RESULTS="${RESULTS:-./gpu-validation-results}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,18 +241,6 @@ def device():
     return get_device()
 
 
-@pytest.fixture(scope="session")
-def aimnet2_calc():
-    """Session-scoped AIMNet2Calculator with the default aimnet2 model.
-
-    Loaded once per test session. Use this instead of constructing
-    AIMNet2Calculator("aimnet2") inside individual tests.
-    """
-    from aimnet.calculators import AIMNet2Calculator
-
-    return AIMNet2Calculator("aimnet2")
-
-
 @pytest.fixture
 def requires_gpu():
     """Skip test if GPU is not available."""
@@ -785,58 +773,3 @@ def _cache_load_model():
         mp.setattr(_resolve, "load_model", _cached_load_model, raising=False)
         mp.setattr(_resolve, "_load_registry_model", _cached_registry_load_model, raising=False)
         yield _cached_load_model
-
-
-@pytest.fixture(scope="session")
-def model_cache():
-    """Session-scoped loader returning fresh ``(nn.Module, metadata)`` pairs.
-
-    Usage::
-
-        module, metadata = model_cache.load("aimnet2", device="cpu")
-
-    The expensive load is memoized once per ``(name, device)``; each ``load``
-    call returns an independent ``copy.deepcopy`` of the cached module, so
-    callers may freely mutate parameters/buffers without leaking across tests.
-    """
-    import copy
-
-    from aimnet.calculators.model_registry import get_model_path
-    from aimnet.models.base import load_registry_model
-
-    cache: dict = {}
-
-    class _ModelCache:
-        @staticmethod
-        def load(name: str = "aimnet2", device: str = "cpu"):
-            key = (name, str(device))
-            if key not in cache:
-                cache[key] = load_registry_model(get_model_path(name), device)
-            model, metadata = cache[key]
-            return copy.deepcopy(model), metadata
-
-    return _ModelCache()
-
-
-@pytest.fixture
-def make_calc(model_cache):
-    """Factory building a fresh ``AIMNet2Calculator`` around a cached module."""
-    from aimnet.calculators import AIMNet2Calculator
-
-    def _make(name: str = "aimnet2", device: str = "cpu", **kwargs):
-        module, _ = model_cache.load(name, device=device)
-        return AIMNet2Calculator(module, **kwargs)
-
-    return _make
-
-
-@pytest.fixture
-def make_ase_calc(model_cache):
-    """Factory building a fresh ``AIMNet2ASE`` around a cached module."""
-    from aimnet.calculators import AIMNet2ASE
-
-    def _make(name: str = "aimnet2", device: str = "cpu", **kwargs):
-        module, _ = model_cache.load(name, device=device)
-        return AIMNet2ASE(module, **kwargs)
-
-    return _make

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -7,7 +7,7 @@ import pytest
 from conftest import CAFFEINE_FILE, CIF_SPIRO
 
 # All tests in this module require ASE
-pytestmark = pytest.mark.ase
+pytestmark = [pytest.mark.ase, pytest.mark.weights]
 
 MODELS = ("aimnet2", "aimnet2_b973c")
 NSE_MODEL = "aimnet2nse"

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -80,7 +80,7 @@ def test_from_legacy_jit_rejects_import_settings_before_loading(monkeypatch: pyt
 
 
 # These are calculator integration tests: most construct and run a model.
-pytestmark = [pytest.mark.ase]
+pytestmark = [pytest.mark.ase, pytest.mark.weights]
 
 
 @pytest.mark.slow

--- a/tests/test_calculator_gpu.py
+++ b/tests/test_calculator_gpu.py
@@ -11,7 +11,7 @@ from conftest import CAFFEINE_FILE, load_mol
 from aimnet.calculators import AIMNet2Calculator
 
 # Skip entire module if CUDA is not available
-pytestmark = pytest.mark.gpu
+pytestmark = [pytest.mark.gpu, pytest.mark.weights]
 
 if not torch.cuda.is_available():
     pytest.skip("CUDA not available", allow_module_level=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,25 @@ def test_download_all_fetches_every_registry_model(runner, monkeypatch):
     assert sorted(fetched) == sorted(model_registry.load_model_registry()["models"])
 
 
+def test_download_all_continues_after_one_failure(runner, monkeypatch):
+    all_models = sorted(model_registry.load_model_registry()["models"])
+    failing = all_models[0]
+    fetched = []
+
+    def flaky_fetch(name):
+        if name == failing:
+            raise RuntimeError("simulated network failure")
+        fetched.append(name)
+        return f"mock://{name}.pt"
+
+    monkeypatch.setattr(model_registry, "get_registry_model_path", flaky_fetch)
+    result = runner.invoke(cli, ["download", "--all"])
+    assert result.exit_code != 0
+    assert sorted(fetched) == sorted(m for m in all_models if m != failing)
+    assert f"{failing}: FAILED" in result.output
+    assert "1 of" in result.output
+
+
 def test_info_reports_environment(runner):
     result = runner.invoke(cli, ["info"])
     assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,9 @@ def test_download_unknown_model_fails(runner):
 
 def test_download_named_model_fetches_it(runner, monkeypatch):
     fetched = []
-    monkeypatch.setattr(model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt")
+    monkeypatch.setattr(
+        model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt"
+    )
     result = runner.invoke(cli, ["download", "aimnet2"])
     assert result.exit_code == 0, result.output
     assert fetched == [model_registry.resolve_registry_model_name("aimnet2")]
@@ -58,7 +60,9 @@ def test_download_named_model_fetches_it(runner, monkeypatch):
 
 def test_download_all_fetches_every_registry_model(runner, monkeypatch):
     fetched = []
-    monkeypatch.setattr(model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt")
+    monkeypatch.setattr(
+        model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt"
+    )
     result = runner.invoke(cli, ["download", "--all"])
     assert result.exit_code == 0, result.output
     assert sorted(fetched) == sorted(model_registry.load_model_registry()["models"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,13 @@ def test_download_all_fetches_every_registry_model(runner, monkeypatch):
     result = runner.invoke(cli, ["download", "--all"])
     assert result.exit_code == 0, result.output
     assert sorted(fetched) == sorted(model_registry.load_model_registry()["models"])
+
+
+def test_info_reports_environment(runner):
+    result = runner.invoke(cli, ["info"])
+    assert result.exit_code == 0, result.output
+    assert "aimnet" in result.output
+    assert "torch" in result.output
+    assert "warp-lang" in result.output
+    assert "aimnet::conv_sv_2d_sp_fwd" in result.output
+    assert "model cache" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,19 +1,21 @@
 import importlib.util
 
-from click.testing import CliRunner
+import click.testing
+import pytest
 
+from aimnet.calculators import model_registry
 from aimnet.cli import cli
 
 
 def test_cli_help_smoke():
-    result = CliRunner().invoke(cli, ["--help"])
+    result = click.testing.CliRunner().invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "train" in result.output
     assert "export" in result.output
 
 
 def test_train_help_smoke_without_eager_train_imports():
-    result = CliRunner().invoke(cli, ["train", "--help"])
+    result = click.testing.CliRunner().invoke(cli, ["train", "--help"])
     assert result.exit_code == 0
     assert "--config" in result.output
     assert "--no-default-config" in result.output
@@ -27,3 +29,36 @@ def test_calculators_star_import_without_optional_deps():
         assert "AIMNet2ASE" not in calculators.__all__
     if importlib.util.find_spec("pysisyphus") is None:
         assert "AIMNet2Pysis" not in calculators.__all__
+
+
+@pytest.fixture
+def runner():
+    return click.testing.CliRunner()
+
+
+def test_download_requires_arguments(runner):
+    result = runner.invoke(cli, ["download"])
+    assert result.exit_code != 0
+    assert "Specify model names or --all" in result.output
+
+
+def test_download_unknown_model_fails(runner):
+    result = runner.invoke(cli, ["download", "no-such-model"])
+    assert result.exit_code != 0
+    assert "not found in the registry" in str(result.output) + str(result.exception)
+
+
+def test_download_named_model_fetches_it(runner, monkeypatch):
+    fetched = []
+    monkeypatch.setattr(model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt")
+    result = runner.invoke(cli, ["download", "aimnet2"])
+    assert result.exit_code == 0, result.output
+    assert fetched == [model_registry.resolve_registry_model_name("aimnet2")]
+
+
+def test_download_all_fetches_every_registry_model(runner, monkeypatch):
+    fetched = []
+    monkeypatch.setattr(model_registry, "get_registry_model_path", lambda name: fetched.append(name) or f"mock://{name}.pt")
+    result = runner.invoke(cli, ["download", "--all"])
+    assert result.exit_code == 0, result.output
+    assert sorted(fetched) == sorted(model_registry.load_model_registry()["models"])

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -19,7 +19,7 @@ from aimnet.models import base as model_base
 from aimnet.models.artifact_validation import validate_model_yaml
 from aimnet.modules import AtomicShift
 
-pytestmark = pytest.mark.hf
+pytestmark = [pytest.mark.hf, pytest.mark.weights]
 
 
 @pytest.fixture

--- a/tests/test_hvp.py
+++ b/tests/test_hvp.py
@@ -6,6 +6,8 @@ import torch
 
 from aimnet.calculators import AIMNet2Calculator
 
+pytestmark = pytest.mark.weights
+
 
 def _set_method(calc, method):
     with warnings.catch_warnings():

--- a/tests/test_lr.py
+++ b/tests/test_lr.py
@@ -6,6 +6,8 @@ import torch
 from aimnet import nbops, ops
 from aimnet.modules.lr import LRCoulomb, SRCoulomb
 
+pytestmark = pytest.mark.weights
+
 # Coulomb methods for parametrized tests (non-periodic)
 # Note: "ewald" excluded here because it requires cell and flat format (mode 1)
 # Ewald is tested separately in TestLRCoulombEwald and TestLRCoulombEwaldPBC classes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,6 +11,8 @@ from aimnet.config import build_module
 from aimnet.models.base import load_model
 from aimnet.modules.core import Forces
 
+pytestmark = pytest.mark.weights
+
 aimnet2_d3_def = os.path.join(os.path.dirname(__file__), "..", "aimnet", "models", "aimnet2_dftd3_wb97m.yaml")
 model_defs = [aimnet2_d3_def]
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -20,6 +20,8 @@ from aimnet.calculators.model_registry import (
 )
 from aimnet.models.base import load_registry_model
 
+pytestmark = pytest.mark.weights
+
 
 def test_load_model_registry_respects_registry_file_param(tmp_path):
     """registry_file param should override the default path."""

--- a/tests/test_pbc.py
+++ b/tests/test_pbc.py
@@ -14,7 +14,7 @@ from aimnet import nbops, ops
 from aimnet.calculators import AIMNet2Calculator
 from aimnet.modules.lr import LRCoulomb
 
-pytestmark = [pytest.mark.ase, pytest.mark.gpu]
+pytestmark = [pytest.mark.ase, pytest.mark.gpu, pytest.mark.weights]
 
 
 def setup_pbc_data_with_nblist(data: dict, device: torch.device, cutoff: float = 8.0) -> dict:

--- a/tests/test_pysis.py
+++ b/tests/test_pysis.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 import torch
 
-pytestmark = pytest.mark.pysis
+pytestmark = [pytest.mark.pysis, pytest.mark.weights]
 
 pytest.importorskip("pysisyphus", reason="pysisyphus not installed")
 

--- a/tests/test_sella.py
+++ b/tests/test_sella.py
@@ -9,7 +9,7 @@ installed will deselect them automatically.
 import numpy as np
 import pytest
 
-pytestmark = [pytest.mark.sella, pytest.mark.ase]
+pytestmark = [pytest.mark.sella, pytest.mark.ase, pytest.mark.weights]
 
 
 def _h2o2_guess():

--- a/tests/test_serialization_abi.py
+++ b/tests/test_serialization_abi.py
@@ -34,6 +34,8 @@ from aimnet.models.artifact_validation import (
     validate_registry_v2_artifact,
 )
 
+pytestmark = pytest.mark.weights
+
 _PACKAGE_ROOT = Path(aimnet.__file__).parent
 _ASSETS_DIR = _PACKAGE_ROOT / "calculators" / "assets"
 

--- a/tests/test_torchsim.py
+++ b/tests/test_torchsim.py
@@ -15,7 +15,7 @@ from conftest import CAFFEINE_FILE, CIF_SPIRO  # noqa: E402
 
 from aimnet.calculators import AIMNet2Calculator, AIMNet2TorchSim  # noqa: E402
 
-pytestmark = pytest.mark.torch_sim
+pytestmark = [pytest.mark.torch_sim, pytest.mark.weights]
 
 
 class _FakeAIMNet2Calculator:

--- a/tests/test_warp_cuda_guard.py
+++ b/tests/test_warp_cuda_guard.py
@@ -94,7 +94,11 @@ def test_cpu_import_emits_no_cuda_error_noise():
     env = dict(os.environ, CUDA_VISIBLE_DEVICES="")
     proc = subprocess.run(  # noqa: S603 -- fixed argv, no untrusted input
         [sys.executable, "-c", "import aimnet.kernels"],
-        capture_output=True, text=True, env=env, timeout=120, check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=True,
     )
     assert "Warp CUDA error" not in proc.stderr
 

--- a/tests/test_warp_cuda_guard.py
+++ b/tests/test_warp_cuda_guard.py
@@ -1,0 +1,82 @@
+"""The AEV kernel gate must consult warp's CUDA availability, not only torch's.
+
+A CUDA-enabled pytorch alongside a CPU-only warp-lang build is a solver-reachable
+environment on conda-forge; the gate must fall back to the einsum path instead of
+letting conv_sv_2d_sp raise inside forward.
+"""
+
+import pytest
+import torch
+
+import aimnet.kernels
+import aimnet.modules.aev as aev_mod
+from aimnet import nbops
+from aimnet.modules.aev import ConvSV
+
+
+def test_warp_cuda_available_is_bool():
+    assert isinstance(aimnet.kernels.WARP_CUDA_AVAILABLE, bool)
+
+
+def _generate_valid_neighbor_idx(b: int, m: int, num_neighbors: int, device: str) -> torch.Tensor:
+    """Neighbor indices with real entries first and the padding sentinel (b - 1) after.
+
+    Mirrors `generate_valid_neighbor_idx` in tests/test_conv_sv_2d_sp.py: the last
+    batch row is a padding atom, and the Warp kernel skips computing its output row
+    entirely (it launches over `b - 1` rows), so any einsum reference must be fed
+    matching padding to agree with the kernel.
+    """
+    padding_value = b - 1
+    idx = torch.full((b, m), padding_value, device=device, dtype=torch.int64)
+    n = min(num_neighbors, m)
+    if n > 0 and b > 1:
+        idx[:, :n] = torch.randint(0, padding_value, (b, n), device=device, dtype=torch.int64)
+    return idx
+
+
+def _conv_inputs(device, dtype=torch.float32):
+    """Mode-1 (padded flat) ConvSV.forward inputs, mirroring
+    TestConvSVDispatch.convsv_data in tests/test_conv_sv_2d_sp.py: nchannel/nshifts_s
+    are the (B, nchannel, nshifts_s) feature axes conv_sv_2d_sp contracts over, and
+    nshifts_v must equal nshifts_s here for the vector-combination step in
+    ConvSV.forward to line up (d2features requires nshifts_s == nshifts_v; see
+    aimnet/models/aimnet2.py).
+    """
+    torch.manual_seed(0)
+    b, nchannel, nshifts_s, m, ncomb_v = 4, 3, 4, 6, 2
+    nshifts_v = nshifts_s
+
+    idx = _generate_valid_neighbor_idx(b, m, num_neighbors=m - 1, device=device)
+    idx[-1] = b - 1  # last atom is the padding row; it has no real neighbors
+    a = torch.randn(b, nchannel, nshifts_s, device=device, dtype=dtype)
+    g_sv = torch.randn(b, m, nshifts_s, 4, device=device, dtype=dtype)
+    g_sv = g_sv * (idx < b - 1).view(b, m, 1, 1)
+
+    conv = ConvSV(nshifts_s=nshifts_s, nchannel=nchannel, d2features=True, nshifts_v=nshifts_v, ncomb_v=ncomb_v).to(
+        device=device, dtype=dtype
+    )
+    data = nbops.set_nb_mode({"g_sv": g_sv, "nbmat": idx})
+    return conv, data, a
+
+
+@pytest.mark.gpu
+def test_cuda_forward_without_warp_cuda_uses_einsum_fallback(monkeypatch):
+    """With warp CUDA reported unavailable, a fp32 CUDA forward must not raise."""
+    monkeypatch.setattr(aev_mod, "WARP_CUDA_AVAILABLE", False)
+    conv, data, a = _conv_inputs("cuda")
+    with pytest.warns(RuntimeWarning, match="warp-lang has no CUDA support"):
+        out = conv(data, a)
+    assert out.device.type == "cuda"
+
+
+@pytest.mark.gpu
+def test_cuda_fallback_matches_kernel_path(monkeypatch):
+    """Fallback einsum result must match the Warp kernel result."""
+    conv, data, a = _conv_inputs("cuda")
+    if not aimnet.kernels.WARP_CUDA_AVAILABLE:
+        pytest.skip("warp has no CUDA here; kernel path unavailable")
+    ref = conv(data, a)
+    monkeypatch.setattr(aev_mod, "WARP_CUDA_AVAILABLE", False)
+    with pytest.warns(RuntimeWarning):
+        alt = conv(data, a)
+    torch.testing.assert_close(ref, alt, rtol=1e-4, atol=1e-5)

--- a/tests/test_warp_cuda_guard.py
+++ b/tests/test_warp_cuda_guard.py
@@ -5,12 +5,18 @@ environment on conda-forge; the gate must fall back to the einsum path instead o
 letting conv_sv_2d_sp raise inside forward.
 """
 
+import io
+import os
+import subprocess
+import sys
+
 import pytest
 import torch
 
 import aimnet.kernels
 import aimnet.modules.aev as aev_mod
 from aimnet import nbops
+from aimnet.kernels.conv_sv_2d_sp_wp import _filter_benign_warp_init_noise, _init_warp_quietly
 from aimnet.modules.aev import ConvSV
 
 
@@ -80,3 +86,31 @@ def test_cuda_fallback_matches_kernel_path(monkeypatch):
     with pytest.warns(RuntimeWarning):
         alt = conv(data, a)
     torch.testing.assert_close(ref, alt, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.slow
+def test_cpu_import_emits_no_cuda_error_noise():
+    """Importing the kernels on a CUDA-less host must not spam stderr."""
+    env = dict(os.environ, CUDA_VISIBLE_DEVICES="")
+    proc = subprocess.run(  # noqa: S603 -- fixed argv, no untrusted input
+        [sys.executable, "-c", "import aimnet.kernels"],
+        capture_output=True, text=True, env=env, timeout=120, check=True,
+    )
+    assert "Warp CUDA error" not in proc.stderr
+
+
+def test_init_falls_back_when_stderr_has_no_fileno(monkeypatch):
+    """Hosts without a real stderr fd (Jupyter, embedded interpreters) must not crash import."""
+    import aimnet.kernels.conv_sv_2d_sp_wp as wp_mod
+
+    monkeypatch.setattr(wp_mod.sys, "stderr", io.StringIO())
+    # wp.init() is a singleton no-op once initialized, so re-invoking is safe here.
+    _init_warp_quietly()
+
+
+def test_filter_keeps_non_benign_lines():
+    """Only the expected no-CUDA-device line is dropped; other diagnostics survive."""
+    captured = "Warp CUDA error 100: no CUDA-capable device is detected\nWarp CUDA error 999: something real"
+    kept = _filter_benign_warp_init_noise(captured)
+    assert "Warp CUDA error 100" not in kept
+    assert "Warp CUDA error 999: something real" in kept


### PR DESCRIPTION
Phase 0 of the conda-forge release plan: upstream hardening that gates the v0.3.0 tag.

- AEV kernel gate now checks warp CUDA availability and falls back to the pure-torch path (a CUDA pytorch + CPU warp-lang env is solver-reachable on conda-forge)
- Suppress the benign warp "CUDA error 100" init line via guarded stderr capture-and-replay (wp.config.quiet cannot reach it; native fprintf)
- New `aimnet download` (offline/HPC cache pre-seeding) and `aimnet info` (kernel-path diagnostics) CLI commands
- Installer-neutral optional-dependency hints (conda equivalents where they exist; pysisyphus/torch-sim named directly as pip-only)
- New `weights` pytest marker; the non-weights selection is verified fully offline (cold cache + unroutable proxy: 312 passed, 0 network attempts)
- Explicit hatch excludes for the weight cache in wheel+sdist (proven with a poisoned build)
- CI: torch matrix extended to 2.13, weight-cache + pre-warm steps replace the silent live-GCS dependency, new scheduled latest-torch lane
- Fix registry-fleet workflow: runner context is not valid in job-level env (workflow has failed at parse since introduction)
- CHANGELOG reconciliation for the 2.8-2.13 matrix

GPU-side torch 2.13 validation (gpu/compile/HVP suites) runs on CUDA hardware as the release gate before tagging v0.3.0.