### PR TITLE
Genericize solvation-artifact references in comments

### DIFF
--- a/aimnet/models/artifact_validation.py
+++ b/aimnet/models/artifact_validation.py
@@ -53,8 +53,8 @@ _DEFAULT_CLASS_IMPORT_PATHS = frozenset({
     "aimnet.modules.Quadrupole",
     "aimnet.modules.SRCoulomb",
     # Embedded-dispersion modules. Both are first-party nn.Modules in
-    # aimnet/modules/lr.py and both are referenced by the shipped CPCM(water)
-    # solvation artifact, which could not load without them.
+    # aimnet/modules/lr.py and both are referenced by first-party solvation
+    # artifacts with embedded dispersion, which cannot load without them.
     "aimnet.modules.D3TS",
     # The submodule spelling of the same class. The barrel re-export
     # (aimnet.modules.D3TS, above) and this fully qualified path both resolve

--- a/tests/test_model_artifact_security.py
+++ b/tests/test_model_artifact_security.py
@@ -1377,7 +1377,7 @@ def test_hf_registry_fallback_fails_on_unexpected_key_without_extra(
     ],
 )
 def test_embedded_dispersion_modules_are_trusted(path: str) -> None:
-    """The shipped CPCM(water) artifact references these and cannot load without them.
+    """First-party solvation artifacts reference these and cannot load without them.
 
     All are first-party ``nn.Module`` subclasses (or spellings of one) in
     ``aimnet/modules/lr.py``. When the artifact trust boundary was introduced

--- a/tests/test_serialization_abi.py
+++ b/tests/test_serialization_abi.py
@@ -85,7 +85,7 @@ _FROZEN_CLASS_PATHS = (
     # machinery that detects D3TS by class name matches the "D3TS" substring
     # regardless of spelling, so both spellings must be pinned here too.
     "aimnet.modules.lr.D3TS",
-    # Dispersion-parameter module carried by the shipped CPCM(water) artifact
+    # Dispersion-parameter module carried by solvation artifacts
     # alongside D3TS; released artifacts reference it, so it is ABI.
     "aimnet.modules.lr.DispParam",
     # Public configuration building blocks (documented in docs/api as intended
@@ -227,8 +227,8 @@ def test_allowed_model_import_paths_are_shared_and_immutable():
         "aimnet.modules.Output",
         "aimnet.modules.Quadrupole",
         "aimnet.modules.SRCoulomb",
-        # Embedded-dispersion modules referenced by the shipped CPCM(water)
-        # solvation artifact. D3TS was already in _FROZEN_CLASS_PATHS above --
+        # Embedded-dispersion modules referenced by first-party solvation
+        # artifacts. D3TS was already in _FROZEN_CLASS_PATHS above --
         # the serialization ABI knew released checkpoints reference it while
         # the runtime allowlist did not, and that inconsistency is what stopped
         # the model loading.


### PR DESCRIPTION
Comment/docstring-only change: replaces references to a specific unreleased solvation artifact with generic wording (first-party solvation artifacts with embedded dispersion). One of the comments ships in the PyPI package; the wording also incorrectly implied the artifact is publicly shipped. No code or test behavior changes.