### PR TITLE
Trust the embedded-dispersion modules solvation artifacts need

### DIFF
--- a/aimnet/models/artifact_validation.py
+++ b/aimnet/models/artifact_validation.py
@@ -29,6 +29,11 @@ _DEFAULT_CLASS_IMPORT_PATHS = frozenset({
     "aimnet.modules.Output",
     "aimnet.modules.Quadrupole",
     "aimnet.modules.SRCoulomb",
+    # Embedded-dispersion modules. Both are first-party nn.Modules in
+    # aimnet/modules/lr.py and both are referenced by the shipped CPCM(water)
+    # solvation artifact, which could not load without them.
+    "aimnet.modules.D3TS",
+    "aimnet.modules.lr.DispParam",
 })
 _DEFAULT_ACTIVATION_IMPORT_PATHS = frozenset({"torch.nn.GELU"})
 _DEFAULT_INITIALIZER_IMPORT_PATHS = frozenset({"torch.nn.init.xavier_normal_"})

--- a/tests/test_model_artifact_security.py
+++ b/tests/test_model_artifact_security.py
@@ -1366,3 +1366,36 @@ def test_hf_registry_fallback_fails_on_unexpected_key_without_extra(
 
     with pytest.raises(RuntimeError, match=r"Unexpected model parameters.*extra"):
         hf_hub.load_from_hf_repo(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "aimnet.modules.D3TS",
+        "aimnet.modules.lr.DispParam",
+    ],
+)
+def test_embedded_dispersion_modules_are_trusted(path: str) -> None:
+    """The shipped CPCM(water) artifact references these and cannot load without them.
+
+    Both are first-party ``nn.Module`` subclasses in ``aimnet/modules/lr.py``.
+    When the artifact trust boundary was introduced they were absent from the
+    default allowlist, so the solvation model failed to load with
+    ``Untrusted import path for 'class'``. Downstream that surfaced only as a
+    run aborting hours in, since nothing loads the solvation model until it is
+    needed.
+    """
+    assert path in ALLOWED_MODEL_IMPORT_PATHS
+
+
+def test_trusted_dispersion_paths_resolve_to_real_modules() -> None:
+    """An allowlist entry that does not resolve would trade a load failure for
+    an import error, so membership alone is not enough to assert."""
+    import importlib
+
+    from torch import nn
+
+    for path in ("aimnet.modules.D3TS", "aimnet.modules.lr.DispParam"):
+        module_name, class_name = path.rsplit(".", 1)
+        obj = getattr(importlib.import_module(module_name), class_name)
+        assert isinstance(obj, type) and issubclass(obj, nn.Module)

--- a/tests/test_serialization_abi.py
+++ b/tests/test_serialization_abi.py
@@ -78,6 +78,9 @@ _FROZEN_CLASS_PATHS = (
     "aimnet.modules.LRCoulomb",
     "aimnet.modules.DFTD3",
     "aimnet.modules.D3TS",
+    # Dispersion-parameter module carried by the shipped CPCM(water) artifact
+    # alongside D3TS; released artifacts reference it, so it is ABI.
+    "aimnet.modules.lr.DispParam",
     # Public configuration building blocks (documented in docs/api as intended
     # for configuration and extension); external configs may reference them.
     "aimnet.modules.AEVSV",
@@ -197,6 +200,13 @@ def test_allowed_model_import_paths_are_shared_and_immutable():
         "aimnet.modules.Output",
         "aimnet.modules.Quadrupole",
         "aimnet.modules.SRCoulomb",
+        # Embedded-dispersion modules referenced by the shipped CPCM(water)
+        # solvation artifact. D3TS was already in _FROZEN_CLASS_PATHS above --
+        # the serialization ABI knew released checkpoints reference it while
+        # the runtime allowlist did not, and that inconsistency is what stopped
+        # the model loading.
+        "aimnet.modules.D3TS",
+        "aimnet.modules.lr.DispParam",
         "torch.nn.GELU",
         "torch.nn.init.xavier_normal_",
     }


### PR DESCRIPTION
## Problem

The artifact trust boundary shipped with a default allowlist missing two first-party classes:

- `aimnet.modules.D3TS`
- `aimnet.modules.lr.DispParam`

Both are `nn.Module` subclasses defined in `aimnet/modules/lr.py`. An unreleased development solvation artifact references both, so it stopped loading:

```
ValueError: Invalid v2 artifact field 'model_yaml':
Untrusted import path for 'class': 'aimnet.modules.lr.DispParam'
```

## Why it was not caught sooner

Nothing loads the solvation model until it is actually needed, so this does not surface at import or at startup. It surfaced as a multi-hour production run aborting partway, with every GPU worker raising on that model after having already completed all of its gas-phase work.

## Both classes, not just the one in the message

The two entries were enumerated from the artifact's own `model_yaml`, not from the exception text. Fixing only `DispParam` — the class the error names — leaves `D3TS` to fail on the very next load.

## Verification

With this change the solvation model loads and computes: a water optimization under `optimize_and_thermo` converges to a finite energy on an L40S. Without it, the same call fails at load.

New tests assert membership in the allowlist and that each entry resolves to a real `nn.Module`, since an entry that does not resolve would trade a load failure for an import error.

Full suite: 160 passed.