### PR TITLE
Publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -7,6 +7,10 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        permissions:
+            # OIDC token for PyPI trusted publishing; no long-lived secret.
+            id-token: write
+            contents: read
         steps:
             - name: Check out
               uses: actions/checkout@v7
@@ -35,7 +39,7 @@ jobs:
                   if not any(pattern.match(name) for name in files):
                       raise SystemExit(f"dist artifacts {files!r} do not match release tag {tag!r}")
                   PY
-                  uv publish --token ${{ secrets.PYPI_TOKEN }}
+                  uv publish --trusted-publishing always
 
     deploy-docs:
         needs: publish


### PR DESCRIPTION
Switches the release publish step from the long-lived `PYPI_TOKEN` secret to PyPI Trusted Publishing (OIDC): the publish job gets `id-token: write` and `uv publish --trusted-publishing always` replaces the token flag.

**Merge prerequisite:** on PyPI, the `aimnet` project must first have a trusted publisher registered (GitHub, owner `isayevlab`, repository `aimnetcentral`, workflow `on-release-main.yml`, no environment) — requires the project owner. A second project owner should be added at the same time.

The `PYPI_TOKEN` secret stays untouched as a manual fallback; delete it after the first successful OIDC publish.